### PR TITLE
SEC-06 Add SECURITY.md and initial CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project are documented here.
+This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- `SECURITY.md` describing the vulnerability disclosure process.
+- `.github/PULL_REQUEST_TEMPLATE.md` with summary / linked tickets / change list / test plan / risk sections.
+- `.githooks/commit-msg` enforcing the project's commit-subject format; activated via `core.hooksPath` on a per-clone basis.
+- DBus session setup in the CI test job so keyring-dependent tests pass on Ubuntu runners.
+
+### Changed
+
+- Test code across 37 `_test.go` files now checks error returns from setup helpers (state, networking, snapshot, security, p2p, runtime, storage, payment, agent, tunnel, ingress, redundancy, molt, crawl, agent, daemon, identity, proxy, client, upgrade).
+- Production code: cleanup paths (Delete / Stop / Close / Disconnect / network deadlines) now log on failure; init paths propagate errors to the caller.
+- Crypto-randomness call sites (`crypto/rand.Read`) propagate errors. ID generators in `snapshot`, `storage/multipart`, `agent`, `crawl`, `proxy`, `cloning` now return `error`. The reverse-tunnel HMAC secret bootstrap panics rather than producing zero bytes if `rand.Read` fails.
+- `Checkpointer.SetInterval` ticker is now stored via `atomic.Pointer[time.Ticker]` so the read in `checkpointLoop`'s select case does not race with the swap.
+- Inline wallet auth (`VerifyInlineAuth`) now requires the `moltbunker-auth:` prefix and a well-formed body; messages with other prefixes are rejected before signature verification.
+- Exec ownership check (`/v1/exec/challenge`) now rejects an empty `Owner` field on the deployment rather than treating it as a wildcard.
+- Inbound P2P messages with an empty `Signature` are now rejected with a logged warning and a peer-score penalty when a key manager is configured; there is no signature-skipping fast path.
+
+### Fixed
+
+- `golangci-lint` clean across the repo (`errcheck`, `gosimple`, `staticcheck`, `ineffassign`, `unused` all at 0).
+- Data race in `HealthChecker.Reset` vs `Start`'s deferred `close(doneCh)` (close moved inside the mutex).
+- Data race between `Checkpointer.SetInterval` and `checkpointLoop` (atomic-pointer ticker swap, as above).
+- `internal/networking/TestFallbackNetwork_ContainerIP` now skips on Linux where `linuxContainerNetwork` is in use.
+- `internal/api` SARIF upload step in the Security Scan job has the `security-events: write` permission required by `codeql-action/upload-sarif`.
+
+### Security
+
+- `logging.EnableRedaction()` is now called at daemon startup. Structured-log attributes that look like API keys (`mb_live_*` / `mb_test_*`), wallet keystore JSON, session tokens (`wt_*`), private keys, or EIP-191 signatures are scrubbed by the redacting handler before reaching the underlying log handler.
+- `NewAPIKeyManagerInMemory` no longer emits the plaintext development API key as a structured field; the plaintext is now printed once to stdout and never enters the log pipeline.
+
+### Removed
+
+- 17 unused symbols across production and test code (and their now-dead imports).
+- Windows entries from the build matrix. The daemon depends on Linux-only subsystems (containerd, namespaces, hypervisor integration) and Unix syscalls (`syscall.Statfs`); Windows was never a supported target. The supported build matrix is now `{linux, darwin} × {amd64, arm64}`.
+
+[Unreleased]: https://github.com/moltbunker/moltbunker/compare/HEAD~1...HEAD

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by email to **security@moltbunker.com**.
+
+You can expect:
+
+- An acknowledgement within **48 hours**.
+- An initial assessment within **7 days**.
+- A coordinated disclosure timeline agreed with you before any public details are shared.
+
+Please do **not** open a public GitHub issue, social media post, or other public channel for security issues. Use the email above.
+
+## Scope
+
+This policy covers the Moltbunker daemon, HTTP API, CLI, P2P protocol, container runtime integration, and the Solidity smart contracts under `contracts/`. Public marketing pages and third-party services we link to are out of scope.
+
+In-scope examples:
+
+- Authentication or authorization bypass on the HTTP API.
+- P2P message validation or transport security issues.
+- Container escape from the runtime sandbox.
+- Smart contract issues: reentrancy, access-control bypass, oracle manipulation, economic logic errors.
+- Cryptographic weaknesses: weak primitives, nonce reuse, signature verification flaws.
+- Secrets exposed in logs or API responses.
+
+Out of scope:
+
+- Denial-of-service against the public API (mitigated by upstream rate limiting / Cloudflare).
+- Issues that require physical access to a provider host.
+- Vulnerabilities in third-party dependencies that have no demonstrable impact on Moltbunker (please report those upstream).
+- Marketing/copy errors on `moltbunker.com`.
+
+## Supported Versions
+
+Until 1.0.0, only the latest released version is supported with security fixes. Re-base on the latest tag before reporting issues against older versions.
+
+## Safe Harbor
+
+We will not pursue legal action against good-faith security research that follows this policy and does not:
+
+- Access, modify, or exfiltrate data that is not yours.
+- Cause service disruption beyond what is strictly necessary to demonstrate the vulnerability.
+- Use social engineering, phishing, or physical attacks.
+
+## Recognition
+
+Researchers who report valid in-scope issues will be credited in the relevant CHANGELOG.md entry and on the security page, with their permission.


### PR DESCRIPTION
## Summary

- Add a vulnerability disclosure policy (`SECURITY.md`) and start the project's release log (`CHANGELOG.md`).

## Linked tickets / related PRs

- Closes: SEC-06

## What I changed

- `SECURITY.md` — disclosure contact (security@moltbunker.com), expected response times, scope (daemon, HTTP API, CLI, P2P protocol, runtime, Solidity contracts), out-of-scope items, safe-harbour terms, and the recognition policy.
- `CHANGELOG.md` — Keep-a-Changelog format with an `[Unreleased]` section that captures the OPS-01, OPS-02, and SEC-01 work already merged into main. Future release PRs move accumulated entries under a dated version header.

## Why this approach

- Lifts the SECURITY.md draft from `plan/_holding/` (kept private until the most recent batch of hygiene work was deployed).
- Keep-a-Changelog matches the format already in use by `moltbunker-sdk`, keeping repos consistent.
- `[Unreleased]` rather than backfilled version headers — the project has no git tags yet; tagging is a separate decision the maintainer can make at any release moment.

## Test plan

- [x] `golangci-lint run ./...` still at 0 findings (no Go code touched).
- [x] `go build ./...` clean.
- [x] Both files render correctly as Markdown.
- [x] Pre-flight grep on diff: no `plan/` references, no commit-history leak markers.

## Risk

- Blast radius: documentation only; no code paths affected.
- Reversibility: trivial `git revert`.
- Operational: `security@moltbunker.com` is published as the disclosure contact. Confirm the alias forwards correctly before this commit goes public.