### PR TITLE
OPS-04 Add Linux real-containerd E2E CI job and wire Anvil

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,86 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # tests/integration spins up a local chain with Anvil and deploys the
+      # contracts with forge. Without Foundry the suite silently SKIPs
+      # (integration_test.go: "SKIP: Foundry not installed"), so install it and
+      # verify the binaries land where the tests look for them (~/.foundry/bin).
+      - name: Install Foundry (anvil / forge / cast)
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Verify Foundry toolchain
+        run: |
+          set -eux
+          ls -l "$HOME/.foundry/bin/anvil" "$HOME/.foundry/bin/forge" "$HOME/.foundry/bin/cast"
+          "$HOME/.foundry/bin/anvil" --version
+
       - name: Run integration tests
-        run: go test -v -tags=integration ./tests/...
+        run: go test -v -tags=integration -timeout 15m ./tests/...
+
+  runtime-e2e:
+    name: Runtime E2E (Linux containerd)
+    # R11: exercise the real ContainerdClient lifecycle against a live containerd
+    # on Linux. Until now these tests (tests/e2e/colima, //go:build colima) ran
+    # only against Colima on a developer's macOS and never in CI, so Linux
+    # runtime regressions (containerd, snapshots, runc tasks) shipped unverified.
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-e2e-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-e2e-
+            ${{ runner.os }}-go-
+
+      - name: Prepare containerd
+        run: |
+          set -euxo pipefail
+          # ubuntu-latest ships a running containerd (used by Docker) at
+          # /run/containerd/containerd.sock. Ensure it is installed + running and
+          # grant the unprivileged runner user access to the socket so the e2e
+          # client (which connects as the test process, not root) can reach it.
+          if ! command -v containerd >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y containerd runc
+          fi
+          # Start via systemd if available; otherwise launch a background daemon.
+          # `|| true` keeps `set -e` from aborting when the unit is already active.
+          sudo systemctl start containerd 2>/dev/null || true
+          if [ ! -S /run/containerd/containerd.sock ]; then
+            sudo sh -c 'containerd >/tmp/containerd.log 2>&1 &'
+          fi
+          # Wait (≤20s) for the socket to appear. The `if/fi` form is set -e safe.
+          for _ in $(seq 1 40); do
+            if [ -S /run/containerd/containerd.sock ]; then break; fi
+            sleep 0.5
+          done
+          test -S /run/containerd/containerd.sock
+          sudo chmod 666 /run/containerd/containerd.sock
+          sudo ctr version
+
+      - name: Run real-containerd E2E tests
+        env:
+          # tests/e2e/colima honors this override (colima_test.go: colimaSocket);
+          # point it at the Linux runner's system containerd socket.
+          COLIMA_CONTAINERD_SOCKET: /run/containerd/containerd.sock
+        run: go test -tags colima -v -timeout 12m ./tests/e2e/colima/...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-all daemon api cli exec-agent test test-quick test-smoke test-e2e test-colima \
-       test-integration test-localnet test-fuzz test-contracts test-all test-production \
+       test-containerd-linux test-integration test-localnet test-fuzz test-contracts test-all test-production \
        test-production-verbose clean install lint vet coverage doctor setup setup-linux \
        dev localnet localnet-stop localnet-status localnet-logs localnet-clean \
        docker docker-dev docker-up docker-down release release-snapshot tidy check help
@@ -58,6 +58,11 @@ test-e2e:
 test-colima:
 	@echo "Running Colima E2E tests (requires Colima running)..."
 	@go test -v -tags=colima -timeout 5m ./tests/e2e/colima/...
+
+test-containerd-linux:
+	@echo "Running real-containerd E2E tests against the system containerd (Linux/CI parity)..."
+	@echo "Requires containerd at /run/containerd/containerd.sock (or set COLIMA_CONTAINERD_SOCKET)."
+	@go test -v -tags=colima -timeout 12m ./tests/e2e/colima/...
 
 test-integration:
 	@echo "Running integration tests..."

--- a/tests/e2e/colima/colima_test.go
+++ b/tests/e2e/colima/colima_test.go
@@ -1,16 +1,22 @@
 //go:build colima
 
-// Package colima contains E2E tests that run against a real containerd instance
-// inside Colima on macOS. These tests verify the ContainerdClient against actual
-// container lifecycle operations.
+// Package colima contains E2E tests that run against a REAL containerd instance.
+// They verify the ContainerdClient against actual container lifecycle operations
+// (pull, create, start, stop, delete, resources). Despite the package/tag name,
+// these run in two environments:
 //
