### PR TITLE
SEC-12 Encrypt bbolt state values at rest (R8)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -113,7 +113,28 @@ func main() {
 	if stateDBPath == "" {
 		stateDBPath = filepath.Join(cfg.Daemon.DataDir, "moltbunker.db")
 	}
-	stateStore, err := state.NewBboltStore(stateDBPath)
+
+	// R8: state-at-rest encryption. Enabled by default (zero value of
+	// StateEncryptionDisabled). Mitigates stolen-disk / leaked-backup / casual
+	// filesystem access to moltbunker.db; it does NOT defend against a live
+	// host-root attacker who can also read DataDir/state.key (that needs
+	// SEV-SNP / TPM). Key-load failure is FATAL: falling back to a nil key would
+	// silently mis-read existing encrypted values as garbage and write new
+	// values in plaintext, so we fail closed and let the operator fix the key
+	// (or set security.state_encryption_disabled to opt out deliberately).
+	var stateEncKey []byte
+	if !cfg.Security.StateEncryptionDisabled {
+		k, kerr := state.LoadOrCreateStateKey(cfg.Daemon.DataDir)
+		if kerr != nil {
+			log.Fatalf("Failed to load state encryption key (set security.state_encryption_disabled to run without it): %v", kerr)
+		}
+		stateEncKey = k
+		logging.Info("state-at-rest encryption enabled", logging.Component("daemon"))
+	} else {
+		logging.Info("state-at-rest encryption disabled", logging.Component("daemon"))
+	}
+
+	stateStore, err := state.NewBboltStore(stateDBPath, stateEncKey)
 	if err != nil {
 		log.Fatalf("Failed to open state database: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -402,6 +402,13 @@ type SecurityConfig struct {
 	// PATH, deploys are scanned (block HIGH/CRITICAL). Default false: a no-op
 	// scanner is used so a host without trivy never fails a deploy.
 	ImageScanEnabled bool `yaml:"image_scan_enabled"`
+
+	// R8 — state-at-rest encryption. The zero value (false) means ENABLED, so
+	// existing configs get bbolt value encryption by default. Set to true only to
+	// opt out (e.g. for debugging the raw database). The key lives at
+	// DataDir/state.key with 0600 perms; see internal/state/statekey.go for the
+	// threat model.
+	StateEncryptionDisabled bool `yaml:"state_encryption_disabled"`
 }
 
 // RedundancyConfig contains redundancy settings

--- a/internal/state/bbolt.go
+++ b/internal/state/bbolt.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -8,14 +9,31 @@ import (
 	"time"
 
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/moltbunker/moltbunker/internal/security"
 )
 
 // BboltStore implements StateStore using bbolt (embedded B+ tree KV database).
 // Each category of state (deployments, bans, peers, etc.) is stored in its own bucket.
 // All operations are ACID — partial writes on crash are impossible.
+//
+// R8 — encryption at rest: when encKey is non-nil, every value is stored as
+// encMagic || AES-256-GCM(value) and transparently decrypted on read. A nil
+// encKey disables encryption (plaintext), preserving the legacy behavior.
+//
+// Threat model: see internal/state/statekey.go. The on-disk key mitigates
+// stolen-disk / leaked-backup / casual filesystem access, not a live host-root
+// attacker who can also read state.key.
 type BboltStore struct {
-	db *bolt.DB
+	db     *bolt.DB
+	encKey []byte // nil => encryption disabled (plaintext)
 }
+
+// encMagic is a fixed, non-JSON byte prefix marking an encrypted value on disk.
+// Plaintext state values are JSON or short ASCII (schema version, timestamps),
+// none of which begin with these bytes, so the prefix unambiguously
+// distinguishes encrypted blobs from legacy plaintext during lazy migration.
+var encMagic = []byte{0x4D, 0x42, 0x45, 0x4E, 0x43, 0x31, 0x00} // "MBENC1\x00"
 
 // allBuckets is the list of buckets created on database open.
 var allBuckets = []string{
@@ -34,8 +52,13 @@ var allBuckets = []string{
 }
 
 // NewBboltStore opens or creates a bbolt database at the given path.
-// Parent directories are created if they don't exist.
-func NewBboltStore(path string) (*BboltStore, error) {
+// Parent directories are created if they don't exist. If encKey is non-nil it
+// must be a 32-byte AES-256 key; values are then encrypted at rest. Pass nil to
+// store values as plaintext (legacy behavior).
+func NewBboltStore(path string, encKey []byte) (*BboltStore, error) {
+	if encKey != nil && len(encKey) != 32 {
+		return nil, fmt.Errorf("state encryption key must be 32 bytes, got %d", len(encKey))
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return nil, fmt.Errorf("create state db directory: %w", err)
 	}
@@ -62,27 +85,71 @@ func NewBboltStore(path string) (*BboltStore, error) {
 		return nil, fmt.Errorf("initialize buckets: %w", err)
 	}
 
-	return &BboltStore{db: db}, nil
+	return &BboltStore{db: db, encKey: encKey}, nil
 }
 
 func (s *BboltStore) Close() error {
 	return s.db.Close()
 }
 
+// --- encryption helpers ---
+
+// encode returns the bytes to store on disk for a value. With encryption enabled
+// it produces encMagic || AES-256-GCM(data); otherwise data is returned as-is.
+func (s *BboltStore) encode(data []byte) ([]byte, error) {
+	if s.encKey == nil {
+		return data, nil
+	}
+	ct, err := security.EncryptAES256GCM(s.encKey, data)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt state value: %w", err)
+	}
+	out := make([]byte, 0, len(encMagic)+len(ct))
+	out = append(out, encMagic...)
+	out = append(out, ct...)
+	return out, nil
+}
+
+// decode reverses encode for a value read from disk. A value carrying encMagic
+// is decrypted (and a decrypt failure is a hard error — ciphertext is never
+// returned). A value without the magic prefix is returned verbatim: this is the
+// back-compat / lazy-migration path (legacy plaintext, or values written while
+// encryption was disabled). With encryption disabled, values are returned as-is.
+func (s *BboltStore) decode(stored []byte) ([]byte, error) {
+	if stored == nil {
+		return nil, nil
+	}
+	if s.encKey == nil {
+		return stored, nil
+	}
+	if !bytes.HasPrefix(stored, encMagic) {
+		return stored, nil
+	}
+	pt, err := security.DecryptAES256GCM(s.encKey, stored[len(encMagic):])
+	if err != nil {
+		return nil, fmt.Errorf("decrypt state value: %w", err)
+	}
+	return pt, nil
+}
+
 // --- internal helpers ---
 
 func (s *BboltStore) put(bucket, key string, data []byte) error {
+	stored, err := s.encode(data)
+	if err != nil {
+		return err
+	}
 	return s.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucket))
 		if b == nil {
 			return fmt.Errorf("bucket %s not found", bucket)
 		}
-		return b.Put([]byte(key), data)
+		return b.Put([]byte(key), stored)
 	})
 }
 
 func (s *BboltStore) get(bucket, key string) ([]byte, error) {
-	var result []byte
+	var stored []byte
 	err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucket))
 		if b == nil {
@@ -90,12 +157,15 @@ func (s *BboltStore) get(bucket, key string) ([]byte, error) {
 		}
 		v := b.Get([]byte(key))
 		if v != nil {
-			result = make([]byte, len(v))
-			copy(result, v)
+			stored = make([]byte, len(v))
+			copy(stored, v)
 		}
 		return nil
 	})
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+	return s.decode(stored)
 }
 
 func (s *BboltStore) del(bucket, key string) error {
@@ -118,10 +188,17 @@ func (s *BboltStore) list(bucket string) (map[string][]byte, error) {
 		return b.ForEach(func(k, v []byte) error {
 			cp := make([]byte, len(v))
 			copy(cp, v)
-			result[string(k)] = cp
+			plain, derr := s.decode(cp)
+			if derr != nil {
+				return fmt.Errorf("decode value for key %q: %w", string(k), derr)
+			}
+			result[string(k)] = plain
 			return nil
 		})
 	})
