### PR TITLE
OPS-01 Add commit-msg hook and PR template

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Enforce commit-subject format.
+# Format: [<TICKET-NN> ]<Imperative verb> <description>  (≤72 chars, capitalized, no trailing period)
+# To bypass intentionally (rare): git commit --no-verify
+
+SUBJECT=$(head -1 "$1")
+
+# Allow git-generated subjects through (rebase fixup/squash, reverts, merges)
+case "$SUBJECT" in
+  "fixup! "*|"squash! "*|"Revert "*|"Merge "*) exit 0 ;;
+esac
+
+# Standard regex: optional ticket prefix + uppercase letter + 1-70 more printable chars
+# Internal periods are allowed (e.g., "Bump go-ethereum to v1.14.0", "migrate()").
+REGEX='^([A-Z]{2,5}-[0-9]+ )?[A-Z][[:print:]]{1,70}$'
+
+if ! printf '%s' "$SUBJECT" | grep -Eq "$REGEX"; then
+  echo "❌ Commit subject does not match the standard:"
+  echo "     $SUBJECT"
+  echo
+  echo "   Expected: [TICKET-NN ]<Imperative verb> <description>"
+  echo "   - ≤72 chars total"
+  echo "   - Capitalized (or starts with TICKET-NN, e.g. DEV-42)"
+  echo "   - No trailing period"
+  echo "   - Imperative verb (Add / Fix / Update / Remove / Refactor / etc.)"
+  exit 1
+fi
+
+# Reject trailing period
+case "$SUBJECT" in
+  *.)
+    echo "❌ Commit subject must not end with a period:"
+    echo "     $SUBJECT"
+    exit 1 ;;
+esac
+
+# Hard length cap
+LEN=$(printf '%s' "$SUBJECT" | wc -c | tr -d ' ')
+if [ "$LEN" -gt 72 ]; then
+  echo "❌ Commit subject is $LEN characters; must be ≤72."
+  echo "     $SUBJECT"
+  exit 1
+fi
+
+exit 0

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Summary
+
+<!-- 1-3 bullets. What changed and why. Reader should be able to decide whether they care about this PR from this section alone. -->
+
+- 
+- 
+
+## Linked tickets / related PRs
+
+- Closes: <!-- TICKET-NN -->
+- Related: <!-- other repo PR URLs if cross-repo -->
+
+## What I changed
+
+<!-- 2-6 bullets. Concrete description of the code change. Skip if obvious from the diff. -->
+
+- 
+- 
+
+## Why this approach
+
+<!-- Optional. Use when a non-obvious design choice was made. Mention alternatives considered and why this won. -->
+
+## Test plan
+
+- [ ] <!-- how I verified the happy path -->
+- [ ] <!-- how I verified edge cases -->
+- [ ] <!-- any test you ran that the CI doesn't cover -->
+
+## Risk
+
+<!-- Honest assessment. "Low" is fine but explain. "High" means this PR shouldn't land without a second pair of eyes or a rollback plan. -->
+
+- Blast radius: <!-- which subsystems / users -->
+- Reversibility: <!-- can we revert cleanly? Any migrations? -->
+- Monitoring: <!-- what to watch after merge -->
+
+## Screenshots / artifacts
+
+<!-- For UI changes: before/after. For new endpoints: a curl example. -->
+


### PR DESCRIPTION
Adds .githooks/commit-msg enforcing a uniform subject format: optional ticket prefix (e.g. DEV-42), capitalized imperative verb, max 72 chars, no trailing period. Internal periods are allowed (version numbers, etc.). Standard git-generated subjects (fixup, squash, Revert, Merge) pass through. Activated via core.hooksPath in .git/config; on a fresh clone run: git config core.hooksPath .githooks

Adds .github/PULL_REQUEST_TEMPLATE.md so every PR carries summary, linked tickets, change list, test plan, and risk sections.