### PR TITLE
SEC-01 Tighten input validation and logging discipline

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -73,6 +73,12 @@ func main() {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
+	// Wrap the structured logger with the redacting handler before any
+	// subsystem starts emitting attributes. Anything that looks like a
+	// private key, wallet keystore JSON, API key, or session token is
+	// scrubbed before reaching the underlying handler.
+	logging.EnableRedaction()
+
 	// Override with command-line flags
 	if *port != 0 {
 		cfg.Daemon.Port = *port

--- a/internal/api/apikey.go
+++ b/internal/api/apikey.go
@@ -60,12 +60,14 @@ func NewAPIKeyManagerInMemory() *APIKeyManager {
 		prefixes: make(map[string]string),
 	}
 
-	// Create a default development key
+	// Create a default development key. The structured log captures only
+	// the non-secret prefix; the plaintext key is written to stdout once,
+	// outside the log pipeline, so it doesn't end up in log aggregators.
 	key, plainKey, _ := m.CreateKey("default", []string{"read", "write"}, 0)
-	logging.Info("created default API key (development mode)",
+	logging.Info("created default API key (development mode — store the key shown on stdout safely)",
 		"key_prefix", key.KeyPrefix,
-		"plain_key", plainKey,
 		logging.Component("api"))
+	fmt.Printf("DEVELOPMENT API KEY: %s\n", plainKey)
 
 	return m
 }

--- a/internal/api/exec_handler.go
+++ b/internal/api/exec_handler.go
@@ -168,8 +168,10 @@ func (s *Server) handleExecChallenge(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"container not running"}`, http.StatusConflict)
 		return
 	}
-	// Ownership check: only the deployer's wallet can exec
-	if deployment.Owner != "" && !strings.EqualFold(deployment.Owner, walletAddr) {
+	// Ownership check: only the deployer's wallet can exec. An empty
+	// Owner field means no requester has claimed this deployment; treat
+	// that the same as a mismatched wallet rather than letting it through.
+	if deployment.Owner == "" || !strings.EqualFold(deployment.Owner, walletAddr) {
 		logging.Warn("exec challenge denied: wallet does not own container",
 			"wallet", walletAddr,
 			"owner", deployment.Owner,

--- a/internal/api/wallet_auth.go
+++ b/internal/api/wallet_auth.go
@@ -154,23 +154,28 @@ func (m *WalletAuthManager) VerifySignature(message, signature, claimedAddress s
 }
 
 // VerifyInlineAuth verifies inline wallet authentication headers
-// This is for stateless requests where the client signs each request
+// This is for stateless requests where the client signs each request.
+// The message format is strictly "moltbunker-auth:{timestamp}".
 func (m *WalletAuthManager) VerifyInlineAuth(walletAddr, signature, message string) (string, error) {
-	// For inline auth, verify the message timestamp is recent
-	// The message format is: "moltbunker-auth:{timestamp}"
-	if strings.HasPrefix(message, "moltbunker-auth:") {
-		parts := strings.Split(message, ":")
-		if len(parts) >= 2 {
-			var timestamp int64
-			// Best-effort parse; failure leaves timestamp=0, which the bounds check below rejects.
-			_, _ = fmt.Sscanf(parts[1], "%d", &timestamp)
+	// Require the dedicated inline-auth prefix so signatures over messages
+	// produced for other contexts cannot satisfy this endpoint.
+	if !strings.HasPrefix(message, "moltbunker-auth:") {
+		return "", fmt.Errorf("invalid auth message format")
+	}
 
-			// Check if timestamp is within 5 minutes
-			now := time.Now().Unix()
-			if now-timestamp > 300 || timestamp-now > 60 {
-				return "", fmt.Errorf("auth message timestamp expired or invalid")
-			}
-		}
+	parts := strings.Split(message, ":")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("invalid auth message format")
+	}
+
+	var timestamp int64
+	// Best-effort parse; failure leaves timestamp=0, which the bounds check below rejects.
+	_, _ = fmt.Sscanf(parts[1], "%d", &timestamp)
+
+	// Check if timestamp is within 5 minutes
+	now := time.Now().Unix()
+	if now-timestamp > 300 || timestamp-now > 60 {
+		return "", fmt.Errorf("auth message timestamp expired or invalid")
 	}
 
 	return m.VerifySignature(message, signature, walletAddr)

--- a/internal/p2p/routing.go
+++ b/internal/p2p/routing.go
@@ -428,8 +428,19 @@ func (r *Router) HandleMessage(ctx context.Context, msg *types.Message, from *ty
 		return fmt.Errorf("outdated protocol version: %d (minimum supported: %d)", msg.Version, types.MinSupportedVersion)
 	}
 
-	// 5. Verify message signature if we have a key manager and the message has a signature
-	if r.keyManager != nil && len(msg.Signature) > 0 {
+	// 5. Verify message signature. When a key manager is available, every
+	// inbound message must carry a non-empty signature that verifies — an
+	// empty signature is no longer treated as "skip verification".
+	if r.keyManager != nil {
+		if len(msg.Signature) == 0 {
+			logging.Warn("rejecting message with missing signature",
+				"message_type", string(msg.Type),
+				logging.Component("router"))
+			if r.peerScorer != nil && from != nil {
+				r.peerScorer.RecordEvent(from.ID, PeerEventInvalidMessage)
+			}
+			return fmt.Errorf("missing message signature")
+		}
 		signableBytes := msg.SignableBytes()
 		if signableBytes == nil {
 			return fmt.Errorf("failed to compute signable bytes for verification")


### PR DESCRIPTION
## Summary

- Five small input-validation and logging-hygiene improvements across the exec endpoint, P2P message validation, inline wallet auth, the in-memory API key bootstrap, and daemon startup.

## Linked tickets / related PRs

- Closes: SEC-01, SEC-02, SEC-03, SEC-04, SEC-05

## What I changed

- `internal/api/exec_handler.go` — reject the exec challenge when `deployment.Owner` is empty (previously short-circuited through to a success response).
- `internal/p2p/routing.go` — when a key manager is configured, an inbound message with an empty `Signature` is now rejected with the same warn+peer-score-penalty path as an invalid signature.
- `internal/api/wallet_auth.go` — `VerifyInlineAuth` now requires the `moltbunker-auth:` prefix and a well-formed body; messages with any other prefix are rejected before signature verification.
- `internal/api/apikey.go` — `NewAPIKeyManagerInMemory` no longer includes the plaintext key as a structured field on its INFO line; it now prints the plaintext once to stdout outside the log pipeline.
- `cmd/daemon/main.go` — call `logging.EnableRedaction()` immediately after config load so the redacting handler wraps the default logger before any subsystem emits attributes.

## Why this approach

- Each change is minimal and local to its file; no API or wire-format changes, no migrations.
- Failure modes are explicit (return error / reject with logged warning) rather than silent pass-through.
- The redaction handler was already implemented in `internal/logging/redact.go`; this commit only wires it in.

## Test plan

- [x] `golangci-lint run --timeout=5m ./...` → 0 findings on both `darwin` and `GOOS=linux` targets.
- [x] `go build ./...` clean on all four supported targets: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64.
- [x] `go test -race -count=1 -timeout=10m ./...` → all 35 packages PASS.
- [x] Each diff reviewed against its surrounding code.

## Risk

- Blast radius: rejection paths in four files, plus one wire-in at startup. Successful-request paths are unchanged.
- Reversibility: every commit on this branch is small and self-contained; `git revert <hash>` cleanly undoes any single concern.
- Monitoring after merge: watch CI on main, and watch the rate of "exec challenge denied" warn entries in case any consumer relied on the empty-Owner pass-through.