+	if err != nil {
+		return nil, err
+	}
 	return result, err
 }
 

--- a/internal/state/bbolt_encryption_test.go
+++ b/internal/state/bbolt_encryption_test.go
@@ -1,0 +1,369 @@
+package state
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/moltbunker/moltbunker/internal/security"
+)
+
+func newKey(t *testing.T) []byte {
+	t.Helper()
+	k, err := security.GenerateKey(32)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return k
+}
+
+func openEncrypted(t *testing.T, key []byte) (*BboltStore, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "enc.db")
+	s, err := NewBboltStore(path, key)
+	if err != nil {
+		t.Fatalf("NewBboltStore: %v", err)
+	}
+	return s, path
+}
+
+// TestEncryptedRoundTrip verifies a value written and read back under encryption
+// matches the original plaintext.
+func TestEncryptedRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	key := newKey(t)
+	s, _ := openEncrypted(t, key)
+	defer s.Close()
+
+	plain := []byte(`{"id":"dep-1","image":"nginx:latest","secret":"hunter2"}`)
+	if err := s.PutDeployment(ctx, "dep-1", plain); err != nil {
+		t.Fatalf("PutDeployment: %v", err)
+	}
+	got, err := s.GetDeployment(ctx, "dep-1")
+	if err != nil {
+		t.Fatalf("GetDeployment: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, plain)
+	}
+}
+
+// TestRawValueIsEncrypted opens the underlying bolt file directly and asserts the
+// stored bytes are NOT the plaintext and DO carry the magic prefix.
+func TestRawValueIsEncrypted(t *testing.T) {
+	ctx := context.Background()
+	key := newKey(t)
+	s, path := openEncrypted(t, key)
+
+	plain := []byte(`{"id":"dep-secret","token":"do-not-leak"}`)
+	if err := s.PutDeployment(ctx, "dep-secret", plain); err != nil {
+		t.Fatalf("PutDeployment: %v", err)
+	}
+	// Close so we can re-open the file read-only at the bolt level.
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("bolt.Open: %v", err)
+	}
+	defer db.Close()
+
+	var raw []byte
+	err = db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(BucketDeployments))
+		v := b.Get([]byte("dep-secret"))
+		raw = append([]byte(nil), v...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("View: %v", err)
+	}
+
+	if bytes.Equal(raw, plain) {
+		t.Fatal("raw on-disk value equals plaintext — not encrypted")
+	}
+	if bytes.Contains(raw, []byte("do-not-leak")) {
+		t.Fatal("plaintext token leaked into raw on-disk value")
+	}
+	if !bytes.HasPrefix(raw, encMagic) {
+		t.Fatalf("raw value missing magic prefix: %x", raw)
+	}
+}
+
+// TestBackCompatPlaintextReadByEncryptedStore verifies a value written by a
+// nil-key (plaintext) store is still readable by a key-enabled store — the
+// lazy-migration path.
+func TestBackCompatPlaintextReadByEncryptedStore(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "compat.db")
+
+	// Write plaintext with a nil-key store.
+	plainStore, err := NewBboltStore(path, nil)
+	if err != nil {
+		t.Fatalf("NewBboltStore plaintext: %v", err)
+	}
+	legacy := []byte(`{"legacy":true}`)
+	if err := plainStore.PutDeployment(ctx, "legacy-1", legacy); err != nil {
+		t.Fatalf("PutDeployment plaintext: %v", err)
+	}
+	if err := plainStore.Close(); err != nil {
+		t.Fatalf("Close plaintext: %v", err)
+	}
+
+	// Reopen with a key and confirm the legacy plaintext value still reads.
+	key := newKey(t)
+	encStore, err := NewBboltStore(path, key)
+	if err != nil {
+		t.Fatalf("NewBboltStore encrypted: %v", err)
+	}
+	defer encStore.Close()
+
+	got, err := encStore.GetDeployment(ctx, "legacy-1")
+	if err != nil {
+		t.Fatalf("GetDeployment legacy: %v", err)
+	}
+	if !bytes.Equal(got, legacy) {
+		t.Fatalf("legacy read mismatch: got %q want %q", got, legacy)
+	}
+
+	// Rewriting the value should now encrypt it (lazy migration).
+	updated := []byte(`{"legacy":false}`)
+	if err := encStore.PutDeployment(ctx, "legacy-1", updated); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got, err = encStore.GetDeployment(ctx, "legacy-1")
+	if err != nil {
+		t.Fatalf("GetDeployment after rewrite: %v", err)
+	}
+	if !bytes.Equal(got, updated) {
+		t.Fatalf("after rewrite mismatch: got %q want %q", got, updated)
+	}
+}
+
+// TestWrongKeyGetReturnsError verifies that opening an encrypted DB with the
+// wrong key causes Get to error rather than return ciphertext.
+func TestWrongKeyGetReturnsError(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "wrongkey.db")
+
+	key := newKey(t)
+	s1, err := NewBboltStore(path, key)
+	if err != nil {
+		t.Fatalf("NewBboltStore: %v", err)
+	}
+	plain := []byte(`{"id":"dep-1"}`)
+	if err := s1.PutDeployment(ctx, "dep-1", plain); err != nil {
+		t.Fatalf("PutDeployment: %v", err)
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	wrong := newKey(t)
+	s2, err := NewBboltStore(path, wrong)
+	if err != nil {
+		t.Fatalf("NewBboltStore wrong key: %v", err)
+	}
+	defer s2.Close()
+
+	got, err := s2.GetDeployment(ctx, "dep-1")
+	if err == nil {
+		t.Fatalf("expected error decrypting with wrong key, got value %q", got)
+	}
+	if got != nil {
+		t.Fatalf("expected nil value on decrypt failure, got %q", got)
+	}
+}
+
+// TestWrongKeyListReturnsError verifies List errors (not ciphertext) on bad key.
+func TestWrongKeyListReturnsError(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "wrongkeylist.db")
+
+	key := newKey(t)
+	s1, err := NewBboltStore(path, key)
+	if err != nil {
+		t.Fatalf("NewBboltStore: %v", err)
+	}
+	if err := s1.PutDeployment(ctx, "dep-1", []byte("secret")); err != nil {
+		t.Fatalf("PutDeployment: %v", err)
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	wrong := newKey(t)
+	s2, err := NewBboltStore(path, wrong)
+	if err != nil {
+		t.Fatalf("NewBboltStore wrong key: %v", err)
+	}
+	defer s2.Close()
+
+	if _, err := s2.ListDeployments(ctx); err == nil {
+		t.Fatal("expected error listing with wrong key")
+	}
+}
+
+// TestEncryptedListDecryptsAll verifies List decrypts every entry.
+func TestEncryptedListDecryptsAll(t *testing.T) {
+	ctx := context.Background()
+	key := newKey(t)
+	s, _ := openEncrypted(t, key)
+	defer s.Close()
+
+	want := map[string][]byte{
+		"d1": []byte("one"),
+		"d2": []byte("two"),
+		"d3": []byte(`{"three":3}`),
+	}
+	for k, v := range want {
+		if err := s.PutDeployment(ctx, k, v); err != nil {
+			t.Fatalf("PutDeployment %s: %v", k, err)
+		}
+	}
+
+	got, err := s.ListDeployments(ctx)
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d entries, got %d", len(want), len(got))
+	}
+	for k, v := range want {
+		if !bytes.Equal(got[k], v) {
+			t.Errorf("%s: got %q want %q", k, got[k], v)
+		}
+	}
+}
+
+// TestEncryptedTypedMethods exercises several distinct typed method pairs under
+// encryption: Deployment, APIKey, StorageObject, and Meta.
+func TestEncryptedTypedMethods(t *testing.T) {
+	ctx := context.Background()
+	key := newKey(t)
+	s, _ := openEncrypted(t, key)
+	defer s.Close()
+
+	// Deployment
+	if err := s.PutDeployment(ctx, "dep", []byte("dep-val")); err != nil {
+		t.Fatalf("PutDeployment: %v", err)
+	}
+	if got, _ := s.GetDeployment(ctx, "dep"); !bytes.Equal(got, []byte("dep-val")) {
+		t.Errorf("Deployment: got %q", got)
+	}
+
+	// APIKey (via List, since there is no GetAPIKey)
+	if err := s.PutAPIKey(ctx, "key-1", []byte(`{"hash":"abc"}`)); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	keys, err := s.ListAPIKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	if !bytes.Equal(keys["key-1"], []byte(`{"hash":"abc"}`)) {
+		t.Errorf("APIKey: got %q", keys["key-1"])
+	}
+
+	// StorageObject
+	if err := s.PutStorageObject(ctx, "obj", []byte("blob")); err != nil {
+		t.Fatalf("PutStorageObject: %v", err)
+	}
+	if got, _ := s.GetStorageObject(ctx, "obj"); !bytes.Equal(got, []byte("blob")) {
+		t.Errorf("StorageObject: got %q", got)
+	}
+
+	// Meta
+	if err := s.PutMeta(ctx, "created_at", []byte("2026-06-07")); err != nil {
+		t.Fatalf("PutMeta: %v", err)
+	}
+	if got, _ := s.GetMeta(ctx, "created_at"); !bytes.Equal(got, []byte("2026-06-07")) {
+		t.Errorf("Meta: got %q", got)
+	}
+}
+
+// TestLoadOrCreateStateKey verifies perms, length, and stability across calls.
+func TestLoadOrCreateStateKey(t *testing.T) {
+	dir := t.TempDir()
+
+	k1, err := LoadOrCreateStateKey(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreateStateKey (create): %v", err)
+	}
+	if len(k1) != stateKeySize {
+		t.Fatalf("key length = %d, want %d", len(k1), stateKeySize)
+	}
+
+	path := filepath.Join(dir, stateKeyFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	// Permission check is meaningful only on Unix.
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Fatalf("key file perms = %o, want 0600", perm)
+		}
+	}
+
+	k2, err := LoadOrCreateStateKey(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreateStateKey (load): %v", err)
+	}
+	if !bytes.Equal(k1, k2) {
+		t.Fatal("key not stable across calls")
+	}
+}
+
+// TestLoadStateKeyInvalidSize verifies a corrupt-length key file is rejected.
+func TestLoadStateKeyInvalidSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, stateKeyFile)
+	if err := os.WriteFile(path, []byte("too-short"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := LoadOrCreateStateKey(dir); err == nil {
+		t.Fatal("expected error for invalid key size")
+	}
+}
+
+// TestEncryptionDisabledIsPlaintext confirms a nil-key store stores raw plaintext
+// (no magic prefix) — preserving legacy behavior / the opt-out path.
+func TestEncryptionDisabledIsPlaintext(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "plain.db")
+	s, err := NewBboltStore(path, nil)
+	if err != nil {
+		t.Fatalf("NewBboltStore: %v", err)
+	}
+	plain := []byte(`{"plain":true}`)
+	if err := s.PutDeployment(ctx, "dep-1", plain); err != nil {
+		t.Fatalf("PutDeployment: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("bolt.Open: %v", err)
+	}
+	defer db.Close()
+	var raw []byte
+	_ = db.View(func(tx *bolt.Tx) error {
+		raw = append([]byte(nil), tx.Bucket([]byte(BucketDeployments)).Get([]byte("dep-1"))...)
+		return nil
+	})
+	if !bytes.Equal(raw, plain) {
+		t.Fatalf("plaintext store altered value on disk: got %q", raw)
+	}
+	if bytes.HasPrefix(raw, encMagic) {
+		t.Fatal("plaintext store wrote magic prefix")
+	}
+}

--- a/internal/state/migration_test.go
+++ b/internal/state/migration_test.go
@@ -270,7 +270,7 @@ func TestMigrateFromJSON_BboltStore(t *testing.T) {
 
 	// Use bbolt store
 	dbPath := filepath.Join(dataDir, "moltbunker.db")
-	store, err := NewBboltStore(dbPath)
+	store, err := NewBboltStore(dbPath, nil)
 	if err != nil {
 		t.Fatalf("NewBboltStore: %v", err)
 	}

--- a/internal/state/statekey.go
+++ b/internal/state/statekey.go
@@ -1,0 +1,64 @@
+package state
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/moltbunker/moltbunker/internal/logging"
+	"github.com/moltbunker/moltbunker/internal/security"
+)
+
+// stateKeyFile is the filename (under DataDir) for the persisted symmetric key
+// used to encrypt bbolt state values at rest (R8).
+const stateKeyFile = "state.key"
+
+// stateKeySize is the AES-256 key length in bytes for at-rest state encryption.
+const stateKeySize = 32
+
+// Threat model (R8): at-rest encryption of state values with an on-disk key
+// protects against a stolen disk, a leaked backup, or casual filesystem access
+// where the attacker obtains moltbunker.db but NOT the daemon's runtime
+// environment. It does NOT defend against a live host-root attacker who can read
+// both moltbunker.db and state.key (sitting beside it with 0600 perms) — that
+// threat requires hardware-backed key custody (SEV-SNP / TPM) and is out of
+// scope for this layer.
+
+// LoadOrCreateStateKey loads the persisted 32-byte state-encryption key from
+// dataDir/state.key, generating and persisting a fresh random key if absent. The
+// key file is written with 0600 permissions. The returned key is never logged.
+// Mirrors the persistence pattern of internal/daemon/provider_key.go.
+func LoadOrCreateStateKey(dataDir string) ([]byte, error) {
+	if dataDir == "" {
+		dataDir = os.TempDir()
+	}
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return nil, fmt.Errorf("create data dir: %w", err)
+	}
+	path := filepath.Join(dataDir, stateKeyFile)
+
+	// Try to load an existing key.
+	// #nosec G304 -- path is DataDir + constant filename, not user input.
+	if data, err := os.ReadFile(path); err == nil {
+		if len(data) != stateKeySize {
+			return nil, fmt.Errorf("state key file %s has invalid size %d (expected %d)", path, len(data), stateKeySize)
+		}
+		key := make([]byte, stateKeySize)
+		copy(key, data)
+		logging.Info("loaded state-at-rest encryption key", logging.Component("state"))
+		return key, nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read state key file: %w", err)
+	}
+
+	// Generate a fresh key and persist it.
+	key, err := security.GenerateKey(stateKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("generate state key: %w", err)
+	}
+	if err := os.WriteFile(path, key, 0600); err != nil {
+		return nil, fmt.Errorf("persist state key: %w", err)
+	}
+	logging.Info("generated new state-at-rest encryption key", logging.Component("state"))
+	return key, nil
+}

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -327,7 +327,7 @@ func TestMemoryStore(t *testing.T) {
 func TestBboltStore(t *testing.T) {
 	conformanceTests(t, "BboltStore", func(t *testing.T) StateStore {
 		path := filepath.Join(t.TempDir(), "test.db")
-		s, err := NewBboltStore(path)
+		s, err := NewBboltStore(path, nil)
 		if err != nil {
 			t.Fatalf("NewBboltStore: %v", err)
 		}
@@ -341,7 +341,7 @@ func TestBboltStore_Persistence(t *testing.T) {
 	ctx := context.Background()
 
 	// Write data, close, reopen, verify
-	s1, err := NewBboltStore(path)
+	s1, err := NewBboltStore(path, nil)
 	if err != nil {
 		t.Fatalf("open 1: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestBboltStore_Persistence(t *testing.T) {
 	}
 	s1.Close()
 
-	s2, err := NewBboltStore(path)
+	s2, err := NewBboltStore(path, nil)
 	if err != nil {
 		t.Fatalf("open 2: %v", err)
 	}


### PR DESCRIPTION
## SEC-12 — Encrypt bbolt state at rest (R8)

Daemon state in `moltbunker.db` was stored in **plaintext** — a stolen disk, leaked backup, or casual filesystem read exposed all tenant state (deployments, API keys, storage metadata, …). This encrypts state values at rest.

### How
- **Encrypt at the choke points:** every typed `Put*/Get*/List*` (plus `Meta`/`SchemaVersion`) funnels through `BboltStore`'s private `put`/`get`/`list`. Values are AES-256-GCM sealed in `put` and opened in `get`/`list` (`internal/state/bbolt.go`). Keys/bucket names stay plaintext for lookup. No value path stores plaintext.
- **Dedicated key:** 32-byte AES-256 key at `DataDir/state.key` (0600), generated via `crypto/rand` on first run, never logged (`internal/state/statekey.go`).
- **Back-compat / lazy migration:** a distinctive `MAGIC` prefix marks encrypted values. Legacy un-prefixed values are read through unchanged and re-encrypted when next rewritten. A magic-prefixed value that fails to decrypt is a **hard error** — ciphertext is never returned.
- **Default on, opt-out:** `Security.StateEncryptionDisabled` (zero value = enabled), so existing configs get encryption with no change.
- **Fail-closed:** if encryption is enabled but the key can't be loaded, the daemon **exits** rather than silently mis-reading encrypted data or writing plaintext. Early 32-byte key-length guard in `NewBboltStore`.

### Threat model (honest scope)
Mitigates stolen-disk / leaked-backup / casual filesystem access. Does **not** defend against a live host-root attacker who can also read `state.key` (that needs SEV-SNP/TPM). Documented in code.

### Verification
- `go build ./...`, `GOOS=linux go build ./cmd/exec-agent`, `go vet ./...`, `go test ./internal/... ./cmd/...`, `go test -race ./internal/state/...` — all green.
- `gosec ./...` = **0** (the new `state.key` read carries a justified `#nosec G304`).
- New tests: on-disk bytes are ciphertext (opens the bolt file directly), back-compat plaintext reads, lazy re-encrypt, wrong-key returns an error, `List` decrypts all, per-method round-trips (Deployment/APIKey/StorageObject/Meta), key file perms/stability. Conformance (both stores) + migration still pass.

### Follow-ups (out of R8 scope)
No key rotation / eager bulk re-encryption sweep — lazy migration only re-encrypts on rewrite, so cold legacy values stay plaintext until next write. The `MBENC1` magic leaves room for a versioned/rotatable scheme later.
