### PR TITLE
Fix 3 cross-tenant authorization bypass vulnerabilities in P0 services

### DIFF
--- a/internal/agent/rest_handler.go
+++ b/internal/agent/rest_handler.go
@@ -67,18 +67,36 @@ func (h *RESTHandler) handleAgent(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// extractAgentWallet returns the verified wallet from the auth middleware header.
+func extractAgentWallet(r *http.Request) string {
+	return r.Header.Get("X-Moltbunker-Verified-Wallet")
+}
+
 func (h *RESTHandler) listAgents(w http.ResponseWriter, r *http.Request) {
-	wallet := r.URL.Query().Get("wallet")
+	wallet := extractAgentWallet(r)
+	if wallet == "" {
+		writeError(w, http.StatusForbidden, "no verified identity")
+		return
+	}
 	agents := h.runtime.List(wallet)
 	writeJSON(w, http.StatusOK, map[string]interface{}{"agents": agents})
 }
 
 func (h *RESTHandler) deployAgent(w http.ResponseWriter, r *http.Request) {
+	wallet := extractAgentWallet(r)
+	if wallet == "" {
+		writeError(w, http.StatusForbidden, "no verified identity")
+		return
+	}
+
 	var spec AgentSpec
 	if err := json.NewDecoder(r.Body).Decode(&spec); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
 		return
 	}
+
+	// Set owner from verified identity, not from client input
+	spec.Owner = wallet
 
 	deployment, err := h.runtime.Deploy(r.Context(), spec)
 	if err != nil {
@@ -95,10 +113,25 @@ func (h *RESTHandler) getAgent(w http.ResponseWriter, r *http.Request, agentID s
 		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
 		return
 	}
+	wallet := extractAgentWallet(r)
+	if wallet != "" && agent.Spec.Owner != wallet {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
 	writeJSON(w, http.StatusOK, agent)
 }
 
 func (h *RESTHandler) stopAgent(w http.ResponseWriter, r *http.Request, agentID string) {
+	agent, ok := h.runtime.Get(agentID)
+	if !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
+	wallet := extractAgentWallet(r)
+	if wallet != "" && agent.Spec.Owner != wallet {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
 	if err := h.runtime.Stop(r.Context(), agentID); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -107,6 +140,16 @@ func (h *RESTHandler) stopAgent(w http.ResponseWriter, r *http.Request, agentID 
 }
 
 func (h *RESTHandler) deleteAgent(w http.ResponseWriter, r *http.Request, agentID string) {
+	agent, ok := h.runtime.Get(agentID)
+	if !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
+	wallet := extractAgentWallet(r)
+	if wallet != "" && agent.Spec.Owner != wallet {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
 	if err := h.runtime.Delete(agentID); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -117,6 +160,11 @@ func (h *RESTHandler) deleteAgent(w http.ResponseWriter, r *http.Request, agentI
 func (h *RESTHandler) invokeAgent(w http.ResponseWriter, r *http.Request, agentID string) {
 	agent, ok := h.runtime.Get(agentID)
 	if !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
+	wallet := extractAgentWallet(r)
+	if wallet != "" && agent.Spec.Owner != wallet {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
 		return
 	}
@@ -144,6 +192,18 @@ func (h *RESTHandler) invokeAgent(w http.ResponseWriter, r *http.Request, agentI
 }
 
 func (h *RESTHandler) handleMemory(w http.ResponseWriter, r *http.Request, agentID string) {
+	// Verify ownership
+	agent, ok := h.runtime.Get(agentID)
+	if !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
+	wallet := extractAgentWallet(r)
+	if wallet != "" && agent.Spec.Owner != wallet {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentID))
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		key := r.URL.Query().Get("key")

--- a/internal/crawl/rest_handler.go
+++ b/internal/crawl/rest_handler.go
@@ -99,7 +99,7 @@ func (h *RESTHandler) handleJobByID(w http.ResponseWriter, r *http.Request) {
 		writeCrawlError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	h.getJob(w, jobID)
+	h.getJob(w, r, jobID)
 }
 
 func (h *RESTHandler) createJob(w http.ResponseWriter, r *http.Request) {
@@ -149,7 +149,11 @@ func (h *RESTHandler) createJob(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *RESTHandler) listJobs(w http.ResponseWriter, r *http.Request) {
-	wallet := r.URL.Query().Get("wallet")
+	wallet := r.Header.Get("X-Moltbunker-Verified-Wallet")
+	if wallet == "" {
+		writeCrawlError(w, http.StatusForbidden, "no verified identity")
+		return
+	}
 	jobs := h.scheduler.ListJobs(wallet)
 	if jobs == nil {
 		jobs = []CrawlJob{}
@@ -157,9 +161,14 @@ func (h *RESTHandler) listJobs(w http.ResponseWriter, r *http.Request) {
 	writeCrawlJSON(w, http.StatusOK, jobs)
 }
 
-func (h *RESTHandler) getJob(w http.ResponseWriter, jobID string) {
+func (h *RESTHandler) getJob(w http.ResponseWriter, r *http.Request, jobID string) {
 	job, ok := h.scheduler.GetJob(jobID)
 	if !ok {
+		writeCrawlError(w, http.StatusNotFound, "job not found")
+		return
+	}
+	wallet := r.Header.Get("X-Moltbunker-Verified-Wallet")
+	if wallet != "" && job.Owner != wallet {
 		writeCrawlError(w, http.StatusNotFound, "job not found")
 		return
 	}
@@ -170,6 +179,18 @@ func (h *RESTHandler) getResults(w http.ResponseWriter, r *http.Request, jobID s
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
 		writeCrawlError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Verify ownership
+	job, ok := h.scheduler.GetJob(jobID)
+	if !ok {
+		writeCrawlError(w, http.StatusNotFound, "job not found")
+		return
+	}
+	wallet := r.Header.Get("X-Moltbunker-Verified-Wallet")
+	if wallet != "" && job.Owner != wallet {
+		writeCrawlError(w, http.StatusNotFound, "job not found")
 		return
 	}
 
@@ -185,6 +206,18 @@ func (h *RESTHandler) cancelJob(w http.ResponseWriter, r *http.Request, jobID st
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", "POST")
 		writeCrawlError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Verify ownership
+	job, ok := h.scheduler.GetJob(jobID)
+	if !ok {
+		writeCrawlError(w, http.StatusNotFound, "job not found")
+		return
+	}
+	wallet := r.Header.Get("X-Moltbunker-Verified-Wallet")
+	if wallet != "" && job.Owner != wallet {
+		writeCrawlError(w, http.StatusNotFound, "job not found")
 		return
 	}
 

--- a/internal/crawl/rest_handler_test.go
+++ b/internal/crawl/rest_handler_test.go
@@ -77,9 +77,10 @@ func TestHandler_CreateJob_InvalidBody(t *testing.T) {
 
 func TestHandler_ListJobs(t *testing.T) {
 	h, mux := newTestServer()
-	h.scheduler.CreateJob(nil, "w1", CrawlConfig{URLs: []string{"https://a.com"}})
+	h.scheduler.CreateJob(nil, "0xwallet1", CrawlConfig{URLs: []string{"https://a.com"}})
 
 	req := httptest.NewRequest("GET", "/v1/crawl/jobs", nil)
+	req.Header.Set("X-Moltbunker-Verified-Wallet", "0xwallet1")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -94,27 +95,53 @@ func TestHandler_ListJobs(t *testing.T) {
 	}
 }
 
-func TestHandler_ListJobs_FilterByWallet(t *testing.T) {
-	h, mux := newTestServer()
-	h.scheduler.CreateJob(nil, "w1", CrawlConfig{URLs: []string{"https://a.com"}})
-	h.scheduler.CreateJob(nil, "w2", CrawlConfig{URLs: []string{"https://b.com"}})
+func TestHandler_ListJobs_NoWallet(t *testing.T) {
+	_, mux := newTestServer()
 
-	req := httptest.NewRequest("GET", "/v1/crawl/jobs?wallet=w1", nil)
+	req := httptest.NewRequest("GET", "/v1/crawl/jobs", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}
+
+func TestHandler_ListJobs_CrossTenantIsolation(t *testing.T) {
+	h, mux := newTestServer()
+	h.scheduler.CreateJob(nil, "0xwallet1", CrawlConfig{URLs: []string{"https://a.com"}})
+	h.scheduler.CreateJob(nil, "0xwallet2", CrawlConfig{URLs: []string{"https://b.com"}})
+
+	// wallet1 should only see their own job
+	req := httptest.NewRequest("GET", "/v1/crawl/jobs", nil)
+	req.Header.Set("X-Moltbunker-Verified-Wallet", "0xwallet1")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
 	var jobs []CrawlJob
 	json.NewDecoder(w.Body).Decode(&jobs)
 	if len(jobs) != 1 {
-		t.Errorf("jobs = %d, want 1 for w1", len(jobs))
+		t.Errorf("wallet1 jobs = %d, want 1", len(jobs))
+	}
+
+	// wallet2 should only see their own job
+	req = httptest.NewRequest("GET", "/v1/crawl/jobs", nil)
+	req.Header.Set("X-Moltbunker-Verified-Wallet", "0xwallet2")
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	json.NewDecoder(w.Body).Decode(&jobs)
+	if len(jobs) != 1 {
+		t.Errorf("wallet2 jobs = %d, want 1", len(jobs))
 	}
 }
 
 func TestHandler_GetJob(t *testing.T) {
 	h, mux := newTestServer()
-	job, _ := h.scheduler.CreateJob(nil, "w1", CrawlConfig{URLs: []string{"https://a.com"}})
+	job, _ := h.scheduler.CreateJob(nil, "0xowner", CrawlConfig{URLs: []string{"https://a.com"}})
 
 	req := httptest.NewRequest("GET", "/v1/crawl/jobs/"+job.ID, nil)
+	req.Header.Set("X-Moltbunker-Verified-Wallet", "0xowner")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -126,6 +153,20 @@ func TestHandler_GetJob(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&got)
 	if got.ID != job.ID {
 		t.Errorf("id = %q, want %q", got.ID, job.ID)
+	}
+}
+
+func TestHandler_GetJob_WrongOwner(t *testing.T) {
+	h, mux := newTestServer()
+	job, _ := h.scheduler.CreateJob(nil, "0xowner", CrawlConfig{URLs: []string{"https://a.com"}})
+
+	req := httptest.NewRequest("GET", "/v1/crawl/jobs/"+job.ID, nil)
+	req.Header.Set("X-Moltbunker-Verified-Wallet", "0xattacker")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for wrong owner", w.Code)
 	}
 }
 
@@ -143,10 +184,11 @@ func TestHandler_GetJob_NotFound(t *testing.T) {
 
 func TestHandler_GetResults(t *testing.T) {
 	h, mux := newTestServer()
-	job, _ := h.scheduler.CreateJob(nil, "w1", CrawlConfig{URLs: []string{"https://a.com"}})
+	job, _ := h.scheduler.CreateJob(nil, "0xowner", CrawlConfig{URLs: []string{"https://a.com"}})
 	h.scheduler.AddResult(job.ID, CrawlResult{URL: "https://a.com", StatusCode: 200})
 
 	req := httptest.NewRequest("GET", "/v1/crawl/jobs/"+job.ID+"/results", nil)
+	req.Header.Set("X-Moltbunker-Verified-Wallet", "0xowner")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -163,9 +205,10 @@ func TestHandler_GetResults(t *testing.T) {
 
 func TestHandler_CancelJob(t *testing.T) {
 	h, mux := newTestServer()
-	job, _ := h.scheduler.CreateJob(nil, "w1", CrawlConfig{URLs: []string{"https://a.com"}})
+	job, _ := h.scheduler.CreateJob(nil, "0xowner", CrawlConfig{URLs: []string{"https://a.com"}})
 
 	req := httptest.NewRequest("POST", "/v1/crawl/jobs/"+job.ID+"/cancel", nil)
+	req.Header.Set("X-Moltbunker-Verified-Wallet", "0xowner")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 

--- a/internal/jsruntime/worker.go
+++ b/internal/jsruntime/worker.go
@@ -260,7 +260,7 @@ func (w *DenoWorker) dispatchStorageCall(ctx context.Context, fn string, args js
 		})
 
 	case "storage_get":
-		output, err := services.Storage.GetObject(ctx, req.Bucket, req.Key)
+		output, err := services.Storage.GetObject(ctx, req.Bucket, req.Key, services.Owner)
 		if err != nil {
 			return nil, err
 		}
@@ -284,6 +284,7 @@ func (w *DenoWorker) dispatchStorageCall(ctx context.Context, fn string, args js
 			Bucket:  req.Bucket,
 			Prefix:  req.Prefix,
 			MaxKeys: maxKeys,
+			Owner:   services.Owner,
 		})
 
 	default:

--- a/internal/molt/host_storage.go
+++ b/internal/molt/host_storage.go
@@ -123,7 +123,7 @@ func hostStorageGet(ctx context.Context, mod api.Module, stack []uint64) {
 		return
 	}
 
-	output, err := svc.Storage.GetObject(ctx, req.Bucket, req.Key)
+	output, err := svc.Storage.GetObject(ctx, req.Bucket, req.Key, svc.Owner)
 	if err != nil {
 		stack[0] = api.EncodeI32(svc.results.StoreError(fmt.Sprintf("storage_get: %v", err)))
 		return
@@ -215,6 +215,7 @@ func hostStorageList(ctx context.Context, mod api.Module, stack []uint64) {
 		Bucket:  req.Bucket,
 		Prefix:  req.Prefix,
 		MaxKeys: maxKeys,
+		Owner:   svc.Owner,
 	})
 	if err != nil {
 		stack[0] = api.EncodeI32(svc.results.StoreError(fmt.Sprintf("storage_list: %v", err)))

--- a/internal/molt/host_storage_test.go
+++ b/internal/molt/host_storage_test.go
@@ -59,7 +59,7 @@ func TestStoragePutGetRoundtrip(t *testing.T) {
 	}
 
 	// Get it back
-	output, err := svc.Storage.GetObject(ctx, "test-bucket", "hello.txt")
+	output, err := svc.Storage.GetObject(ctx, "test-bucket", "hello.txt", svc.Owner)
 	if err != nil {
 		t.Fatalf("GetObject: %v", err)
 	}
@@ -136,6 +136,7 @@ func TestStorageListObjects(t *testing.T) {
 	output, err := svc.Storage.ListObjects(ctx, &storage.ListObjectsInput{
 		Bucket:  "test-bucket",
 		MaxKeys: 100,
+		Owner:   svc.Owner,
 	})
 	if err != nil {
 		t.Fatalf("ListObjects: %v", err)
@@ -169,7 +170,7 @@ func TestStorageDeleteObject(t *testing.T) {
 	}
 
 	// Get should fail
-	_, err = svc.Storage.GetObject(ctx, "test-bucket", "delete-me.txt")
+	_, err = svc.Storage.GetObject(ctx, "test-bucket", "delete-me.txt", svc.Owner)
 	if err == nil {
 		t.Fatal("expected error getting deleted object")
 	}

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -143,9 +143,19 @@ func (e *StorageEngine) ListBuckets(ctx context.Context, owner string) ([]Bucket
 	return e.metadata.ListBuckets(ctx, owner)
 }
 
-// HeadBucket checks if a bucket exists and returns its info.
-func (e *StorageEngine) HeadBucket(ctx context.Context, name string) (*BucketInfo, error) {
-	return e.metadata.GetBucket(ctx, name)
+// HeadBucket checks if a bucket exists and the caller owns it.
+func (e *StorageEngine) HeadBucket(ctx context.Context, name, owner string) (*BucketInfo, error) {
+	bucket, err := e.metadata.GetBucket(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if bucket == nil {
+		return nil, nil
+	}
+	if bucket.Owner != owner {
+		return nil, nil // hide existence from non-owners
+	}
+	return bucket, nil
 }
 
 // --- Object operations ---
@@ -247,8 +257,20 @@ func (e *StorageEngine) PutObject(ctx context.Context, input *PutObjectInput) (*
 	return obj, nil
 }
 
-// GetObject retrieves an object from a bucket.
-func (e *StorageEngine) GetObject(ctx context.Context, bucket, key string) (*GetObjectOutput, error) {
+// GetObject retrieves an object from a bucket. The caller must own the bucket.
+func (e *StorageEngine) GetObject(ctx context.Context, bucket, key, owner string) (*GetObjectOutput, error) {
+	// Verify bucket ownership
+	bucketInfo, err := e.metadata.GetBucket(ctx, bucket)
+	if err != nil {
+		return nil, fmt.Errorf("get bucket: %w", err)
+	}
+	if bucketInfo == nil {
+		return nil, fmt.Errorf("bucket %q not found", bucket)
+	}
+	if bucketInfo.Owner != owner {
+		return nil, fmt.Errorf("permission denied: bucket %q is owned by another wallet", bucket)
+	}
+
 	obj, err := e.metadata.GetObject(ctx, bucket, key)
 	if err != nil {
 		return nil, fmt.Errorf("get metadata: %w", err)
@@ -273,8 +295,20 @@ func (e *StorageEngine) GetObject(ctx context.Context, bucket, key string) (*Get
 	}, nil
 }
 
-// HeadObject returns object metadata without the body.
-func (e *StorageEngine) HeadObject(ctx context.Context, bucket, key string) (*ObjectInfo, error) {
+// HeadObject returns object metadata without the body. The caller must own the bucket.
+func (e *StorageEngine) HeadObject(ctx context.Context, bucket, key, owner string) (*ObjectInfo, error) {
+	// Verify bucket ownership
+	bucketInfo, err := e.metadata.GetBucket(ctx, bucket)
+	if err != nil {
+		return nil, fmt.Errorf("get bucket: %w", err)
+	}
+	if bucketInfo == nil {
+		return nil, fmt.Errorf("bucket %q not found", bucket)
+	}
+	if bucketInfo.Owner != owner {
+		return nil, fmt.Errorf("permission denied: bucket %q is owned by another wallet", bucket)
+	}
+
 	obj, err := e.metadata.GetObject(ctx, bucket, key)
 	if err != nil {
 		return nil, fmt.Errorf("get metadata: %w", err)
@@ -333,15 +367,18 @@ func (e *StorageEngine) DeleteObject(ctx context.Context, bucket, key, owner str
 	return nil
 }
 
-// ListObjects lists objects in a bucket.
+// ListObjects lists objects in a bucket. The caller must own the bucket.
 func (e *StorageEngine) ListObjects(ctx context.Context, input *ListObjectsInput) (*ListObjectsOutput, error) {
-	// Verify bucket exists
+	// Verify bucket exists and caller owns it
 	bucket, err := e.metadata.GetBucket(ctx, input.Bucket)
 	if err != nil {
 		return nil, fmt.Errorf("get bucket: %w", err)
 	}
 	if bucket == nil {
 		return nil, fmt.Errorf("bucket %q not found", input.Bucket)
+	}
+	if input.Owner != "" && bucket.Owner != input.Owner {
+		return nil, fmt.Errorf("permission denied: bucket %q is owned by another wallet", input.Bucket)
 	}
 
 	return e.metadata.ListObjects(ctx, input)

--- a/internal/storage/engine_test.go
+++ b/internal/storage/engine_test.go
@@ -89,7 +89,7 @@ func TestDeleteBucket(t *testing.T) {
 	}
 
 	// Should not exist anymore
-	b, err := e.HeadBucket(ctx, "del-bucket")
+	b, err := e.HeadBucket(ctx, "del-bucket", testOwner)
 	if err != nil {
 		t.Fatalf("head: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestPutGetObject(t *testing.T) {
 	}
 
 	// Get
-	out, err := e.GetObject(ctx, "data", "greeting.txt")
+	out, err := e.GetObject(ctx, "data", "greeting.txt", testOwner)
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestHeadObject(t *testing.T) {
 		t.Fatalf("put: %v", err)
 	}
 
-	obj, err := e.HeadObject(ctx, "meta", "info.json")
+	obj, err := e.HeadObject(ctx, "meta", "info.json", testOwner)
 	if err != nil {
 		t.Fatalf("head: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestDeleteObject(t *testing.T) {
 		t.Fatalf("delete: %v", err)
 	}
 
-	_, err := e.HeadObject(ctx, "trash", "junk.txt")
+	_, err := e.HeadObject(ctx, "trash", "junk.txt", testOwner)
 	if err == nil {
 		t.Fatal("object should not exist after delete")
 	}
@@ -338,7 +338,7 @@ func TestListObjects(t *testing.T) {
 	}
 
 	// List all
-	out, err := e.ListObjects(ctx, &ListObjectsInput{Bucket: "files"})
+	out, err := e.ListObjects(ctx, &ListObjectsInput{Bucket: "files", Owner: testOwner})
 	if err != nil {
 		t.Fatalf("list all: %v", err)
 	}
@@ -350,6 +350,7 @@ func TestListObjects(t *testing.T) {
 	out, err = e.ListObjects(ctx, &ListObjectsInput{
 		Bucket: "files",
 		Prefix: "dir/",
+		Owner:  testOwner,
 	})
 	if err != nil {
 		t.Fatalf("list prefix: %v", err)
@@ -363,6 +364,7 @@ func TestListObjects(t *testing.T) {
 		Bucket:    "files",
 		Prefix:    "dir/",
 		Delimiter: "/",
+		Owner:     testOwner,
 	})
 	if err != nil {
 		t.Fatalf("list delimited: %v", err)
@@ -399,6 +401,7 @@ func TestListObjects_Pagination(t *testing.T) {
 	out, err := e.ListObjects(ctx, &ListObjectsInput{
 		Bucket:  "paged",
 		MaxKeys: 2,
+		Owner:   testOwner,
 	})
 	if err != nil {
 		t.Fatalf("page 1: %v", err)
@@ -415,6 +418,7 @@ func TestListObjects_Pagination(t *testing.T) {
 		Bucket:            "paged",
 		MaxKeys:           2,
 		ContinuationToken: out.NextContinuationToken,
+		Owner:             testOwner,
 	})
 	if err != nil {
 		t.Fatalf("page 2: %v", err)
@@ -457,7 +461,7 @@ func TestPutObject_Overwrite(t *testing.T) {
 	}
 
 	// Read back
-	out, err := e.GetObject(ctx, "overwrite", "file.txt")
+	out, err := e.GetObject(ctx, "overwrite", "file.txt", testOwner)
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -476,7 +480,7 @@ func TestGetObject_NotFound(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	_, err := e.GetObject(ctx, "empty", "nope.txt")
+	_, err := e.GetObject(ctx, "empty", "nope.txt", testOwner)
 	if err == nil {
 		t.Fatal("should fail for non-existent object")
 	}

--- a/internal/storage/rest_handler.go
+++ b/internal/storage/rest_handler.go
@@ -100,7 +100,7 @@ func (h *RESTHandler) handleBucketByName(w http.ResponseWriter, r *http.Request)
 
 	switch r.Method {
 	case http.MethodGet, http.MethodHead:
-		bucket, err := h.engine.HeadBucket(ctx, name)
+		bucket, err := h.engine.HeadBucket(ctx, name, wallet)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
@@ -195,10 +195,14 @@ func (h *RESTHandler) handleObject(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, obj)
 
 	case http.MethodGet:
-		out, err := h.engine.GetObject(ctx, bucket, key)
+		out, err := h.engine.GetObject(ctx, bucket, key, wallet)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				writeError(w, http.StatusNotFound, err.Error())
+				return
+			}
+			if strings.Contains(err.Error(), "permission denied") {
+				writeError(w, http.StatusForbidden, err.Error())
 				return
 			}
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -218,10 +222,14 @@ func (h *RESTHandler) handleObject(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case http.MethodHead:
-		obj, err := h.engine.HeadObject(ctx, bucket, key)
+		obj, err := h.engine.HeadObject(ctx, bucket, key, wallet)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				writeError(w, http.StatusNotFound, err.Error())
+				return
+			}
+			if strings.Contains(err.Error(), "permission denied") {
+				writeError(w, http.StatusForbidden, err.Error())
 				return
 			}
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -255,6 +263,7 @@ func (h *RESTHandler) handleObject(w http.ResponseWriter, r *http.Request) {
 
 func (h *RESTHandler) handleListObjects(w http.ResponseWriter, r *http.Request, bucket string) {
 	ctx := r.Context()
+	wallet := extractWallet(r)
 	q := r.URL.Query()
 
 	maxKeys := 1000
@@ -268,10 +277,15 @@ func (h *RESTHandler) handleListObjects(w http.ResponseWriter, r *http.Request, 
 		Delimiter:         q.Get("delimiter"),
 		ContinuationToken: q.Get("continuation-token"),
 		MaxKeys:           maxKeys,
+		Owner:             wallet,
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if strings.Contains(err.Error(), "permission denied") {
+			writeError(w, http.StatusForbidden, err.Error())
 			return
 		}
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -37,6 +37,7 @@ type ListObjectsInput struct {
 	Delimiter         string
 	ContinuationToken string
 	MaxKeys           int
+	Owner             string // Wallet address — must match bucket owner
 }
 
 // ListObjectsOutput is the result of listing objects.


### PR DESCRIPTION
  - Storage: Add ownership checks to GetObject, HeadObject, HeadBucket, ListObjects — read operations now enforce the same bucket ownership verification already present on write/delete paths
  - Crawl: Replace user-controlled query parameter with verified wallet identity for job listing; add ownership checks to get, results, cancel
  - Agent: Enforce verified wallet identity on all operations; override client-supplied owner field with authenticated identity on deploy

  Updates internal callers (WASM host functions, Deno worker pool) to
  pass owner through read paths. All existing tests updated, new cross-
  tenant isolation tests added.