-// Prerequisites:
-//   - Colima running: `colima start --runtime containerd`
-//   - containerd socket at ~/.colima/default/containerd.sock
+//   - macOS dev: Colima containerd (`colima start --runtime containerd`),
+//     socket at ~/.colima/default/containerd.sock.
+//   - Linux CI (R11): the system containerd socket at
+//     /run/containerd/containerd.sock — see the `runtime-e2e` job in
+//     .github/workflows/ci.yml.
+//
+// Socket resolution order (colimaSocket): COLIMA_CONTAINERD_SOCKET env override,
+// then the Linux system socket on non-darwin, then the Colima default.
 //
 // Run with:
 //
-//	go test -tags colima -v -timeout 5m ./tests/e2e/colima/...
+//	go test -tags colima -v -timeout 12m ./tests/e2e/colima/...
 package colima
 
 import (
@@ -19,6 +25,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 	"time"
@@ -38,10 +45,23 @@ const (
 	lifecycleTimeout = 30 * time.Second
 )
 
-// colimaSocket returns the containerd socket path, checking env override first.
+// linuxContainerdSocket is the system containerd socket used on Linux (e.g. CI
+// runners), where there is no Colima VM.
+const linuxContainerdSocket = "/run/containerd/containerd.sock"
+
+// colimaSocket returns the containerd socket path. Resolution order: the
+// COLIMA_CONTAINERD_SOCKET env override (used by CI), then the Linux system
+// socket on non-darwin if present, then the macOS Colima default.
 func colimaSocket() string {
 	if s := os.Getenv("COLIMA_CONTAINERD_SOCKET"); s != "" {
 		return s
+	}
+
+	// On Linux (CI / native containerd) prefer the system socket.
+	if goruntime.GOOS != "darwin" {
+		if _, err := os.Stat(linuxContainerdSocket); err == nil {
+			return linuxContainerdSocket
+		}
 	}
 
 	home, err := os.UserHomeDir()


### PR DESCRIPTION
Make CI actually exercise the runtime layer on Linux (R11) and stop the integration suite from silently skipping.

runtime-e2e job (.github/workflows/ci.yml):
- New job on ubuntu-latest that ensures containerd is installed + running, grants the unprivileged runner access to /run/containerd/containerd.sock, and runs the real-containerd lifecycle E2E (go test -tags colima ./tests/e2e/colima/...) against the system containerd. This is the first time the ContainerdClient lifecycle (pull/create/start/stop/delete/ resources) is verified on Linux in CI; previously these tests ran only against Colima on a developer's macOS, so Linux runtime regressions (containerd, snapshots, runc tasks) shipped unverified.

Integration job now installs Foundry:
- tests/integration spins up Anvil + deploys contracts with forge but SKIPs when ~/.foundry/bin/anvil is absent, which it always was in CI. Add the foundry-rs/foundry-toolchain action + a verify step (and submodules + a 15m timeout) so the chain integration tests run instead of skipping.

Linux-aware socket resolution (tests/e2e/colima/colima_test.go):
- colimaSocket() now falls back to /run/containerd/containerd.sock on non-darwin (after the COLIMA_CONTAINERD_SOCKET override), so the real- containerd E2E runs on Linux natively. Updated the package doc to reflect dual macOS-Colima / Linux-CI use. Added a test-containerd-linux Makefile target for local parity.

Validated locally: ci.yml YAML parses (6 jobs, correct needs/steps); the colima E2E tests cross-compile for linux/amd64 (the CI target) and still compile on darwin; integration tests compile; go build ./... green. The live GitHub Actions run is the real check for runner socket perms + image pull/ unpack + runc task start (cannot run Actions/containerd locally).

Follow-ups: assert R5/R13/R14 enforcement in the Linux E2E (harness now exists), wire a full in-container exec E2E, and promote runtime-e2e to a required merge check once it is proven stable.

## Summary

<!-- 1-3 bullets. What changed and why. Reader should be able to decide whether they care about this PR from this section alone. -->

- 
- 

## Linked tickets / related PRs

- Closes: <!-- TICKET-NN -->
- Related: <!-- other repo PR URLs if cross-repo -->

## What I changed

<!-- 2-6 bullets. Concrete description of the code change. Skip if obvious from the diff. -->

- 
- 

## Why this approach

<!-- Optional. Use when a non-obvious design choice was made. Mention alternatives considered and why this won. -->

## Test plan

- [ ] <!-- how I verified the happy path -->
- [ ] <!-- how I verified edge cases -->
- [ ] <!-- any test you ran that the CI doesn't cover -->

## Risk

<!-- Honest assessment. "Low" is fine but explain. "High" means this PR shouldn't land without a second pair of eyes or a rollback plan. -->

- Blast radius: <!-- which subsystems / users -->
- Reversibility: <!-- can we revert cleanly? Any migrations? -->
- Monitoring: <!-- what to watch after merge -->

## Screenshots / artifacts

<!-- For UI changes: before/after. For new endpoints: a curl example. -->

