### PR TITLE
PAY-01 Fix payment/escrow correctness and wire service metering hooks

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -364,6 +364,28 @@ func main() {
 		cm.StartDiskEnforcer(ctx, 60*time.Second)
 	}
 
+	// Escrow event consumer: drive local reservation-ID cache invalidation off
+	// the on-chain escrow lifecycle. On Refunded/Finalized, the reservation has
+	// reached a terminal state, so the jobID→reservationID mapping must be
+	// dropped — otherwise a redeploy with the same jobID would reuse a stale
+	// on-chain reservation. The events only carry the reservationID, so we
+	// reverse-resolve the jobID from the payment service's cache.
+	if eventWatcher != nil {
+		util.SafeGoWithName("escrow-event-consumer", func() {
+			for ev := range eventWatcher.EscrowEvents() {
+				switch ev.Kind {
+				case payment.EscrowEventRefunded, payment.EscrowEventFinalized:
+					if jobID, ok := paymentSvc.JobIDForReservationID(ev.ReservationID); ok {
+						paymentSvc.InvalidateEscrowReservation(jobID)
+						logging.Debug("escrow event: invalidated reservation cache",
+							"kind", ev.Kind.String(),
+							logging.Component("daemon"))
+					}
+				}
+			}
+		})
+	}
+
 	// Start subdomain expiry cleanup (removes expired gossip entries hourly)
 	if cm := apiServer.GetContainerManager(); cm != nil && cm.GossipProtocol() != nil {
 		daemon.StartSubdomainCleanup(ctx, cm.GossipProtocol(), paymentSvc)
@@ -715,6 +737,9 @@ func main() {
 			if storageErr != nil {
 				log.Fatalf("Failed to create storage engine: %v", storageErr)
 			}
+			// Wire storage usage metering for billing (PaymentService satisfies
+			// storage.MeteringHook structurally).
+			storageEngine.SetMeteringHook(paymentSvc)
 			httpAPIServer.SetStorageHandler(storage.NewRESTHandler(storageEngine))
 			logging.Info("object storage service enabled", logging.Component("daemon"))
 		}
@@ -727,6 +752,9 @@ func main() {
 				UseTor:      cfg.Proxy.UseTor,
 				MaxSessions: cfg.Proxy.MaxSessions,
 			}, &proxy.DirectDialer{}, &proxy.AllowAllAuth{DefaultWallet: "system"})
+			// Wire proxy session metering before Start so it propagates to the
+			// SOCKS5/HTTP sub-servers (PaymentService satisfies proxy.ProxyMeteringHook).
+			proxyServer.SetMeteringHook(paymentSvc)
 			if proxyErr := proxyServer.Start(ctx); proxyErr != nil {
 				log.Fatalf("Failed to start proxy service: %v", proxyErr)
 			}
@@ -750,6 +778,8 @@ func main() {
 				MaxConcurrentJobs: cfg.Crawl.MaxConcurrent,
 				MaxPagesPerJob:    cfg.Crawl.MaxPages,
 			})
+			// Wire crawl job metering (PaymentService satisfies crawl.CrawlMeteringHook).
+			scheduler.SetMeteringHook(paymentSvc)
 			httpAPIServer.SetCrawlHandler(crawl.NewRESTHandler(scheduler, crawl.NewRobotsChecker()))
 			logging.Info("web crawling service enabled", logging.Component("daemon"))
 		}
@@ -759,7 +789,10 @@ func main() {
 			agentRuntime := agent.NewAgentRuntime(agent.RuntimeConfig{
 				MaxAgentsPerWallet: cfg.Agent.MaxAgentsPerWallet,
 			})
-			httpAPIServer.SetAgentHandler(agent.NewRESTHandler(agentRuntime, agent.NewMemoryStore()))
+			agentHandler := agent.NewRESTHandler(agentRuntime, agent.NewMemoryStore())
+			// Wire agent invocation metering (PaymentService satisfies agent.AgentMeteringHook).
+			agentHandler.SetMeteringHook(paymentSvc)
+			httpAPIServer.SetAgentHandler(agentHandler)
 			logging.Info("agent runtime service enabled", logging.Component("daemon"))
 		}
 

--- a/internal/agent/rest_handler.go
+++ b/internal/agent/rest_handler.go
@@ -9,10 +9,22 @@ import (
 	"github.com/moltbunker/moltbunker/internal/logging"
 )
 
+// AgentMeteringHook receives agent invocation usage for billing. It is defined
+// locally (not imported from payment) so the agent package does not depend on
+// payment, avoiding an import cycle. payment.PaymentService satisfies it
+// structurally via RecordAgentInvocation.
+//
+// The hook is optional: when nil, the handler behaves exactly as before (no
+// metering), so existing callers and tests need no changes.
+type AgentMeteringHook interface {
+	RecordAgentInvocation(wallet string, tokensUsed int64)
+}
+
 // RESTHandler provides HTTP endpoints for agent management.
 type RESTHandler struct {
 	runtime *AgentRuntime
 	memory  *MemoryStore
+	meter   AgentMeteringHook // optional usage metering hook (nil = no metering)
 }
 
 // NewRESTHandler creates a new agent REST handler.
@@ -21,6 +33,11 @@ func NewRESTHandler(runtime *AgentRuntime, memory *MemoryStore) *RESTHandler {
 		runtime: runtime,
 		memory:  memory,
 	}
+}
+
+// SetMeteringHook installs an optional agent metering hook. Pass nil to disable.
+func (h *RESTHandler) SetMeteringHook(m AgentMeteringHook) {
+	h.meter = m
 }
 
 // RegisterRoutes registers agent routes on a mux.
@@ -188,6 +205,13 @@ func (h *RESTHandler) invokeAgent(w http.ResponseWriter, r *http.Request, agentI
 		AgentID:    agentID,
 		Response:   fmt.Sprintf("Agent %s received: %s", agentID, req.Message),
 		TokensUsed: 0,
+	}
+
+	// Record invocation for billing (optional, nil-safe). Wired now so that when
+	// the placeholder TokensUsed=0 is replaced with a real value, metering is
+	// already in place.
+	if h.meter != nil {
+		h.meter.RecordAgentInvocation(wallet, resp.TokensUsed)
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/crawl/scheduler.go
+++ b/internal/crawl/scheduler.go
@@ -13,6 +13,17 @@ import (
 	"github.com/moltbunker/moltbunker/internal/logging"
 )
 
+// CrawlMeteringHook receives completed crawl job usage for billing. It is
+// defined locally (not imported from payment) so the crawl package does not
+// depend on payment, avoiding an import cycle. payment.PaymentService satisfies
+// it structurally via RecordCrawlJob.
+//
+// The hook is optional: when nil, the scheduler behaves exactly as before (no
+// metering), so existing callers and tests need no changes.
+type CrawlMeteringHook interface {
+	RecordCrawlJob(wallet string, pagesCrawled, resultBytes int64)
+}
+
 // Scheduler manages crawl jobs and distributes work.
 type Scheduler struct {
 	mu   sync.RWMutex
@@ -21,6 +32,14 @@ type Scheduler struct {
 	config    SchedulerConfig
 	rateLimit *DomainRateLimiter
 	dedup     *URLDedup
+	meter     CrawlMeteringHook // optional usage metering hook (nil = no metering)
+}
+
+// SetMeteringHook installs an optional crawl metering hook. Pass nil to disable.
+func (s *Scheduler) SetMeteringHook(h CrawlMeteringHook) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.meter = h
 }
 
 // SchedulerConfig configures the crawl scheduler.
@@ -161,15 +180,28 @@ func (s *Scheduler) AddResult(jobID string, result CrawlResult) error {
 // CompleteJob marks a job as completed.
 func (s *Scheduler) CompleteJob(jobID string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	job, ok := s.jobs[jobID]
 	if !ok {
+		s.mu.Unlock()
 		return fmt.Errorf("job %q not found", jobID)
 	}
 
 	job.Status = JobStatusCompleted
 	job.CompletedAt = time.Now()
+
+	// Snapshot under the lock for the (optional) metering call, which is made
+	// after the lock is released so the hook is not invoked while holding s.mu.
+	meter := s.meter
+	owner := job.Owner
+	pages := int64(job.PagesCrawled)
+	totalBytes := job.TotalBytes
+	s.mu.Unlock()
+
+	// Record usage for billing (optional, nil-safe).
+	if meter != nil {
+		meter.RecordCrawlJob(owner, pages, totalBytes)
+	}
 	return nil
 }
 

--- a/internal/daemon/container_manager.go
+++ b/internal/daemon/container_manager.go
@@ -301,6 +301,14 @@ func NewContainerManager(ctx context.Context, config ContainerManagerConfig, nod
 		cm.reconcileOnStartup(ctx)
 	}
 
+	// Recover orphaned escrows: after a crash between Stop and FinalizeJob, a
+	// terminal-status originator deployment may still have an un-finalized
+	// on-chain escrow. Sweep them (non-blocking) right after the status
+	// reconcile so the freshly-synced statuses are used.
+	if cm.payment != nil {
+		cm.reconcileEscrowsOnStartup(ctx, cm.payment)
+	}
+
 	// Periodic cleanup of stale pending deployments (async deploys)
 	util.SafeGoWithName("pending-deployment-cleanup", func() {
 		cm.cleanStalePendingDeployments(ctx)
@@ -423,8 +431,12 @@ func (cm *ContainerManager) Deploy(ctx context.Context, req *DeployRequest) (*De
 		return nil, fmt.Errorf("resource validation failed: %w", err)
 	}
 
-	// Gate on escrow: either use user-provided reservation or create one
+	// Gate on escrow: either use user-provided reservation or create one.
+	// reservationIDStr is the decimal on-chain reservation ID bound to this
+	// deployment; it is persisted onto the Deployment record below so the
+	// startup reconciler can rehydrate the in-memory cache after a restart.
 	duration := parseDuration(req.Duration)
+	var reservationIDStr string
 	if cm.payment != nil {
 		jobID := payment.JobIDFromString(deploymentID)
 
@@ -436,6 +448,7 @@ func (cm *ContainerManager) Deploy(ctx context.Context, req *DeployRequest) (*De
 				return nil, fmt.Errorf("invalid reservation_id: %s", req.ReservationID)
 			}
 			cm.payment.RegisterExternalReservation(jobID, resID)
+			reservationIDStr = resID.String()
 			logging.Info("registered user-created escrow for deployment",
 				logging.ContainerID(deploymentID),
 				"reservation_id", req.ReservationID)
@@ -461,8 +474,16 @@ func (cm *ContainerManager) Deploy(ctx context.Context, req *DeployRequest) (*De
 				return nil, fmt.Errorf("failed to create escrow: %w", err)
 			}
 
+			// Capture the on-chain reservation ID assigned during creation so it
+			// can be persisted on the Deployment. After a restart the in-memory
+			// cache is empty; without this the orphan reconciler cannot finalize.
+			if resID, ok := cm.payment.ReservationIDForJob(jobID); ok {
+				reservationIDStr = resID.String()
+			}
+
 			logging.Info("escrow created for deployment",
 				logging.ContainerID(deploymentID),
+				"reservation_id", reservationIDStr,
 				"price", payment.FormatTokenAmount(price),
 				"duration", duration.String())
 		}
@@ -489,6 +510,7 @@ func (cm *ContainerManager) Deploy(ctx context.Context, req *DeployRequest) (*De
 		TorOnly:         req.TorOnly,
 		OriginatorID:    cm.node.nodeInfo.ID, // Local node is the originator
 		Owner:           req.Owner,
+		ReservationID:   reservationIDStr, // persisted so orphan reconciler can rehydrate after restart
 		MinProviderTier: types.ProviderTier(req.MinProviderTier),
 		Spot:            req.Spot,
 		// R3/R4/R13/R14: carry the per-deployment security policy onto the
@@ -1028,6 +1050,11 @@ func (cm *ContainerManager) Stop(ctx context.Context, containerID string) error 
 			logging.Warn("failed to finalize escrow on stop",
 				logging.ContainerID(containerID),
 				logging.Err(err))
+		} else {
+			// Mark finalized so the startup reconciler skips this deployment.
+			cm.mu.Lock()
+			deployment.EscrowFinalized = true
+			cm.mu.Unlock()
 		}
 	}
 
@@ -1133,6 +1160,8 @@ func (cm *ContainerManager) Delete(ctx context.Context, containerID string) erro
 				logging.Warn("failed to finalize escrow on delete",
 					logging.ContainerID(containerID),
 					logging.Err(err))
+			} else {
+				deployment.EscrowFinalized = true
 			}
 		} else {
 			// Early termination or never started: refund
@@ -1140,6 +1169,8 @@ func (cm *ContainerManager) Delete(ctx context.Context, containerID string) erro
 				logging.Warn("failed to refund escrow on delete",
 					logging.ContainerID(containerID),
 					logging.Err(err))
+			} else {
+				deployment.EscrowFinalized = true
 			}
 		}
 	}
@@ -1507,6 +1538,152 @@ func (cm *ContainerManager) reconcileOnStartup(ctx context.Context) {
 	logging.Info("startup reconciliation complete",
 		"deployments", len(entries),
 		"updated", changed)
+}
+
+// escrowFinalizer is the narrow payment dependency used by the startup escrow
+// reconciler. *payment.PaymentService satisfies it via FinalizeJob and
+// RegisterExternalReservation. Keeping it as an interface lets
+// reconcileEscrowsOnStartup be unit-tested while cm.payment stays a concrete
+// *payment.PaymentService elsewhere.
+//
+// RegisterExternalReservation is required because the in-memory
+// jobID→reservationID cache inside the escrow contract is lost on restart;
+// FinalizeJob resolves the reservation ID from that cache, so the reconciler
+// must rehydrate it from the persisted Deployment.ReservationID before calling
+// FinalizeJob — otherwise every orphan finalize fails with "no reservation ID
+// found".
+type escrowFinalizer interface {
+	FinalizeJob(ctx context.Context, jobID [32]byte) error
+	RegisterExternalReservation(jobID [32]byte, reservationID *big.Int)
+}
+
+// reconcileEscrowsOnStartup recovers from the crash-between-stop-and-finalize
+// gap. After a crash, a deployment may be in a terminal status
+// (Stopped/Failed/Deleted) yet its on-chain escrow was never finalized (no
+// FinalizeJob TX landed). This sweep finalizes those orphans.
+//
+// It is non-blocking: each FinalizeJob is issued in its own SafeGoWithName
+// goroutine so a slow RPC does not delay daemon startup. Idempotency is
+// guaranteed by the on-chain contract (finalizeReservation reverts if already
+// finalized) and by the persisted EscrowFinalized flag, which is set
+// optimistically on both success and an "already finalized" error so confirmed
+// terminal transactions are not re-issued on subsequent restarts.
+//
+// Only originator-owned deployments are swept; replicas (OriginatorID != nodeID)
+// never own the escrow and are skipped, matching FinalizeAllEscrows.
+func (cm *ContainerManager) reconcileEscrowsOnStartup(ctx context.Context, finalizer escrowFinalizer) {
+	if finalizer == nil {
+		return
+	}
+
+	nodeID := cm.node.nodeInfo.ID
+
+	type orphan struct {
+		id            string
+		reservationID string // persisted on-chain reservation ID (decimal); may be empty
+	}
+
+	cm.mu.RLock()
+	var orphans []orphan
+	for id, dep := range cm.deployments {
+		if dep.OriginatorID != nodeID {
+			continue
+		}
+		if dep.EscrowFinalized {
+			continue
+		}
+		// Terminal statuses whose escrow must be finalized. There is no
+		// "deleted" status in this codebase — Delete() removes the deployment
+		// from the map entirely (and already finalizes the escrow), so a
+		// persisted deployment in a terminal state means it was stopped/failed
+		// but the finalize TX may not have landed before a crash.
+		switch dep.Status {
+		case types.ContainerStatusStopped,
+			types.ContainerStatusFailed:
+			orphans = append(orphans, orphan{id: id, reservationID: dep.ReservationID})
+		}
+	}
+	cm.mu.RUnlock()
+
+	if len(orphans) == 0 {
+		return
+	}
+
+	// Rehydrate the in-memory jobID→reservationID cache from the persisted
+	// reservation IDs BEFORE sweeping. FinalizeJob resolves the reservation ID
+	// from this cache, which is empty after a restart; without rehydration every
+	// finalize fails with "no reservation ID found". Done synchronously (cheap,
+	// in-memory) so the cache is warm before the async finalize goroutines run.
+	for _, o := range orphans {
+		if o.reservationID == "" {
+			continue
+		}
+		resID := new(big.Int)
+		if _, ok := resID.SetString(o.reservationID, 10); !ok {
+			logging.Warn("escrow reconcile: skipping orphan with unparseable reservation ID",
+				logging.ContainerID(o.id), "reservation_id", o.reservationID)
+			continue
+		}
+		finalizer.RegisterExternalReservation(payment.JobIDFromString(o.id), resID)
+	}
+
+	logging.Info("escrow reconcile: finalizing orphan jobs",
+		"count", len(orphans))
+
+	for _, o := range orphans {
+		containerID := o.id
+		util.SafeGoWithName("escrow-reconcile-"+containerID, func() {
+			jobID := payment.JobIDFromString(containerID)
+			err := finalizer.FinalizeJob(ctx, jobID)
+			if err == nil {
+				cm.markEscrowFinalized(containerID)
+				logging.Info("escrow reconcile: finalized orphan job",
+					logging.ContainerID(containerID))
+				return
+			}
+			// The contract reverts re-finalization; treat that as already done
+			// so we stop retrying on every restart.
+			if isAlreadyFinalizedErr(err) {
+				cm.markEscrowFinalized(containerID)
+				logging.Info("escrow reconcile: job already finalized on-chain",
+					logging.ContainerID(containerID))
+				return
+			}
+			// Transient error: leave EscrowFinalized=false so a later restart
+			// retries.
+			logging.Warn("escrow reconcile: finalize failed, will retry next restart",
+				logging.ContainerID(containerID), logging.Err(err))
+		})
+	}
+}
+
+// markEscrowFinalized sets EscrowFinalized=true on the deployment (if it still
+// exists) and persists the change.
+func (cm *ContainerManager) markEscrowFinalized(containerID string) {
+	cm.mu.Lock()
+	dep, ok := cm.deployments[containerID]
+	if ok {
+		dep.EscrowFinalized = true
+	}
+	cm.mu.Unlock()
+	if ok {
+		cm.saveStateAsync()
+	}
+}
+
+// isAlreadyFinalizedErr reports whether an escrow finalize error indicates the
+// reservation is ALREADY in a terminal on-chain state (Completed/Refunded/
+// Disputed), so re-finalizing is a confirmed no-op and the reconciler may mark
+// the deployment done.
+//
+// Detection is delegated to payment.IsAlreadyTerminalEscrowErr, which prefers
+// decoding the contract's typed InvalidStatus custom-error data over substring
+// matching and never matches ambiguous transient phrasings. This is
+// deliberately NARROW: an error like "reservation not yet finalizable" (which
+// merely contains the substring "finalized") is treated as TRANSIENT, so a live
+// escrow is never abandoned.
+func isAlreadyFinalizedErr(err error) bool {
+	return payment.IsAlreadyTerminalEscrowErr(err)
 }
 
 // reconcileContainerStatus periodically checks containerd for actual container status

--- a/internal/daemon/deployment.go
+++ b/internal/daemon/deployment.go
@@ -51,6 +51,19 @@ type Deployment struct {
 	RuntimeType              types.RuntimeType  `json:"runtime_type,omitempty"`                // "container" (default) or "molt" for WASM workloads
 	MoltSpec                 *types.MoltSpec    `json:"molt_spec,omitempty"`                   // Molt spec for WASM deployments (nil for containers)
 
+	// EscrowFinalized records whether the terminal escrow call (FinalizeJob or
+	// RefundJob) completed successfully for this deployment. Persisted so the
+	// startup escrow reconciler can skip re-submitting confirmed on-chain
+	// terminal transactions after a crash/restart.
+	EscrowFinalized bool `json:"escrow_finalized,omitempty"`
+
+	// ReservationID is the decimal string of the on-chain escrow reservation ID
+	// bound to this deployment. Persisted at escrow-create time so the startup
+	// reconciler can rehydrate the in-memory jobID→reservationID cache (which is
+	// lost on restart) before finalizing orphaned escrows. Without this, every
+	// orphan finalize fails with "no reservation ID found" after a restart.
+	ReservationID string `json:"reservation_id,omitempty"`
+
 	// R3/R4/R13/R14 — optional per-deployment security policy. These gossip with
 	// the deployment so replica nodes apply the same gates as the originator.
 	// All nil/false => identical to legacy behavior (no verify, no scan, allow-all).

--- a/internal/daemon/escrow_reconcile_test.go
+++ b/internal/daemon/escrow_reconcile_test.go
@@ -1,0 +1,373 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/moltbunker/moltbunker/internal/payment"
+	"github.com/moltbunker/moltbunker/pkg/types"
+)
+
+// mockEscrowFinalizer records FinalizeJob + RegisterExternalReservation calls
+// and can be configured to return a canned error. It satisfies the
+// escrowFinalizer interface. Used for the status/replica/transient unit tests
+// that do not need the real reservation-cache behavior.
+type mockEscrowFinalizer struct {
+	mu         sync.Mutex
+	calls      int
+	jobIDs     [][32]byte
+	registered map[[32]byte]*big.Int
+	retErr     error
+	done       chan struct{} // closed-once signal after the expected number of calls
+	expected   int
+}
+
+func newMockFinalizer(expected int) *mockEscrowFinalizer {
+	return &mockEscrowFinalizer{
+		done:       make(chan struct{}),
+		expected:   expected,
+		registered: make(map[[32]byte]*big.Int),
+	}
+}
+
+func (m *mockEscrowFinalizer) RegisterExternalReservation(jobID [32]byte, reservationID *big.Int) {
+	m.mu.Lock()
+	m.registered[jobID] = new(big.Int).Set(reservationID)
+	m.mu.Unlock()
+}
+
+func (m *mockEscrowFinalizer) FinalizeJob(_ context.Context, jobID [32]byte) error {
+	m.mu.Lock()
+	m.calls++
+	m.jobIDs = append(m.jobIDs, jobID)
+	reached := m.calls >= m.expected
+	err := m.retErr
+	m.mu.Unlock()
+	if reached {
+		// Non-blocking close-once.
+		select {
+		case <-m.done:
+		default:
+			close(m.done)
+		}
+	}
+	return err
+}
+
+func (m *mockEscrowFinalizer) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+// newReconcileCM builds a minimal ContainerManager wired with a node ID and a
+// temp data dir (so saveStateAsync writes to JSON without error).
+func newReconcileCM(t *testing.T, nodeID types.NodeID) *ContainerManager {
+	t.Helper()
+	return &ContainerManager{
+		deployments: make(map[string]*Deployment),
+		dataDir:     t.TempDir(),
+		node:        &Node{nodeInfo: &types.Node{ID: nodeID}},
+	}
+}
+
+func nodeIDFrom(b byte) types.NodeID {
+	var id types.NodeID
+	id[0] = b
+	return id
+}
+
+// waitFor polls fn until it returns true or the deadline elapses.
+func waitFor(t *testing.T, fn func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+func TestReconcileEscrowsOnStartup_FinalizesStopped(t *testing.T) {
+	nodeID := nodeIDFrom(0x01)
+	cm := newReconcileCM(t, nodeID)
+	cm.deployments["dep-stop"] = &Deployment{
+		ID:              "dep-stop",
+		Status:          types.ContainerStatusStopped,
+		OriginatorID:    nodeID,
+		EscrowFinalized: false,
+	}
+
+	fin := newMockFinalizer(1)
+	cm.reconcileEscrowsOnStartup(context.Background(), fin)
+
+	if !waitFor(t, func() bool { return fin.callCount() == 1 }) {
+		t.Fatalf("expected FinalizeJob called once, got %d", fin.callCount())
+	}
+	if !waitFor(t, func() bool {
+		cm.mu.RLock()
+		defer cm.mu.RUnlock()
+		return cm.deployments["dep-stop"].EscrowFinalized
+	}) {
+		t.Fatal("expected EscrowFinalized to become true")
+	}
+}
+
+func TestReconcileEscrowsOnStartup_SkipsAlreadyFinalized(t *testing.T) {
+	nodeID := nodeIDFrom(0x02)
+	cm := newReconcileCM(t, nodeID)
+	cm.deployments["dep-done"] = &Deployment{
+		ID:              "dep-done",
+		Status:          types.ContainerStatusStopped,
+		OriginatorID:    nodeID,
+		EscrowFinalized: true, // already finalized
+	}
+
+	fin := newMockFinalizer(1)
+	cm.reconcileEscrowsOnStartup(context.Background(), fin)
+
+	// Give any (erroneously) spawned goroutine a chance to run.
+	time.Sleep(100 * time.Millisecond)
+	if got := fin.callCount(); got != 0 {
+		t.Fatalf("expected FinalizeJob NOT called, got %d", got)
+	}
+}
+
+func TestReconcileEscrowsOnStartup_SkipsReplicas(t *testing.T) {
+	nodeID := nodeIDFrom(0x03)
+	otherNode := nodeIDFrom(0x99)
+	cm := newReconcileCM(t, nodeID)
+	cm.deployments["dep-replica"] = &Deployment{
+		ID:              "dep-replica",
+		Status:          types.ContainerStatusStopped,
+		OriginatorID:    otherNode, // not this node => replica, must be skipped
+		EscrowFinalized: false,
+	}
+
+	fin := newMockFinalizer(1)
+	cm.reconcileEscrowsOnStartup(context.Background(), fin)
+
+	time.Sleep(100 * time.Millisecond)
+	if got := fin.callCount(); got != 0 {
+		t.Fatalf("expected FinalizeJob NOT called for replica, got %d", got)
+	}
+	cm.mu.RLock()
+	finalized := cm.deployments["dep-replica"].EscrowFinalized
+	cm.mu.RUnlock()
+	if finalized {
+		t.Error("replica deployment must not be marked finalized")
+	}
+}
+
+func TestReconcileEscrowsOnStartup_AlreadyFinalizedOnChain(t *testing.T) {
+	nodeID := nodeIDFrom(0x04)
+	cm := newReconcileCM(t, nodeID)
+	cm.deployments["dep-onchain"] = &Deployment{
+		ID:              "dep-onchain",
+		Status:          types.ContainerStatusFailed,
+		OriginatorID:    nodeID,
+		EscrowFinalized: false,
+	}
+
+	fin := newMockFinalizer(1)
+	// Precise terminal custom-error phrasing (InvalidStatus actual=Completed).
+	fin.retErr = fmt.Errorf("execution reverted: reservation already finalized")
+	cm.reconcileEscrowsOnStartup(context.Background(), fin)
+
+	if !waitFor(t, func() bool { return fin.callCount() == 1 }) {
+		t.Fatalf("expected FinalizeJob called once, got %d", fin.callCount())
+	}
+	// Despite the error, the "already finalized" message must mark it done.
+	if !waitFor(t, func() bool {
+		cm.mu.RLock()
+		defer cm.mu.RUnlock()
+		return cm.deployments["dep-onchain"].EscrowFinalized
+	}) {
+		t.Fatal("expected EscrowFinalized=true after already-finalized error")
+	}
+}
+
+func TestReconcileEscrowsOnStartup_TransientErrorLeavesUnfinalized(t *testing.T) {
+	nodeID := nodeIDFrom(0x05)
+	cm := newReconcileCM(t, nodeID)
+	cm.deployments["dep-transient"] = &Deployment{
+		ID:              "dep-transient",
+		Status:          types.ContainerStatusStopped,
+		OriginatorID:    nodeID,
+		EscrowFinalized: false,
+	}
+
+	fin := newMockFinalizer(1)
+	fin.retErr = fmt.Errorf("dial tcp: connection refused")
+	cm.reconcileEscrowsOnStartup(context.Background(), fin)
+
+	if !waitFor(t, func() bool { return fin.callCount() == 1 }) {
+		t.Fatalf("expected FinalizeJob called once, got %d", fin.callCount())
+	}
+	// A transient error must leave the flag false so a later restart retries.
+	time.Sleep(100 * time.Millisecond)
+	cm.mu.RLock()
+	finalized := cm.deployments["dep-transient"].EscrowFinalized
+	cm.mu.RUnlock()
+	if finalized {
+		t.Error("transient error must NOT mark EscrowFinalized true")
+	}
+}
+
+// TestReconcileEscrowsOnStartup_NotYetFinalizableIsTransient asserts the HIGH-2
+// regression: an ambiguous "not yet finalizable" revert (which contains the
+// substring "finalized") must be treated as TRANSIENT — the live escrow must
+// NOT be marked finalized.
+func TestReconcileEscrowsOnStartup_NotYetFinalizableIsTransient(t *testing.T) {
+	nodeID := nodeIDFrom(0x07)
+	cm := newReconcileCM(t, nodeID)
+	cm.deployments["dep-notyet"] = &Deployment{
+		ID:              "dep-notyet",
+		Status:          types.ContainerStatusStopped,
+		OriginatorID:    nodeID,
+		EscrowFinalized: false,
+	}
+
+	fin := newMockFinalizer(1)
+	fin.retErr = fmt.Errorf("execution reverted: reservation not yet finalizable")
+	cm.reconcileEscrowsOnStartup(context.Background(), fin)
+
+	if !waitFor(t, func() bool { return fin.callCount() == 1 }) {
+		t.Fatalf("expected FinalizeJob called once, got %d", fin.callCount())
+	}
+	time.Sleep(100 * time.Millisecond)
+	cm.mu.RLock()
+	finalized := cm.deployments["dep-notyet"].EscrowFinalized
+	cm.mu.RUnlock()
+	if finalized {
+		t.Error("'not yet finalizable' must be TRANSIENT — escrow must NOT be abandoned")
+	}
+}
+
+func TestReconcileEscrowsOnStartup_NilFinalizer(t *testing.T) {
+	cm := newReconcileCM(t, nodeIDFrom(0x06))
+	cm.deployments["d"] = &Deployment{
+		ID: "d", Status: types.ContainerStatusStopped, OriginatorID: nodeIDFrom(0x06),
+	}
+	// Must not panic with a nil finalizer.
+	cm.reconcileEscrowsOnStartup(context.Background(), nil)
+}
+
+// TestReconcileEscrowsOnStartup_RehydratesPersistedReservation asserts the
+// reconciler rehydrates the persisted Deployment.ReservationID into the cache
+// (via RegisterExternalReservation) BEFORE finalizing, and skips orphans with
+// no persisted reservation ID for rehydration.
+func TestReconcileEscrowsOnStartup_RehydratesPersistedReservation(t *testing.T) {
+	nodeID := nodeIDFrom(0x08)
+	cm := newReconcileCM(t, nodeID)
+	cm.deployments["dep-with-res"] = &Deployment{
+		ID:            "dep-with-res",
+		Status:        types.ContainerStatusStopped,
+		OriginatorID:  nodeID,
+		ReservationID: "12345",
+	}
+
+	fin := newMockFinalizer(1)
+	cm.reconcileEscrowsOnStartup(context.Background(), fin)
+
+	if !waitFor(t, func() bool { return fin.callCount() == 1 }) {
+		t.Fatalf("expected FinalizeJob called once, got %d", fin.callCount())
+	}
+	// The persisted reservation ID must have been rehydrated for the right job.
+	wantJob := payment.JobIDFromString("dep-with-res")
+	fin.mu.Lock()
+	got, ok := fin.registered[wantJob]
+	fin.mu.Unlock()
+	if !ok {
+		t.Fatal("expected RegisterExternalReservation to be called for the orphan")
+	}
+	if got.Cmp(big.NewInt(12345)) != 0 {
+		t.Fatalf("rehydrated reservation = %s, want 12345", got)
+	}
+}
+
+// TestReconcileEscrowsOnStartup_RealEscrowEndToEnd drives the reconciler through
+// a REAL *payment.PaymentService (mock mode) — not a finalizer mock that
+// bypasses the reservation cache. It reproduces the crash-recovery sequence:
+// create escrow, persist the on-chain reservation ID, clear the in-memory cache
+// (simulating a restart), then reconcile. The reconciler must rehydrate the
+// cache from the persisted ID and finalize successfully.
+func TestReconcileEscrowsOnStartup_RealEscrowEndToEnd(t *testing.T) {
+	svc, err := payment.NewPaymentService(&payment.PaymentServiceConfig{MockMode: true})
+	if err != nil {
+		t.Fatalf("new mock payment service: %v", err)
+	}
+
+	ctx := context.Background()
+	const depID = "dep-e2e"
+	jobID := payment.JobIDFromString(depID)
+
+	// Create the escrow as the deploy path would, then read back + persist the
+	// assigned reservation ID.
+	if err := svc.CreateJobEscrow(ctx, jobID, common.Address{}, big.NewInt(1_000_000), time.Hour); err != nil {
+		t.Fatalf("create escrow: %v", err)
+	}
+	resID, ok := svc.ReservationIDForJob(jobID)
+	if !ok {
+		t.Fatal("expected a reservation ID after CreateJobEscrow")
+	}
+
+	nodeID := nodeIDFrom(0x09)
+	cm := newReconcileCM(t, nodeID)
+	cm.deployments[depID] = &Deployment{
+		ID:            depID,
+		Status:        types.ContainerStatusStopped,
+		OriginatorID:  nodeID,
+		ReservationID: resID.String(), // persisted at create time, survives restart
+	}
+
+	// Simulate a daemon restart: the in-memory jobID->reservationID cache is gone.
+	svc.InvalidateEscrowReservation(jobID)
+	if _, stillCached := svc.ReservationIDForJob(jobID); stillCached {
+		t.Fatal("precondition: cache should be empty after simulated restart")
+	}
+
+	// Wrap the real service so we can confirm rehydration ran via the real path.
+	spy := &reservationSpy{PaymentService: svc}
+	cm.reconcileEscrowsOnStartup(ctx, spy)
+
+	if !waitFor(t, func() bool {
+		cm.mu.RLock()
+		defer cm.mu.RUnlock()
+		return cm.deployments[depID].EscrowFinalized
+	}) {
+		t.Fatal("expected EscrowFinalized=true after real end-to-end reconcile")
+	}
+	// The cache was rehydrated through the real EscrowContract.
+	if spy.registerCount() != 1 {
+		t.Fatalf("expected exactly one RegisterExternalReservation, got %d", spy.registerCount())
+	}
+}
+
+// reservationSpy embeds a real *payment.PaymentService and counts
+// RegisterExternalReservation calls while delegating to the real path.
+type reservationSpy struct {
+	*payment.PaymentService
+	mu        sync.Mutex
+	registers int
+}
+
+func (s *reservationSpy) RegisterExternalReservation(jobID [32]byte, reservationID *big.Int) {
+	s.mu.Lock()
+	s.registers++
+	s.mu.Unlock()
+	s.PaymentService.RegisterExternalReservation(jobID, reservationID)
+}
+
+func (s *reservationSpy) registerCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.registers
+}

--- a/internal/payment/contracts.go
+++ b/internal/payment/contracts.go
@@ -962,6 +962,20 @@ const EscrowContractABI = `[
 		],
 		"name": "FeeSplitUpdated",
 		"type": "event"
+	},
+	{
+		"inputs": [{"name": "reservationId", "type": "uint256"}],
+		"name": "InvalidReservation",
+		"type": "error"
+	},
+	{
+		"inputs": [
+			{"name": "reservationId", "type": "uint256"},
+			{"name": "expected", "type": "uint8"},
+			{"name": "actual", "type": "uint8"}
+		],
+		"name": "InvalidStatus",
+		"type": "error"
 	}
 ]`
 
@@ -1205,6 +1219,53 @@ func (s EscrowState) String() string {
 	}
 }
 
+// EscrowEventKind discriminates the on-chain escrow lifecycle event carried by
+// an EscrowEvent. The EventWatcher emits one EscrowEvent per matching log so a
+// single consumer can react to the full reservation lifecycle.
+type EscrowEventKind uint8
+
+const (
+	// EscrowEventCreated is a ReservationCreated event.
+	EscrowEventCreated EscrowEventKind = iota
+	// EscrowEventPaymentReleased is a PaymentReleased event.
+	EscrowEventPaymentReleased
+	// EscrowEventRefunded is a Refunded event.
+	EscrowEventRefunded
+	// EscrowEventFinalized is a ReservationFinalized event.
+	EscrowEventFinalized
+)
+
+// String returns a human-readable label for the event kind.
+func (k EscrowEventKind) String() string {
+	switch k {
+	case EscrowEventCreated:
+		return "created"
+	case EscrowEventPaymentReleased:
+		return "payment_released"
+	case EscrowEventRefunded:
+		return "refunded"
+	case EscrowEventFinalized:
+		return "finalized"
+	default:
+		return "unknown"
+	}
+}
+
+// EscrowEvent is a discriminated union over the four escrow lifecycle events
+// (ReservationCreated, PaymentReleased, Refunded, ReservationFinalized). The
+// Kind field selects which fields are populated:
+//   - Created:         ReservationID, Requester, Amount
+//   - PaymentReleased: ReservationID, Amount (grossAmount)
+//   - Refunded:        ReservationID, Requester, Amount (refundAmount)
+//   - Finalized:       ReservationID
+type EscrowEvent struct {
+	Kind          EscrowEventKind
+	ReservationID *big.Int
+	Amount        *big.Int
+	Requester     common.Address
+	Timestamp     time.Time
+}
+
 // DisputeState represents the state of a dispute
 type DisputeState uint8
 
@@ -1264,9 +1325,9 @@ const DelegationContractABI = `[
 		"outputs": [
 			{"name": "", "type": "tuple", "components": [
 				{"name": "provider", "type": "address"},
-				{"name": "amount", "type": "uint256"},
-				{"name": "rewardDebt", "type": "uint256"},
-				{"name": "delegatedAt", "type": "uint48"}
+				{"name": "amount", "type": "uint128"},
+				{"name": "delegatedAt", "type": "uint48"},
+				{"name": "active", "type": "bool"}
 			]}
 		],
 		"stateMutability": "view",
@@ -1814,11 +1875,16 @@ func (t ReputationTier) String() string {
 }
 
 // DelegationData represents a delegation record from BunkerDelegation.
+//
+// Mirrors the on-chain DelegationInfo struct
+// {address provider; uint128 amount; uint48 delegatedAt; bool active}.
+// There is no rewardDebt field in V1; reward accounting is added alongside
+// the abigen migration (ABIGEN-01).
 type DelegationData struct {
 	Provider    common.Address
 	Amount      *big.Int
-	RewardDebt  *big.Int
 	DelegatedAt time.Time
+	Active      bool
 }
 
 // ProviderDelegationConfigData represents a provider's delegation configuration.

--- a/internal/payment/delegation_contract.go
+++ b/internal/payment/delegation_contract.go
@@ -108,8 +108,8 @@ func (dc *DelegationContract) mockDelegate(_ context.Context, provider common.Ad
 	dc.mockDelegations[delegator] = &DelegationData{
 		Provider:    provider,
 		Amount:      new(big.Int).Set(amount),
-		RewardDebt:  big.NewInt(0),
 		DelegatedAt: time.Now(),
+		Active:      true,
 	}
 
 	total, exists := dc.mockTotalDelegated[provider]
@@ -211,6 +211,38 @@ func (dc *DelegationContract) mockCompleteUndelegate(_ context.Context, index *b
 	return nil, nil
 }
 
+// delegationInfoTuple is the canonical Go shape that go-ethereum unpacks the
+// getDelegation() return tuple into. It must match the on-chain DelegationInfo
+// struct field-for-field, in declaration order:
+//
+//	struct DelegationInfo { address provider; uint128 amount; uint48 delegatedAt; bool active; }
+//
+// go-ethereum decodes uint128/uint48 into *big.Int. Field names (capitalized)
+// map to ABI component names by case-insensitive match. Keeping this as a named
+// type (rather than an inline anonymous struct) makes the decode path stable and
+// grep-able, and is the seam the abigen migration (ABIGEN-01) will replace.
+//
+// TODO(ABIGEN-01): replace with abigen-generated binding.
+type delegationInfoTuple struct {
+	Provider    common.Address
+	Amount      *big.Int
+	DelegatedAt *big.Int
+	Active      bool
+}
+
+// providerConfigTuple is the canonical Go shape getProviderConfig() unpacks
+// into, matching the Go-side ABI tuple declared in DelegationContractABI.
+// rewardCutEffectiveAt is uint48 on-chain and decodes as *big.Int (seconds).
+//
+// TODO(ABIGEN-01): replace with abigen-generated binding.
+type providerConfigTuple struct {
+	RewardCutBps         uint16
+	FeeShareBps          uint16
+	AcceptDelegations    bool
+	PendingRewardCutBps  uint16
+	RewardCutEffectiveAt *big.Int
+}
+
 // GetDelegation returns the delegation data for a delegator.
 func (dc *DelegationContract) GetDelegation(ctx context.Context, delegator common.Address) (*DelegationData, error) {
 	if dc.mockMode {
@@ -218,37 +250,41 @@ func (dc *DelegationContract) GetDelegation(ctx context.Context, delegator commo
 		defer dc.mockMu.RUnlock()
 		del, exists := dc.mockDelegations[delegator]
 		if !exists {
-			return &DelegationData{Amount: big.NewInt(0), RewardDebt: big.NewInt(0)}, nil
+			return &DelegationData{Amount: big.NewInt(0)}, nil
 		}
 		return &DelegationData{
 			Provider:    del.Provider,
 			Amount:      new(big.Int).Set(del.Amount),
-			RewardDebt:  new(big.Int).Set(del.RewardDebt),
 			DelegatedAt: del.DelegatedAt,
+			Active:      del.Active,
 		}, nil
 	}
 
-	var result []interface{}
-	err := dc.contract.Call(&bind.CallOpts{Context: ctx}, &result, "getDelegation", delegator)
-	if err != nil {
+	// go-ethereum decodes a single tuple return by mapping the output argument
+	// positionally onto the fields of the destination struct. The tuple is
+	// therefore the single field of an outer wrapper, decoded via
+	// UnpackIntoInterface (the bind.Call res[0] path). Asserting on the raw
+	// []interface{} fails because the runtime tuple type is a reflect.StructOf
+	// (with json tags) that is not identical to any named Go type — that
+	// mismatch is exactly the silent-zero bug this PR fixes.
+	var out struct {
+		Info delegationInfoTuple
+	}
+	result := []interface{}{&out}
+	if err := dc.contract.Call(&bind.CallOpts{Context: ctx}, &result, "getDelegation", delegator); err != nil {
 		return nil, fmt.Errorf("failed to get delegation: %w", err)
 	}
 
-	data := &DelegationData{Amount: big.NewInt(0), RewardDebt: big.NewInt(0)}
-	if len(result) > 0 {
-		if res, ok := result[0].(struct {
-			Provider    common.Address
-			Amount      *big.Int
-			RewardDebt  *big.Int
-			DelegatedAt *big.Int
-		}); ok {
-			data.Provider = res.Provider
-			data.Amount = res.Amount
-			data.RewardDebt = res.RewardDebt
-			if res.DelegatedAt != nil {
-				data.DelegatedAt = time.Unix(res.DelegatedAt.Int64(), 0)
-			}
-		}
+	data := &DelegationData{
+		Provider: out.Info.Provider,
+		Amount:   big.NewInt(0),
+		Active:   out.Info.Active,
+	}
+	if out.Info.Amount != nil {
+		data.Amount = out.Info.Amount
+	}
+	if out.Info.DelegatedAt != nil {
+		data.DelegatedAt = time.Unix(out.Info.DelegatedAt.Int64(), 0)
 	}
 	return data, nil
 }
@@ -274,29 +310,26 @@ func (dc *DelegationContract) GetProviderConfig(ctx context.Context, provider co
 		}, nil
 	}
 
-	var result []interface{}
-	err := dc.contract.Call(&bind.CallOpts{Context: ctx}, &result, "getProviderConfig", provider)
-	if err != nil {
+	// Same single-tuple-output decode pattern as GetDelegation: the tuple is the
+	// single field of an outer wrapper, mapped positionally via the bind.Call
+	// res[0] UnpackIntoInterface path (a raw []interface{} assertion would
+	// silently fail because the runtime tuple type is a reflect.StructOf).
+	var out struct {
+		Config providerConfigTuple
+	}
+	result := []interface{}{&out}
+	if err := dc.contract.Call(&bind.CallOpts{Context: ctx}, &result, "getProviderConfig", provider); err != nil {
 		return nil, fmt.Errorf("failed to get provider config: %w", err)
 	}
 
-	data := &ProviderDelegationConfigData{}
-	if len(result) > 0 {
-		if res, ok := result[0].(struct {
-			RewardCutBps         uint16
-			FeeShareBps          uint16
-			AcceptDelegations    bool
-			PendingRewardCutBps  uint16
-			RewardCutEffectiveAt *big.Int
-		}); ok {
-			data.RewardCutBps = res.RewardCutBps
-			data.FeeShareBps = res.FeeShareBps
-			data.AcceptDelegations = res.AcceptDelegations
-			data.PendingRewardCutBps = res.PendingRewardCutBps
-			if res.RewardCutEffectiveAt != nil {
-				data.RewardCutEffectiveAt = time.Unix(res.RewardCutEffectiveAt.Int64(), 0)
-			}
-		}
+	data := &ProviderDelegationConfigData{
+		RewardCutBps:        out.Config.RewardCutBps,
+		FeeShareBps:         out.Config.FeeShareBps,
+		AcceptDelegations:   out.Config.AcceptDelegations,
+		PendingRewardCutBps: out.Config.PendingRewardCutBps,
+	}
+	if out.Config.RewardCutEffectiveAt != nil {
+		data.RewardCutEffectiveAt = time.Unix(out.Config.RewardCutEffectiveAt.Int64(), 0)
 	}
 	return data, nil
 }

--- a/internal/payment/escrow_contract.go
+++ b/internal/payment/escrow_contract.go
@@ -100,10 +100,15 @@ func NewEscrowContract(baseClient *BaseClient, tokenContract *TokenContract, con
 	return ec, nil
 }
 
-// NewMockEscrowContract creates a mock escrow contract for testing
+// NewMockEscrowContract creates a mock escrow contract for testing.
+// The contract ABI is parsed so event topic lookups (used by the event
+// watcher) resolve even in mock mode; the parse error is ignored because the
+// ABI is a compile-time constant exercised by the contracts ABI tests.
 func NewMockEscrowContract() *EscrowContract {
+	parsedABI, _ := abi.JSON(strings.NewReader(EscrowContractABI))
 	return &EscrowContract{
-		mockMode:       true,
+		mockMode:         true,
+		contractABI:      parsedABI,
 		reservationIDs:   make(map[[32]byte]*big.Int),
 		reservationTimes: make(map[[32]byte]time.Time),
 		mockEscrows:      make(map[[32]byte]*EscrowData),
@@ -140,6 +145,20 @@ func (ec *EscrowContract) StoreExternalReservationID(jobID [32]byte, resID *big.
 	ec.storeReservationID(jobID, resID)
 }
 
+// ReservationIDForJob returns the on-chain reservation ID currently mapped to
+// jobID, or (nil, false) if none is cached. Used by the deploy path to persist
+// the reservation ID onto the Deployment record so it survives a daemon restart
+// (the in-memory cache does not).
+func (ec *EscrowContract) ReservationIDForJob(jobID [32]byte) (*big.Int, bool) {
+	ec.reservationMu.RLock()
+	defer ec.reservationMu.RUnlock()
+	resID, exists := ec.reservationIDs[jobID]
+	if !exists || resID == nil {
+		return nil, false
+	}
+	return new(big.Int).Set(resID), true
+}
+
 // removeReservationID removes the jobID→reservationID mapping when the escrow
 // reaches a terminal state (finalized, refunded) to prevent unbounded growth.
 func (ec *EscrowContract) removeReservationID(jobID [32]byte) {
@@ -147,6 +166,32 @@ func (ec *EscrowContract) removeReservationID(jobID [32]byte) {
 	defer ec.reservationMu.Unlock()
 	delete(ec.reservationIDs, jobID)
 	delete(ec.reservationTimes, jobID)
+}
+
+// InvalidateReservation removes the jobID→reservationID mapping under the lock.
+// Exposed so the daemon's escrow-event consumer can drop a stale reservation
+// when a Refunded/Finalized event arrives, without reaching into the unexported
+// cache directly.
+func (ec *EscrowContract) InvalidateReservation(jobID [32]byte) {
+	ec.removeReservationID(jobID)
+}
+
+// JobIDForReservationID reverse-resolves a job ID from an on-chain reservation
+// ID. The cache is keyed by jobID, so this scans for the matching value. Returns
+// the jobID and true if found. Used by the event consumer, which only receives
+// the reservationID in escrow lifecycle events.
+func (ec *EscrowContract) JobIDForReservationID(resID *big.Int) ([32]byte, bool) {
+	if resID == nil {
+		return [32]byte{}, false
+	}
+	ec.reservationMu.RLock()
+	defer ec.reservationMu.RUnlock()
+	for jobID, stored := range ec.reservationIDs {
+		if stored != nil && stored.Cmp(resID) == 0 {
+			return jobID, true
+		}
+	}
+	return [32]byte{}, false
 }
 
 // CleanupStaleReservations removes reservation mappings older than maxAge.

--- a/internal/payment/escrow_errors.go
+++ b/internal/payment/escrow_errors.go
@@ -1,0 +1,153 @@
+package payment
+
+import (
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// escrowABIOnce lazily parses the escrow ABI once for custom-error decoding.
+var (
+	escrowABIOnce   sync.Once
+	escrowABIParsed abi.ABI
+	escrowABIErr    error
+)
+
+func escrowABI() (abi.ABI, error) {
+	escrowABIOnce.Do(func() {
+		escrowABIParsed, escrowABIErr = abi.JSON(strings.NewReader(EscrowContractABI))
+	})
+	return escrowABIParsed, escrowABIErr
+}
+
+// IsAlreadyTerminalEscrowErr reports whether a finalize/refund error indicates
+// the on-chain reservation has ALREADY reached a terminal state (Completed,
+// Refunded, or Disputed) — i.e. re-finalizing is a confirmed no-op and the
+// orphan reconciler may mark the deployment done.
+//
+// It is intentionally precise. The only terminal signal the BunkerEscrow
+// contract emits for a finalize/refund against a terminal reservation is the
+// custom error InvalidStatus(reservationId, expected, actual) where `actual`
+// is one of the terminal Status values. This function prefers decoding that
+// typed custom-error data (via rpc.DataError) over any substring matching.
+//
+// Crucially it does NOT match ambiguous transient strings. In particular an
+// error like "reservation not yet finalizable" — which contains the substring
+// "finalized" — must be treated as TRANSIENT (return false) so a live escrow is
+// never abandoned by the reconciler.
+func IsAlreadyTerminalEscrowErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// 1) Preferred path: typed custom-error data. go-ethereum surfaces a revert
+	//    during gas estimation / eth_call as an rpc.DataError carrying the ABI-
+	//    encoded custom-error bytes. Decode and inspect the actual status.
+	if data, ok := extractRevertData(err); ok {
+		if terminal, decoded := isTerminalStatusRevert(data); decoded {
+			return terminal
+		}
+	}
+
+	// 2) Narrow string fallback for nodes/providers that only relay the decoded
+	//    revert reason as a message. Match ONLY the precise, unambiguous terminal
+	//    phrasings — never the bare "finalized"/"not active"/"invalid state"
+	//    catch-alls, which collide with transient messages like
+	//    "reservation not yet finalizable".
+	msg := strings.ToLower(err.Error())
+	for _, precise := range []string{
+		"reservation already finalized",
+		"reservation already completed",
+		"reservation already refunded",
+		"already finalized",
+		"invalidstatus", // raw custom-error name some nodes echo verbatim
+	} {
+		if strings.Contains(msg, precise) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractRevertData pulls the raw ABI-encoded revert/custom-error bytes from an
+// error if it implements rpc.DataError. The ErrorData() value is typically a
+// 0x-prefixed hex string.
+func extractRevertData(err error) ([]byte, bool) {
+	var de rpc.DataError
+	if !errors.As(err, &de) {
+		return nil, false
+	}
+	raw := de.ErrorData()
+	switch v := raw.(type) {
+	case string:
+		b, decErr := hexutil.Decode(v)
+		if decErr != nil || len(b) < 4 {
+			return nil, false
+		}
+		return b, true
+	case []byte:
+		if len(v) < 4 {
+			return nil, false
+		}
+		return v, true
+	default:
+		return nil, false
+	}
+}
+
+// isTerminalStatusRevert decodes ABI-encoded custom-error data against the
+// escrow ABI. It returns (terminal, true) when the data decodes to an
+// InvalidStatus error whose actual status is terminal (Completed/Refunded/
+// Disputed). The second return is false when the data is not a recognizable
+// escrow custom error (caller should fall through to string matching).
+func isTerminalStatusRevert(data []byte) (terminal bool, decoded bool) {
+	parsed, err := escrowABI()
+	if err != nil || len(data) < 4 {
+		return false, false
+	}
+	var selector [4]byte
+	copy(selector[:], data[:4])
+
+	abiErr, err := parsed.ErrorByID(selector)
+	if err != nil {
+		return false, false
+	}
+
+	switch abiErr.Name {
+	case "InvalidStatus":
+		vals, uErr := abiErr.Unpack(data)
+		if uErr != nil {
+			return false, false
+		}
+		args, ok := vals.([]interface{})
+		// InvalidStatus(reservationId uint256, expected uint8, actual uint8)
+		if !ok || len(args) != 3 {
+			// Decoded as InvalidStatus but shape unexpected: it IS a status
+			// revert, but we cannot read `actual`. Be conservative — treat as
+			// transient (do not abandon the escrow).
+			return false, true
+		}
+		actual, ok := args[2].(uint8)
+		if !ok {
+			return false, true
+		}
+		switch EscrowState(actual) {
+		case EscrowStateCompleted, EscrowStateRefunded, EscrowStateDisputed:
+			return true, true
+		default:
+			// e.g. actual == Created: the reservation exists but is NOT yet
+			// finalizable. Transient from the reconciler's perspective.
+			return false, true
+		}
+	case "InvalidReservation":
+		// Reservation does not exist on-chain (never created or wrong ID).
+		// Not "already finalized"; leave it for retry/operator inspection.
+		return false, true
+	default:
+		return false, false
+	}
+}

--- a/internal/payment/escrow_errors_test.go
+++ b/internal/payment/escrow_errors_test.go
@@ -1,0 +1,194 @@
+package payment
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// newRealEscrowForTest builds a non-mock EscrowContract with initialized caches
+// but no base client. This exercises the REAL getReservationID gate (the code
+// path that the orphan reconciler depends on) without needing a live chain.
+func newRealEscrowForTest() *EscrowContract {
+	return &EscrowContract{
+		mockMode: false,
+		// A zero-value base client (no private key) lets calls that pass the
+		// reservation gate fail cleanly with "no private key configured" instead
+		// of nil-dereferencing.
+		baseClient:       &BaseClient{},
+		reservationIDs:   make(map[[32]byte]*big.Int),
+		reservationTimes: make(map[[32]byte]time.Time),
+	}
+}
+
+// TestFinalizeEscrow_NoReservationIDAfterRestart documents the HIGH-1 bug: with
+// an empty in-memory cache (the state after a daemon restart), the REAL escrow
+// contract's FinalizeEscrow cannot resolve a reservation ID and fails before
+// ever touching the chain. This is the failure the persisted Deployment
+// .ReservationID + reconciler rehydration fixes.
+func TestFinalizeEscrow_NoReservationIDAfterRestart(t *testing.T) {
+	ec := newRealEscrowForTest()
+	jobID := JobIDFromString("dep-orphan")
+
+	_, err := ec.FinalizeEscrow(context.Background(), jobID)
+	if err == nil {
+		t.Fatal("expected finalize to fail with empty reservation cache")
+	}
+	if !strings.Contains(err.Error(), "no reservation ID found") {
+		t.Fatalf("expected 'no reservation ID found', got %v", err)
+	}
+}
+
+// TestReservationIDForJob_RoundTrip verifies the getter used by the deploy path
+// to persist the reservation ID, and that rehydration via
+// StoreExternalReservationID restores it after a simulated restart.
+func TestReservationIDForJob_RoundTrip(t *testing.T) {
+	ec := newRealEscrowForTest()
+	jobID := JobIDFromString("dep-1")
+
+	if _, ok := ec.ReservationIDForJob(jobID); ok {
+		t.Fatal("expected no reservation before store")
+	}
+
+	want := big.NewInt(4242)
+	ec.StoreExternalReservationID(jobID, want)
+
+	got, ok := ec.ReservationIDForJob(jobID)
+	if !ok {
+		t.Fatal("expected reservation after store")
+	}
+	if got.Cmp(want) != 0 {
+		t.Fatalf("reservation = %s, want %s", got, want)
+	}
+
+	// Simulate restart: fresh contract, empty cache.
+	restarted := newRealEscrowForTest()
+	if _, ok := restarted.ReservationIDForJob(jobID); ok {
+		t.Fatal("fresh contract must start with empty cache")
+	}
+	// Rehydrate from the persisted decimal string.
+	rehydrated := new(big.Int)
+	rehydrated.SetString(got.String(), 10)
+	restarted.StoreExternalReservationID(jobID, rehydrated)
+
+	if back, ok := restarted.ReservationIDForJob(jobID); !ok || back.Cmp(want) != 0 {
+		t.Fatalf("rehydrated reservation = %v ok=%v, want %s", back, ok, want)
+	}
+	// And FinalizeEscrow no longer trips the "no reservation ID" guard (it now
+	// proceeds past getReservationID; the nil baseClient causes a later, distinct
+	// failure — which proves the reservation gate is satisfied).
+	if _, err := restarted.FinalizeEscrow(context.Background(), jobID); err != nil {
+		if strings.Contains(err.Error(), "no reservation ID found") {
+			t.Fatalf("reservation gate should be satisfied after rehydration, got %v", err)
+		}
+	}
+}
+
+// --- HIGH-2: IsAlreadyTerminalEscrowErr precision ---
+
+func TestIsAlreadyTerminalEscrowErr_NilAndTransient(t *testing.T) {
+	if IsAlreadyTerminalEscrowErr(nil) {
+		t.Error("nil error must not be terminal")
+	}
+
+	// The headline regression: a message containing the substring "finalized"
+	// but meaning the OPPOSITE must be treated as TRANSIENT.
+	transient := []string{
+		"execution reverted: reservation not yet finalizable",
+		"dial tcp: connection refused",
+		"context deadline exceeded",
+		"reservation not active yet",    // collides with old "not active" catch-all
+		"invalid state transition wait", // collides with old "invalid state" catch-all
+		"escrow not yet finalized, retry later",
+	}
+	for _, m := range transient {
+		if IsAlreadyTerminalEscrowErr(errors.New(m)) {
+			t.Errorf("error %q must be treated as TRANSIENT (not terminal)", m)
+		}
+	}
+}
+
+func TestIsAlreadyTerminalEscrowErr_PreciseStrings(t *testing.T) {
+	terminal := []string{
+		"execution reverted: reservation already finalized",
+		"reservation already completed",
+		"reservation already refunded",
+		"execution reverted: InvalidStatus(5, 2, 3)",
+	}
+	for _, m := range terminal {
+		if !IsAlreadyTerminalEscrowErr(errors.New(m)) {
+			t.Errorf("error %q must be treated as terminal", m)
+		}
+	}
+}
+
+// dataErr is a test rpc.DataError carrying ABI-encoded custom-error bytes.
+type dataErr struct {
+	msg  string
+	data string
+}
+
+func (d *dataErr) Error() string          { return d.msg }
+func (d *dataErr) ErrorCode() int         { return 3 } // execution reverted
+func (d *dataErr) ErrorData() interface{} { return d.data }
+
+// packInvalidStatus ABI-encodes InvalidStatus(reservationId, expected, actual).
+func packInvalidStatus(t *testing.T, reservationID int64, expected, actual uint8) string {
+	t.Helper()
+	parsed, err := abi.JSON(strings.NewReader(EscrowContractABI))
+	if err != nil {
+		t.Fatalf("parse ABI: %v", err)
+	}
+	abiErr, ok := parsed.Errors["InvalidStatus"]
+	if !ok {
+		t.Fatal("InvalidStatus not in ABI")
+	}
+	args, err := abiErr.Inputs.Pack(big.NewInt(reservationID), expected, actual)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	out := append(abiErr.ID.Bytes()[:4], args...)
+	return "0x" + hexEncode(out)
+}
+
+func hexEncode(b []byte) string {
+	const hexchars = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, c := range b {
+		out[i*2] = hexchars[c>>4]
+		out[i*2+1] = hexchars[c&0x0f]
+	}
+	return string(out)
+}
+
+func TestIsAlreadyTerminalEscrowErr_TypedCustomError(t *testing.T) {
+	// expected=Active(2). actual values per Status enum:
+	// None=0, Created=1, Active=2, Completed=3, Refunded=4, Disputed=5.
+	cases := []struct {
+		name   string
+		actual uint8
+		want   bool
+	}{
+		{"completed-is-terminal", uint8(EscrowStateCompleted), true},
+		{"refunded-is-terminal", uint8(EscrowStateRefunded), true},
+		{"disputed-is-terminal", uint8(EscrowStateDisputed), true},
+		{"created-is-transient", uint8(EscrowStateCreated), false},
+		{"none-is-transient", uint8(EscrowStateNone), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			de := &dataErr{
+				msg:  "execution reverted",
+				data: packInvalidStatus(t, 7, uint8(EscrowStateActive), tc.actual),
+			}
+			if got := IsAlreadyTerminalEscrowErr(de); got != tc.want {
+				t.Errorf("actual=%d: got terminal=%v, want %v", tc.actual, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/payment/event_watcher.go
+++ b/internal/payment/event_watcher.go
@@ -22,8 +22,11 @@ const (
 )
 
 // EventWatcher manages WebSocket event subscriptions with automatic reconnection.
-// It watches for Staked/Unstaked, EscrowCreated, and Slashed events and forwards
-// them to consumer channels for cache invalidation and state sync.
+// It watches for Staked/Unstaked, the four escrow lifecycle events
+// (ReservationCreated, PaymentReleased, Refunded, ReservationFinalized), and
+// Slashed events, forwarding them to consumer channels for cache invalidation
+// and state sync. All four escrow events share the single escrowEvents channel
+// and are distinguished by EscrowEvent.Kind.
 type EventWatcher struct {
 	baseClient       *BaseClient
 	stakingContract  *StakingContract
@@ -31,7 +34,7 @@ type EventWatcher struct {
 	slashingContract *SlashingContract
 
 	stakeEvents  chan *StakeEvent
-	escrowEvents chan *EscrowCreatedEvent
+	escrowEvents chan *EscrowEvent
 	slashEvents  chan *SlashEvent
 
 	lastBlock atomic.Uint64
@@ -53,7 +56,7 @@ func NewEventWatcher(
 		escrowContract:   ec,
 		slashingContract: slc,
 		stakeEvents:      make(chan *StakeEvent, eventChannelBuffer),
-		escrowEvents:     make(chan *EscrowCreatedEvent, eventChannelBuffer),
+		escrowEvents:     make(chan *EscrowEvent, eventChannelBuffer),
 		slashEvents:      make(chan *SlashEvent, eventChannelBuffer),
 	}
 }
@@ -84,15 +87,29 @@ func (ew *EventWatcher) Start(ctx context.Context) error {
 	ctx, ew.cancel = context.WithCancel(ctx)
 	ew.running.Store(true)
 
-	// Launch one goroutine per event type
-	ew.wg.Add(3)
+	// Launch one goroutine per event subscription. The four escrow lifecycle
+	// events each get their own subscription (matching the stake/slash pattern)
+	// but all feed the single escrowEvents channel.
+	ew.wg.Add(6)
 	util.SafeGoWithName("event-watcher-stake", func() {
 		defer ew.wg.Done()
 		ew.watchStakeEvents(ctx)
 	})
-	util.SafeGoWithName("event-watcher-escrow", func() {
+	util.SafeGoWithName("event-watcher-escrow-created", func() {
 		defer ew.wg.Done()
-		ew.watchEscrowEvents(ctx)
+		ew.watchEscrowCreatedEvents(ctx)
+	})
+	util.SafeGoWithName("event-watcher-payment-released", func() {
+		defer ew.wg.Done()
+		ew.watchPaymentReleasedEvents(ctx)
+	})
+	util.SafeGoWithName("event-watcher-refunded", func() {
+		defer ew.wg.Done()
+		ew.watchRefundedEvents(ctx)
+	})
+	util.SafeGoWithName("event-watcher-finalized", func() {
+		defer ew.wg.Done()
+		ew.watchReservationFinalizedEvents(ctx)
 	})
 	util.SafeGoWithName("event-watcher-slash", func() {
 		defer ew.wg.Done()
@@ -128,8 +145,10 @@ func (ew *EventWatcher) StakeEvents() <-chan *StakeEvent {
 	return ew.stakeEvents
 }
 
-// EscrowEvents returns the channel for receiving escrow events.
-func (ew *EventWatcher) EscrowEvents() <-chan *EscrowCreatedEvent {
+// EscrowEvents returns the channel for receiving all escrow lifecycle events.
+// Consumers switch on EscrowEvent.Kind to handle Created/PaymentReleased/
+// Refunded/Finalized.
+func (ew *EventWatcher) EscrowEvents() <-chan *EscrowEvent {
 	return ew.escrowEvents
 }
 
@@ -170,11 +189,32 @@ func (ew *EventWatcher) watchStakeEvents(ctx context.Context) {
 	})
 }
 
-// watchEscrowEvents subscribes to ReservationCreated events with reconnection.
-func (ew *EventWatcher) watchEscrowEvents(ctx context.Context) {
-	ev, ok := ew.escrowContract.contractABI.Events["ReservationCreated"]
+// emitEscrowEvent forwards an escrow event to the shared channel, dropping it
+// (with a warning) if the consumer is too slow and the buffer is full.
+func (ew *EventWatcher) emitEscrowEvent(ev *EscrowEvent) {
+	select {
+	case ew.escrowEvents <- ev:
+	default:
+		logging.Warn("event watcher: escrow event channel full, dropping",
+			"kind", ev.Kind.String())
+	}
+}
+
+// watchSingleEvent resolves the topic ID for the named escrow event, builds a
+// filter query for the escrow contract, and subscribes with reconnection. The
+// handler is invoked for each matching log and is responsible for parsing and
+// emitting an EscrowEvent of the given kind. Centralizes the repetitive
+// topic-lookup + query-build + subscribe wiring shared by the four escrow
+// watchers.
+func (ew *EventWatcher) watchSingleEvent(
+	ctx context.Context,
+	name string,
+	kind EscrowEventKind,
+	handler func(ethtypes.Log) *EscrowEvent,
+) {
+	ev, ok := ew.escrowContract.contractABI.Events[name]
 	if !ok {
-		logging.Warn("event watcher: ReservationCreated event not found in ABI")
+		logging.Warn("event watcher: escrow event not found in ABI", "event", name)
 		return
 	}
 
@@ -183,22 +223,95 @@ func (ew *EventWatcher) watchEscrowEvents(ctx context.Context) {
 		Topics:    [][]common.Hash{{ev.ID}},
 	}
 
-	ew.subscribeWithReconnect(ctx, "escrow", query, func(log ethtypes.Log) {
-		event := &EscrowCreatedEvent{
-			Timestamp: time.Now(),
-		}
-		if len(log.Topics) > 1 {
-			event.Requester = common.HexToAddress(log.Topics[1].Hex())
-		}
-		if len(log.Data) >= 32 {
-			event.Amount = new(big.Int).SetBytes(log.Data[:32])
-		}
-		select {
-		case ew.escrowEvents <- event:
-		default:
-			logging.Warn("event watcher: escrow event channel full, dropping")
+	ew.subscribeWithReconnect(ctx, "escrow-"+kind.String(), query, func(log ethtypes.Log) {
+		if out := handler(log); out != nil {
+			ew.emitEscrowEvent(out)
 		}
 	})
+}
+
+// watchEscrowCreatedEvents subscribes to ReservationCreated events.
+func (ew *EventWatcher) watchEscrowCreatedEvents(ctx context.Context) {
+	ew.watchSingleEvent(ctx, "ReservationCreated", EscrowEventCreated, parseEscrowCreatedLog)
+}
+
+// watchPaymentReleasedEvents subscribes to PaymentReleased events.
+func (ew *EventWatcher) watchPaymentReleasedEvents(ctx context.Context) {
+	ew.watchSingleEvent(ctx, "PaymentReleased", EscrowEventPaymentReleased, parsePaymentReleasedLog)
+}
+
+// watchRefundedEvents subscribes to Refunded events.
+func (ew *EventWatcher) watchRefundedEvents(ctx context.Context) {
+	ew.watchSingleEvent(ctx, "Refunded", EscrowEventRefunded, parseRefundedLog)
+}
+
+// watchReservationFinalizedEvents subscribes to ReservationFinalized events.
+func (ew *EventWatcher) watchReservationFinalizedEvents(ctx context.Context) {
+	ew.watchSingleEvent(ctx, "ReservationFinalized", EscrowEventFinalized, parseReservationFinalizedLog)
+}
+
+// The four parse functions below own the topic-position → field mapping for the
+// escrow lifecycle events. They are package-level (not closures) so the mapping
+// can be locked by unit tests against synthetic logs. Each event's indexed
+// topics occupy log.Topics[1..] (Topics[0] is the event signature); non-indexed
+// fields are packed into 32-byte words in log.Data.
+
+// parseEscrowCreatedLog maps a ReservationCreated log:
+// ReservationCreated(uint256 indexed reservationId, address indexed requester,
+// uint256 amount, uint256 duration). amount is the first data word.
+func parseEscrowCreatedLog(log ethtypes.Log) *EscrowEvent {
+	event := &EscrowEvent{Kind: EscrowEventCreated, Timestamp: time.Now()}
+	if len(log.Topics) > 1 {
+		event.ReservationID = new(big.Int).SetBytes(log.Topics[1].Bytes())
+	}
+	if len(log.Topics) > 2 {
+		event.Requester = common.HexToAddress(log.Topics[2].Hex())
+	}
+	if len(log.Data) >= 32 {
+		event.Amount = new(big.Int).SetBytes(log.Data[:32])
+	}
+	return event
+}
+
+// parsePaymentReleasedLog maps a PaymentReleased log:
+// PaymentReleased(uint256 indexed reservationId, uint256 grossAmount, ...).
+// grossAmount is the first non-indexed data word.
+func parsePaymentReleasedLog(log ethtypes.Log) *EscrowEvent {
+	event := &EscrowEvent{Kind: EscrowEventPaymentReleased, Timestamp: time.Now()}
+	if len(log.Topics) > 1 {
+		event.ReservationID = new(big.Int).SetBytes(log.Topics[1].Bytes())
+	}
+	if len(log.Data) >= 32 {
+		event.Amount = new(big.Int).SetBytes(log.Data[:32])
+	}
+	return event
+}
+
+// parseRefundedLog maps a Refunded log:
+// Refunded(uint256 indexed reservationId, address indexed requester,
+// uint256 refundAmount). refundAmount is the first (only) non-indexed word.
+func parseRefundedLog(log ethtypes.Log) *EscrowEvent {
+	event := &EscrowEvent{Kind: EscrowEventRefunded, Timestamp: time.Now()}
+	if len(log.Topics) > 1 {
+		event.ReservationID = new(big.Int).SetBytes(log.Topics[1].Bytes())
+	}
+	if len(log.Topics) > 2 {
+		event.Requester = common.HexToAddress(log.Topics[2].Hex())
+	}
+	if len(log.Data) >= 32 {
+		event.Amount = new(big.Int).SetBytes(log.Data[:32])
+	}
+	return event
+}
+
+// parseReservationFinalizedLog maps a ReservationFinalized log:
+// ReservationFinalized(uint256 indexed reservationId). No data words.
+func parseReservationFinalizedLog(log ethtypes.Log) *EscrowEvent {
+	event := &EscrowEvent{Kind: EscrowEventFinalized, Timestamp: time.Now()}
+	if len(log.Topics) > 1 {
+		event.ReservationID = new(big.Int).SetBytes(log.Topics[1].Bytes())
+	}
+	return event
 }
 
 // watchSlashEvents subscribes to Slashed events with reconnection.

--- a/internal/payment/event_watcher_test.go
+++ b/internal/payment/event_watcher_test.go
@@ -2,8 +2,14 @@ package payment
 
 import (
 	"context"
+	"math/big"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 func TestEventWatcher_NewAndChannels(t *testing.T) {
@@ -84,6 +90,217 @@ func TestEventWatcher_SleepOrDone(t *testing.T) {
 	if !result {
 		t.Error("expected true for short sleep")
 	}
+}
+
+func TestEscrowEventKinds(t *testing.T) {
+	ew := NewEventWatcher(nil, nil, nil, nil)
+
+	// EscrowEvents must be a receive channel of the discriminated union type.
+	var ch <-chan *EscrowEvent = ew.EscrowEvents()
+	if ch == nil {
+		t.Fatal("expected non-nil escrow event channel")
+	}
+
+	// All four kinds must stringify distinctly (guards the const block).
+	kinds := map[EscrowEventKind]string{
+		EscrowEventCreated:         "created",
+		EscrowEventPaymentReleased: "payment_released",
+		EscrowEventRefunded:        "refunded",
+		EscrowEventFinalized:       "finalized",
+	}
+	seen := make(map[string]bool)
+	for k, want := range kinds {
+		if got := k.String(); got != want {
+			t.Errorf("kind %d: want %q, got %q", k, want, got)
+		}
+		if seen[want] {
+			t.Errorf("duplicate kind string %q", want)
+		}
+		seen[want] = true
+	}
+}
+
+func TestWatchEscrowAllTopics(t *testing.T) {
+	// A mock escrow contract parses the real ABI, so all four escrow event
+	// topic IDs must be resolvable. Confirm each is present in the ABI and that
+	// the four watcher entry points run without panicking against a cancelled
+	// context (they short-circuit because there is no WS client).
+	ec := NewMockEscrowContract()
+	for _, name := range []string{
+		"ReservationCreated",
+		"PaymentReleased",
+		"Refunded",
+		"ReservationFinalized",
+	} {
+		ev, ok := ec.contractABI.Events[name]
+		if !ok {
+			t.Fatalf("escrow ABI missing event %q", name)
+		}
+		if ev.ID == [32]byte{} {
+			t.Errorf("event %q has zero topic ID", name)
+		}
+	}
+
+	ew := NewEventWatcher(nil, nil, ec, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // make subscribeWithReconnect return immediately
+
+	// None of these should panic; with a nil base client + cancelled context
+	// they return promptly.
+	ew.watchEscrowCreatedEvents(ctx)
+	ew.watchPaymentReleasedEvents(ctx)
+	ew.watchRefundedEvents(ctx)
+	ew.watchReservationFinalizedEvents(ctx)
+}
+
+// uint256Topic encodes a uint256 as a 32-byte indexed topic.
+func uint256Topic(v int64) common.Hash {
+	return common.BigToHash(big.NewInt(v))
+}
+
+// addressTopic encodes an address as a 32-byte indexed topic (left-padded).
+func addressTopic(a common.Address) common.Hash {
+	return common.BytesToHash(a.Bytes())
+}
+
+// nonIndexedData ABI-packs the non-indexed inputs of the named escrow event.
+func nonIndexedData(t *testing.T, escrowABI abi.ABI, eventName string, vals ...interface{}) []byte {
+	t.Helper()
+	ev, ok := escrowABI.Events[eventName]
+	if !ok {
+		t.Fatalf("event %q not in ABI", eventName)
+	}
+	var nonIndexed abi.Arguments
+	for _, in := range ev.Inputs {
+		if !in.Indexed {
+			nonIndexed = append(nonIndexed, in)
+		}
+	}
+	data, err := nonIndexed.Pack(vals...)
+	if err != nil {
+		t.Fatalf("pack %s data: %v", eventName, err)
+	}
+	return data
+}
+
+// TestParseEscrowEventLogs (LOW-1) packs a representative log for each of the
+// four escrow events — with realistic indexed topics and ABI-encoded data
+// words — and asserts the parsed EscrowEvent fields. This locks the
+// topic-position → field mapping so a future ABI/handler edit that shifts a
+// topic index is caught.
+func TestParseEscrowEventLogs(t *testing.T) {
+	escrowABI, err := abi.JSON(strings.NewReader(EscrowContractABI))
+	if err != nil {
+		t.Fatalf("parse escrow ABI: %v", err)
+	}
+
+	requester := common.HexToAddress("0x00000000000000000000000000000000000000aB")
+
+	t.Run("ReservationCreated", func(t *testing.T) {
+		// indexed: reservationId(1), requester(2); data: amount, duration.
+		log := ethtypes.Log{
+			Topics: []common.Hash{
+				escrowABI.Events["ReservationCreated"].ID,
+				uint256Topic(101),
+				addressTopic(requester),
+			},
+			Data: nonIndexedData(t, escrowABI, "ReservationCreated", big.NewInt(5000), big.NewInt(3600)),
+		}
+		ev := parseEscrowCreatedLog(log)
+		if ev.Kind != EscrowEventCreated {
+			t.Errorf("kind = %v, want Created", ev.Kind)
+		}
+		if ev.ReservationID == nil || ev.ReservationID.Int64() != 101 {
+			t.Errorf("reservationID = %v, want 101", ev.ReservationID)
+		}
+		if ev.Requester != requester {
+			t.Errorf("requester = %s, want %s", ev.Requester, requester)
+		}
+		if ev.Amount == nil || ev.Amount.Int64() != 5000 {
+			t.Errorf("amount = %v, want 5000", ev.Amount)
+		}
+	})
+
+	t.Run("PaymentReleased", func(t *testing.T) {
+		// indexed: reservationId(1); data: grossAmount(first word), ...
+		log := ethtypes.Log{
+			Topics: []common.Hash{
+				escrowABI.Events["PaymentReleased"].ID,
+				uint256Topic(202),
+			},
+			Data: nonIndexedData(t, escrowABI, "PaymentReleased",
+				big.NewInt(9000), // grossAmount
+				big.NewInt(8000), // netToProviders
+				big.NewInt(1000), // protocolFee
+				big.NewInt(400),  // burnedAmount
+				big.NewInt(600),  // treasuryAmount
+			),
+		}
+		ev := parsePaymentReleasedLog(log)
+		if ev.Kind != EscrowEventPaymentReleased {
+			t.Errorf("kind = %v, want PaymentReleased", ev.Kind)
+		}
+		if ev.ReservationID == nil || ev.ReservationID.Int64() != 202 {
+			t.Errorf("reservationID = %v, want 202", ev.ReservationID)
+		}
+		// Amount must be the FIRST data word (grossAmount), not a later one.
+		if ev.Amount == nil || ev.Amount.Int64() != 9000 {
+			t.Errorf("amount = %v, want 9000 (grossAmount)", ev.Amount)
+		}
+		// PaymentReleased has no indexed requester.
+		if ev.Requester != (common.Address{}) {
+			t.Errorf("requester should be zero for PaymentReleased, got %s", ev.Requester)
+		}
+	})
+
+	t.Run("Refunded", func(t *testing.T) {
+		// indexed: reservationId(1), requester(2); data: refundAmount.
+		log := ethtypes.Log{
+			Topics: []common.Hash{
+				escrowABI.Events["Refunded"].ID,
+				uint256Topic(303),
+				addressTopic(requester),
+			},
+			Data: nonIndexedData(t, escrowABI, "Refunded", big.NewInt(7777)),
+		}
+		ev := parseRefundedLog(log)
+		if ev.Kind != EscrowEventRefunded {
+			t.Errorf("kind = %v, want Refunded", ev.Kind)
+		}
+		if ev.ReservationID == nil || ev.ReservationID.Int64() != 303 {
+			t.Errorf("reservationID = %v, want 303", ev.ReservationID)
+		}
+		if ev.Requester != requester {
+			t.Errorf("requester = %s, want %s", ev.Requester, requester)
+		}
+		if ev.Amount == nil || ev.Amount.Int64() != 7777 {
+			t.Errorf("amount = %v, want 7777 (refundAmount)", ev.Amount)
+		}
+	})
+
+	t.Run("ReservationFinalized", func(t *testing.T) {
+		// indexed: reservationId(1); no data words.
+		log := ethtypes.Log{
+			Topics: []common.Hash{
+				escrowABI.Events["ReservationFinalized"].ID,
+				uint256Topic(404),
+			},
+		}
+		ev := parseReservationFinalizedLog(log)
+		if ev.Kind != EscrowEventFinalized {
+			t.Errorf("kind = %v, want Finalized", ev.Kind)
+		}
+		if ev.ReservationID == nil || ev.ReservationID.Int64() != 404 {
+			t.Errorf("reservationID = %v, want 404", ev.ReservationID)
+		}
+		// No data => Amount stays nil; no requester topic => zero.
+		if ev.Amount != nil {
+			t.Errorf("amount should be nil for Finalized, got %v", ev.Amount)
+		}
+		if ev.Requester != (common.Address{}) {
+			t.Errorf("requester should be zero for Finalized, got %s", ev.Requester)
+		}
+	})
 }
 
 func TestEventWatcher_StartStopWithMockContracts(t *testing.T) {

--- a/internal/payment/metering_test.go
+++ b/internal/payment/metering_test.go
@@ -1,0 +1,130 @@
+package payment
+
+import (
+	"math/big"
+	"testing"
+)
+
+const (
+	oneMB = int64(1024 * 1024)
+	oneGB = int64(1024 * 1024 * 1024)
+)
+
+func newTestMeter() *ServiceMeter {
+	return NewServiceMeter(DefaultServicePricing())
+}
+
+// TestServiceMeterStorageRoundTrip records a 1GB upload and asserts the monthly
+// bill is non-zero and matches the configured per-GB-month rate.
+func TestServiceMeterStorageRoundTrip(t *testing.T) {
+	m := newTestMeter()
+	const wallet = "0xabc"
+
+	m.RecordStorageUpload(wallet, oneGB)
+
+	bill := m.CalculateStorageBill(wallet)
+	if bill.Sign() <= 0 {
+		t.Fatalf("expected non-zero storage bill, got %s", bill)
+	}
+	// 1 GB exactly => one unit of StoragePerGBMonth.
+	if bill.Cmp(DefaultServicePricing().StoragePerGBMonth) != 0 {
+		t.Errorf("expected bill %s for 1GB, got %s",
+			DefaultServicePricing().StoragePerGBMonth, bill)
+	}
+
+	// A delete returns usage (and therefore the bill) to zero.
+	m.RecordStorageDelete(wallet, oneGB)
+	if got := m.CalculateStorageBill(wallet); got.Sign() != 0 {
+		t.Errorf("expected zero bill after delete, got %s", got)
+	}
+}
+
+// TestServiceMeterProxyCost records a proxy session and asserts the cost scales
+// with total bytes transferred.
+func TestServiceMeterProxyCost(t *testing.T) {
+	m := newTestMeter()
+	const wallet = "0xdef"
+
+	in := int64(100) * oneMB
+	out := int64(200) * oneMB
+	m.RecordProxySession(wallet, in, out)
+
+	usage := m.GetUsage(wallet)
+	if usage == nil {
+		t.Fatal("expected usage recorded for proxy session")
+	}
+	if usage.ProxyBytesIn != in || usage.ProxyBytesOut != out || usage.ProxySessions != 1 {
+		t.Errorf("usage mismatch: in=%d out=%d sessions=%d",
+			usage.ProxyBytesIn, usage.ProxyBytesOut, usage.ProxySessions)
+	}
+
+	cost := m.CalculateProxyCost(in, out)
+	if cost.Sign() <= 0 {
+		t.Fatalf("expected non-zero proxy cost, got %s", cost)
+	}
+	// Cost must be proportional: double the bytes => (approximately) double the cost.
+	doubleCost := m.CalculateProxyCost(in*2, out*2)
+	want := new(big.Int).Mul(cost, big.NewInt(2))
+	if doubleCost.Cmp(want) != 0 {
+		t.Errorf("proxy cost not proportional: cost=%s doubleCost=%s want=%s",
+			cost, doubleCost, want)
+	}
+}
+
+// TestServiceMeterCrawlCost verifies the crawl cost accounts for both per-page
+// and per-MB-of-result components.
+func TestServiceMeterCrawlCost(t *testing.T) {
+	m := newTestMeter()
+	const wallet = "0x123"
+
+	pages := int64(50)
+	resultBytes := int64(5) * oneMB
+	m.RecordCrawlJob(wallet, pages, resultBytes)
+
+	usage := m.GetUsage(wallet)
+	if usage == nil || usage.CrawlJobs != 1 || usage.CrawlPages != pages {
+		t.Fatalf("crawl usage not recorded correctly: %+v", usage)
+	}
+
+	pricing := DefaultServicePricing()
+	pageComponent := new(big.Int).Mul(pricing.CrawlPerPage, big.NewInt(pages))
+	mbComponent := new(big.Int).Mul(pricing.CrawlPerMBResult, big.NewInt(5))
+	wantTotal := new(big.Int).Add(pageComponent, mbComponent)
+
+	cost := m.CalculateCrawlCost(pages, resultBytes)
+	if cost.Cmp(wantTotal) != 0 {
+		t.Errorf("crawl cost: want %s (pages %s + mb %s), got %s",
+			wantTotal, pageComponent, mbComponent, cost)
+	}
+	// Both components must contribute (cost strictly greater than either alone).
+	if cost.Cmp(pageComponent) <= 0 {
+		t.Error("crawl cost must exceed the per-page component alone")
+	}
+}
+
+// TestServiceMeterAgentInvocation verifies agent cost = base invocation + per-1K-token rate.
+func TestServiceMeterAgentInvocation(t *testing.T) {
+	m := newTestMeter()
+	const wallet = "0x456"
+
+	m.RecordAgentInvocation(wallet, 1000)
+
+	usage := m.GetUsage(wallet)
+	if usage == nil || usage.AgentInvocations != 1 || usage.AgentTokensUsed != 1000 {
+		t.Fatalf("agent usage not recorded correctly: %+v", usage)
+	}
+
+	pricing := DefaultServicePricing()
+	// 1000 tokens => exactly 1 * per-1K-token rate, plus the base invocation.
+	want := new(big.Int).Add(pricing.AgentPerInvocation, pricing.AgentPer1KTokens)
+	cost := m.CalculateAgentCost(1000)
+	if cost.Cmp(want) != 0 {
+		t.Errorf("agent cost: want base+1K rate %s, got %s", want, cost)
+	}
+
+	// Zero tokens => just the base invocation cost.
+	base := m.CalculateAgentCost(0)
+	if base.Cmp(pricing.AgentPerInvocation) != 0 {
+		t.Errorf("agent base cost: want %s, got %s", pricing.AgentPerInvocation, base)
+	}
+}

--- a/internal/payment/payment_abi_test.go
+++ b/internal/payment/payment_abi_test.go
@@ -1,0 +1,172 @@
+package payment
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestDelegationABIRoundTrip pins the getDelegation output tuple shape at ABI
+// parse time so a future edit that reintroduces the phantom rewardDebt field or
+// the wrong integer width is caught immediately (regression guard for the
+// silent-zero decode bug).
+func TestDelegationABIRoundTrip(t *testing.T) {
+	parsed, err := abi.JSON(strings.NewReader(DelegationContractABI))
+	if err != nil {
+		t.Fatalf("parse delegation ABI: %v", err)
+	}
+
+	method, ok := parsed.Methods["getDelegation"]
+	if !ok {
+		t.Fatal("getDelegation method missing from ABI")
+	}
+	if len(method.Outputs) != 1 {
+		t.Fatalf("expected 1 output (the tuple), got %d", len(method.Outputs))
+	}
+
+	tuple := method.Outputs[0].Type
+	if tuple.T != abi.TupleTy {
+		t.Fatalf("expected tuple output, got %v", tuple.T)
+	}
+
+	// Exactly four components, in declaration order, with the correct types.
+	wantNames := []string{"provider", "amount", "delegatedAt", "active"}
+	if len(tuple.TupleElems) != len(wantNames) {
+		t.Fatalf("expected %d tuple components, got %d (%v)",
+			len(wantNames), len(tuple.TupleElems), tuple.TupleRawNames)
+	}
+	for i, want := range wantNames {
+		if tuple.TupleRawNames[i] != want {
+			t.Errorf("component %d: want name %q, got %q", i, want, tuple.TupleRawNames[i])
+		}
+	}
+
+	// Assert no rewardDebt component lingers anywhere in the tuple.
+	for _, n := range tuple.TupleRawNames {
+		if n == "rewardDebt" {
+			t.Fatal("phantom rewardDebt component must not exist in getDelegation tuple")
+		}
+	}
+
+	// Type assertions: provider=address, amount=uint128, delegatedAt=uint48, active=bool.
+	if got := tuple.TupleElems[0].String(); got != "address" {
+		t.Errorf("provider type: want address, got %s", got)
+	}
+	if got := tuple.TupleElems[1].String(); got != "uint128" {
+		t.Errorf("amount type: want uint128, got %s", got)
+	}
+	if got := tuple.TupleElems[2].String(); got != "uint48" {
+		t.Errorf("delegatedAt type: want uint48, got %s", got)
+	}
+	if got := tuple.TupleElems[3].String(); got != "bool" {
+		t.Errorf("active type: want bool, got %s", got)
+	}
+}
+
+// TestDelegationDecodeSilentZero_Regression encodes a DelegationInfo tuple with
+// the corrected ABI and decodes it the same way production does — via
+// UnpackIntoInterface into the canonical delegationInfoTuple — proving the
+// decode succeeds and active=true is preserved (the old mismatched ABI silently
+// returned zero values, so active was always false).
+func TestDelegationDecodeSilentZero_Regression(t *testing.T) {
+	parsed, err := abi.JSON(strings.NewReader(DelegationContractABI))
+	if err != nil {
+		t.Fatalf("parse delegation ABI: %v", err)
+	}
+	args := parsed.Methods["getDelegation"].Outputs
+
+	provider := common.HexToAddress("0x00000000000000000000000000000000000000aB")
+	amount := big.NewInt(1000)
+	delegatedAt := big.NewInt(1718000000)
+
+	packed, err := args.Pack(delegationInfoTuple{
+		Provider:    provider,
+		Amount:      amount,
+		DelegatedAt: delegatedAt,
+		Active:      true,
+	})
+	if err != nil {
+		t.Fatalf("pack tuple: %v", err)
+	}
+
+	// Decode exactly as GetDelegation does: tuple is the single field of an
+	// outer wrapper, mapped positionally by UnpackIntoInterface.
+	var out struct {
+		Info delegationInfoTuple
+	}
+	if err := parsed.UnpackIntoInterface(&out, "getDelegation", packed); err != nil {
+		t.Fatalf("UnpackIntoInterface: %v", err)
+	}
+	res := out.Info
+	if res.Provider != provider {
+		t.Errorf("provider: want %s, got %s", provider.Hex(), res.Provider.Hex())
+	}
+	if res.Amount == nil || res.Amount.Cmp(amount) != 0 {
+		t.Errorf("amount: want %s, got %v", amount, res.Amount)
+	}
+	if res.DelegatedAt == nil || res.DelegatedAt.Cmp(delegatedAt) != 0 {
+		t.Errorf("delegatedAt: want %s, got %v", delegatedAt, res.DelegatedAt)
+	}
+	if !res.Active {
+		t.Error("active: want true (the bug always returned false)")
+	}
+}
+
+// TestGetProviderConfigDecode encodes a ProviderDelegationConfig tuple in the
+// Go-side ABI's declared shape and verifies all five components decode via the
+// same UnpackIntoInterface path the contract client uses.
+func TestGetProviderConfigDecode(t *testing.T) {
+	parsed, err := abi.JSON(strings.NewReader(DelegationContractABI))
+	if err != nil {
+		t.Fatalf("parse delegation ABI: %v", err)
+	}
+	method, ok := parsed.Methods["getProviderConfig"]
+	if !ok {
+		t.Fatal("getProviderConfig method missing from ABI")
+	}
+	args := method.Outputs
+	tuple := args[0].Type
+	if tuple.T != abi.TupleTy {
+		t.Fatalf("expected tuple output, got %v", tuple.T)
+	}
+	if len(tuple.TupleElems) != 5 {
+		t.Fatalf("expected 5 tuple components, got %d", len(tuple.TupleElems))
+	}
+
+	packed, err := args.Pack(providerConfigTuple{
+		RewardCutBps:         1000,
+		FeeShareBps:          250,
+		AcceptDelegations:    true,
+		PendingRewardCutBps:  1500,
+		RewardCutEffectiveAt: big.NewInt(1718000000),
+	})
+	if err != nil {
+		t.Fatalf("pack config tuple: %v", err)
+	}
+
+	var out struct {
+		Config providerConfigTuple
+	}
+	if err := parsed.UnpackIntoInterface(&out, "getProviderConfig", packed); err != nil {
+		t.Fatalf("UnpackIntoInterface: %v", err)
+	}
+	res := out.Config
+	if res.RewardCutBps != 1000 {
+		t.Errorf("rewardCutBps: want 1000, got %d", res.RewardCutBps)
+	}
+	if res.FeeShareBps != 250 {
+		t.Errorf("feeShareBps: want 250, got %d", res.FeeShareBps)
+	}
+	if !res.AcceptDelegations {
+		t.Error("acceptDelegations: want true")
+	}
+	if res.PendingRewardCutBps != 1500 {
+		t.Errorf("pendingRewardCutBps: want 1500, got %d", res.PendingRewardCutBps)
+	}
+	if res.RewardCutEffectiveAt == nil || res.RewardCutEffectiveAt.Cmp(big.NewInt(1718000000)) != 0 {
+		t.Errorf("rewardCutEffectiveAt: want 1718000000, got %v", res.RewardCutEffectiveAt)
+	}
+}

--- a/internal/payment/service.go
+++ b/internal/payment/service.go
@@ -365,6 +365,14 @@ func (ps *PaymentService) RegisterExternalReservation(jobID [32]byte, reservatio
 	ps.escrowContract.StoreExternalReservationID(jobID, reservationID)
 }
 
+// ReservationIDForJob returns the on-chain reservation ID mapped to jobID and a
+// bool indicating whether one is cached. The deploy path uses this immediately
+// after CreateJobEscrow to persist the reservation ID onto the Deployment so
+// the startup reconciler can rehydrate the cache after a restart.
+func (ps *PaymentService) ReservationIDForJob(jobID [32]byte) (*big.Int, bool) {
+	return ps.escrowContract.ReservationIDForJob(jobID)
+}
+
 // ReleaseJobPayment releases payment for a job based on uptime
 func (ps *PaymentService) ReleaseJobPayment(ctx context.Context, jobID [32]byte, uptime time.Duration) error {
 	uptimeSecs := big.NewInt(int64(uptime.Seconds()))
@@ -690,9 +698,19 @@ func (ps *PaymentService) SubscribeStakeEvents(ctx context.Context, ch chan<- *S
 	return ps.stakingContract.SubscribeStakeEvents(ctx, ch)
 }
 
-// SubscribeEscrowEvents subscribes to escrow events
-func (ps *PaymentService) SubscribeEscrowEvents(ctx context.Context, ch chan<- *EscrowCreatedEvent) error {
-	return ps.escrowContract.SubscribeEscrowEvents(ctx, ch)
+// InvalidateEscrowReservation drops the local jobID→reservationID cache entry
+// for a job. Used by the daemon's escrow-event consumer when a Refunded or
+// ReservationFinalized event arrives so a redeploy with the same jobID does not
+// reuse a stale on-chain reservation.
+func (ps *PaymentService) InvalidateEscrowReservation(jobID [32]byte) {
+	ps.escrowContract.InvalidateReservation(jobID)
+}
+
+// JobIDForReservationID reverse-resolves a job ID from an on-chain reservation
+// ID using the escrow contract's cache. Escrow lifecycle events only carry the
+// reservation ID, so the consumer maps it back to the jobID before invalidating.
+func (ps *PaymentService) JobIDForReservationID(resID *big.Int) ([32]byte, bool) {
+	return ps.escrowContract.JobIDForReservationID(resID)
 }
 
 // SubscribeSlashEvents subscribes to slashing events

--- a/internal/payment/service_metering.go
+++ b/internal/payment/service_metering.go
@@ -6,6 +6,34 @@ import (
 	"time"
 )
 
+// StorageMeteringHook is the metering contract the storage engine depends on.
+// PaymentService satisfies it structurally via its RecordStorageUpload /
+// RecordStorageDelete methods. Defining it here (and mirroring it in the
+// storage package) lets storage call metering without importing payment,
+// avoiding an import cycle.
+type StorageMeteringHook interface {
+	RecordStorageUpload(wallet string, bytes int64)
+	RecordStorageDelete(wallet string, bytes int64)
+}
+
+// ProxyMeteringHook is the metering contract the proxy server depends on.
+// PaymentService satisfies it structurally via RecordProxySession.
+type ProxyMeteringHook interface {
+	RecordProxySession(wallet string, bytesIn, bytesOut int64)
+}
+
+// CrawlMeteringHook is the metering contract the crawl scheduler depends on.
+// PaymentService satisfies it structurally via RecordCrawlJob.
+type CrawlMeteringHook interface {
+	RecordCrawlJob(wallet string, pagesCrawled, resultBytes int64)
+}
+
+// AgentMeteringHook is the metering contract the agent REST handler depends on.
+// PaymentService satisfies it structurally via RecordAgentInvocation.
+type AgentMeteringHook interface {
+	RecordAgentInvocation(wallet string, tokensUsed int64)
+}
+
 // ServiceType identifies which P0 service generated usage.
 type ServiceType string
 

--- a/internal/proxy/http_proxy.go
+++ b/internal/proxy/http_proxy.go
@@ -18,6 +18,7 @@ type HTTPProxyServer struct {
 	auth    Authenticator
 	tracker *SessionTracker
 	acl     *ACL
+	meter   ProxyMeteringHook // optional, set by Server.Start (nil = no metering)
 	server  *http.Server
 
 	ctx    context.Context
@@ -164,6 +165,11 @@ func (p *HTTPProxyServer) handleConnect(w http.ResponseWriter, r *http.Request, 
 
 	session.BytesIn = meter.BytesRead()
 	session.BytesOut = meter.BytesWritten()
+
+	// Record session usage for billing (optional, nil-safe).
+	if p.meter != nil {
+		p.meter.RecordProxySession(session.Wallet, session.BytesIn, session.BytesOut)
+	}
 }
 
 // Hop-by-hop headers that should not be forwarded.
@@ -223,6 +229,15 @@ func (p *HTTPProxyServer) handleForward(w http.ResponseWriter, r *http.Request, 
 	outReq := r.Clone(p.ctx)
 	outReq.RequestURI = ""
 
+	// Count request-body (upload) bytes as they are read by the transport so
+	// BytesIn reflects uploads. Without this, uploads are under-billed (only the
+	// response body was counted as BytesOut). nil body (e.g. GET) is left as-is.
+	var bodyCounter *countingReadCloser
+	if outReq.Body != nil {
+		bodyCounter = &countingReadCloser{rc: outReq.Body}
+		outReq.Body = bodyCounter
+	}
+
 	// Remove hop-by-hop headers
 	for _, h := range hopByHopHeaders {
 		outReq.Header.Del(h)
@@ -259,4 +274,33 @@ func (p *HTTPProxyServer) handleForward(w http.ResponseWriter, r *http.Request, 
 	w.WriteHeader(resp.StatusCode)
 	bytesWritten, _ := io.Copy(w, resp.Body)
 	session.BytesOut = bytesWritten
+
+	// Record uploaded request-body bytes (read by the transport above).
+	if bodyCounter != nil {
+		session.BytesIn = bodyCounter.count()
+	}
+
+	// Record session usage for billing (optional, nil-safe).
+	if p.meter != nil {
+		p.meter.RecordProxySession(session.Wallet, session.BytesIn, session.BytesOut)
+	}
 }
+
+// countingReadCloser wraps an io.ReadCloser and tallies bytes read. Used to
+// meter HTTP forward-proxy request-body (upload) bytes for billing. count() is
+// safe to call from the same goroutine after RoundTrip returns; the transport
+// fully consumes (or aborts) the body before RoundTrip returns.
+type countingReadCloser struct {
+	rc io.ReadCloser
+	n  int64
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.rc.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error { return c.rc.Close() }
+
+func (c *countingReadCloser) count() int64 { return c.n }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -575,6 +575,90 @@ func TestHTTPProxy_Forward(t *testing.T) {
 	}
 }
 
+// capturingMeter records the last RecordProxySession call for assertions.
+type capturingMeter struct {
+	mu       sync.Mutex
+	calls    int
+	wallet   string
+	bytesIn  int64
+	bytesOut int64
+}
+
+func (m *capturingMeter) RecordProxySession(wallet string, bytesIn, bytesOut int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	m.wallet = wallet
+	m.bytesIn = bytesIn
+	m.bytesOut = bytesOut
+}
+
+func (m *capturingMeter) snapshot() (int, int64, int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls, m.bytesIn, m.bytesOut
+}
+
+// TestHTTPProxy_Forward_CountsUploadBytes (LOW-2) asserts that the request-body
+// (upload) bytes are counted into BytesIn for billing, not just the response's
+// BytesOut. Before the fix, BytesIn stayed zero on uploads (under-billing).
+func TestHTTPProxy_Forward_CountsUploadBytes(t *testing.T) {
+	// Target echoes nothing; it just drains the body and returns a small reply.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer target.Close()
+
+	auth := &AllowAllAuth{DefaultWallet: "w-upload"}
+	tracker := NewSessionTracker(10)
+	proxy := NewHTTPProxyServer(&DirectDialer{}, auth, tracker, nil)
+	meter := &capturingMeter{}
+	proxy.meter = meter // in-package: inject the metering hook directly
+
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	proxyConn, err := net.Dial("tcp", strings.TrimPrefix(proxyServer.URL, "http://"))
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer proxyConn.Close()
+	_ = proxyConn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	body := strings.Repeat("A", 1234) // known upload size
+	forwardReq := fmt.Sprintf(
+		"POST %s/upload HTTP/1.1\r\nHost: %s\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+		target.URL, strings.TrimPrefix(target.URL, "http://"), len(body), body)
+	if _, err := proxyConn.Write([]byte(forwardReq)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	// Drain the response so the handler completes and records the session.
+	_, _ = io.Copy(io.Discard, proxyConn)
+
+	// Poll for the metering call (handler runs in the proxy server goroutine).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if calls, _, _ := meter.snapshot(); calls > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	calls, bytesIn, bytesOut := meter.snapshot()
+	if calls == 0 {
+		t.Fatal("expected RecordProxySession to be called")
+	}
+	if bytesIn != int64(len(body)) {
+		t.Errorf("BytesIn = %d, want %d (uploaded body)", bytesIn, len(body))
+	}
+	if bytesOut != 2 { // "ok"
+		t.Errorf("BytesOut = %d, want 2 (response body)", bytesOut)
+	}
+}
+
 // --- REST Handler tests ---
 
 func TestRESTHandler_Status(t *testing.T) {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -8,6 +8,17 @@ import (
 	"github.com/moltbunker/moltbunker/internal/logging"
 )
 
+// ProxyMeteringHook receives proxy session usage for billing. It is defined
+// locally (not imported from payment) so the proxy package does not depend on
+// payment, avoiding an import cycle. payment.PaymentService satisfies it
+// structurally via RecordProxySession.
+//
+// The hook is optional: when nil, the proxy behaves exactly as before (no
+// metering), so existing callers and tests need no changes.
+type ProxyMeteringHook interface {
+	RecordProxySession(wallet string, bytesIn, bytesOut int64)
+}
+
 // Server manages the proxy server lifecycle (SOCKS5 + HTTP).
 type Server struct {
 	cfg     Config
@@ -15,12 +26,21 @@ type Server struct {
 	auth    Authenticator
 	tracker *SessionTracker
 	acl     *ACL
+	meter   ProxyMeteringHook // optional session metering hook (nil = no metering)
 
 	socks5 *SOCKS5Server
 	http   *HTTPProxyServer
 
 	mu      sync.Mutex
 	running bool
+}
+
+// SetMeteringHook installs an optional proxy metering hook. Pass nil to disable.
+// Must be called before Start so the hook propagates to the SOCKS5/HTTP servers.
+func (s *Server) SetMeteringHook(h ProxyMeteringHook) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.meter = h
 }
 
 // NewServer creates a new proxy server with the given configuration.
@@ -55,6 +75,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Start SOCKS5 server
 	if s.cfg.SOCKS5Addr != "" {
 		s.socks5 = NewSOCKS5Server(s.dialer, s.auth, s.tracker, s.acl)
+		s.socks5.meter = s.meter
 		go func() {
 			if err := s.socks5.ListenAndServe(s.cfg.SOCKS5Addr); err != nil {
 				errCh <- fmt.Errorf("socks5: %w", err)
@@ -66,6 +87,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Start HTTP proxy server
 	if s.cfg.HTTPAddr != "" {
 		s.http = NewHTTPProxyServer(s.dialer, s.auth, s.tracker, s.acl)
+		s.http.meter = s.meter
 		go func() {
 			if err := s.http.ListenAndServe(s.cfg.HTTPAddr); err != nil {
 				errCh <- fmt.Errorf("http proxy: %w", err)

--- a/internal/proxy/socks5.go
+++ b/internal/proxy/socks5.go
@@ -80,6 +80,7 @@ type SOCKS5Server struct {
 	auth     Authenticator
 	tracker  *SessionTracker
 	acl      *ACL
+	meter    ProxyMeteringHook // optional, set by Server.Start (nil = no metering)
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -217,6 +218,11 @@ func (s *SOCKS5Server) handleConnection(clientConn net.Conn) {
 	// Update session with final byte counts
 	session.BytesIn = meter.BytesRead()
 	session.BytesOut = meter.BytesWritten()
+
+	// Record session usage for billing (optional, nil-safe).
+	if s.meter != nil {
+		s.meter.RecordProxySession(session.Wallet, session.BytesIn, session.BytesOut)
+	}
 }
 
 // handleGreeting processes the SOCKS5 greeting and authenticates the client.

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -16,6 +16,19 @@ import (
 	"github.com/moltbunker/moltbunker/internal/state"
 )
 
+// MeteringHook receives storage usage events for billing. It is defined locally
+// (rather than imported from the payment package) so the storage package does
+// not depend on payment, avoiding an import cycle. The payment.PaymentService
+// satisfies this interface structurally via its RecordStorageUpload /
+// RecordStorageDelete methods.
+//
+// The hook is optional: when nil, the storage engine behaves exactly as before
+// (no metering), so existing callers and tests need no changes.
+type MeteringHook interface {
+	RecordStorageUpload(wallet string, bytes int64)
+	RecordStorageDelete(wallet string, bytes int64)
+}
+
 // StorageEngine is the main orchestrator for object storage operations.
 // Phase 1: local blob storage with bbolt metadata.
 // Phase 2 adds encryption and IPFS distribution.
@@ -23,6 +36,13 @@ type StorageEngine struct {
 	dataDir  string
 	metadata *MetadataStore
 	config   EngineConfig
+	meter    MeteringHook // optional usage metering hook (nil = no metering)
+}
+
+// SetMeteringHook installs an optional metering hook. Pass nil to disable.
+// Injected at startup so storage usage is recorded for billing.
+func (e *StorageEngine) SetMeteringHook(h MeteringHook) {
+	e.meter = h
 }
 
 // EngineConfig configures the storage engine.
@@ -249,6 +269,11 @@ func (e *StorageEngine) PutObject(ctx context.Context, input *PutObjectInput) (*
 		return nil, fmt.Errorf("persist object metadata: %w", err)
 	}
 
+	// Record usage for billing (optional, nil-safe).
+	if e.meter != nil {
+		e.meter.RecordStorageUpload(input.Owner, n)
+	}
+
 	logging.Debug("object stored",
 		"bucket", input.Bucket,
 		"key", input.Key,
@@ -359,6 +384,11 @@ func (e *StorageEngine) DeleteObject(ctx context.Context, bucket, key, owner str
 	// Delete metadata
 	if err := e.metadata.DeleteObject(ctx, bucket, key); err != nil {
 		return fmt.Errorf("delete metadata: %w", err)
+	}
+
+	// Record usage for billing (optional, nil-safe).
+	if e.meter != nil {
+		e.meter.RecordStorageDelete(obj.Owner, obj.Size)
 	}
 
 	logging.Debug("object deleted",

--- a/internal/storage/engine_test.go
+++ b/internal/storage/engine_test.go
@@ -586,3 +586,110 @@ func TestBucketLimit(t *testing.T) {
 		t.Fatal("should fail when bucket limit exceeded")
 	}
 }
+
+// fakeMeter is a MeteringHook that records the calls it receives.
+type fakeMeter struct {
+	uploads []meterCall
+	deletes []meterCall
+}
+
+type meterCall struct {
+	wallet string
+	bytes  int64
+}
+
+func (f *fakeMeter) RecordStorageUpload(wallet string, bytes int64) {
+	f.uploads = append(f.uploads, meterCall{wallet, bytes})
+}
+
+func (f *fakeMeter) RecordStorageDelete(wallet string, bytes int64) {
+	f.deletes = append(f.deletes, meterCall{wallet, bytes})
+}
+
+func TestPutObject_MeterCalled(t *testing.T) {
+	ctx := context.Background()
+	e := newTestEngine(t)
+	meter := &fakeMeter{}
+	e.SetMeteringHook(meter)
+
+	if _, err := e.CreateBucket(ctx, "metered", testOwner); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	content := "metered payload"
+	if _, err := e.PutObject(ctx, &PutObjectInput{
+		Bucket: "metered",
+		Key:    "obj.txt",
+		Body:   strings.NewReader(content),
+		Owner:  testOwner,
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if len(meter.uploads) != 1 {
+		t.Fatalf("expected 1 upload metered, got %d", len(meter.uploads))
+	}
+	if meter.uploads[0].wallet != testOwner {
+		t.Errorf("upload wallet = %q, want %q", meter.uploads[0].wallet, testOwner)
+	}
+	if meter.uploads[0].bytes != int64(len(content)) {
+		t.Errorf("upload bytes = %d, want %d", meter.uploads[0].bytes, len(content))
+	}
+}
+
+func TestDeleteObject_MeterCalled(t *testing.T) {
+	ctx := context.Background()
+	e := newTestEngine(t)
+	meter := &fakeMeter{}
+	e.SetMeteringHook(meter)
+
+	if _, err := e.CreateBucket(ctx, "metered", testOwner); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	content := "to be deleted"
+	if _, err := e.PutObject(ctx, &PutObjectInput{
+		Bucket: "metered",
+		Key:    "gone.txt",
+		Body:   strings.NewReader(content),
+		Owner:  testOwner,
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if err := e.DeleteObject(ctx, "metered", "gone.txt", testOwner); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	if len(meter.deletes) != 1 {
+		t.Fatalf("expected 1 delete metered, got %d", len(meter.deletes))
+	}
+	if meter.deletes[0].wallet != testOwner {
+		t.Errorf("delete wallet = %q, want %q", meter.deletes[0].wallet, testOwner)
+	}
+	if meter.deletes[0].bytes != int64(len(content)) {
+		t.Errorf("delete bytes = %d, want %d", meter.deletes[0].bytes, len(content))
+	}
+}
+
+// TestStorageEngine_NoMeterHook verifies operations still succeed when no
+// metering hook is installed (the nil-safe path used by existing callers).
+func TestStorageEngine_NoMeterHook(t *testing.T) {
+	ctx := context.Background()
+	e := newTestEngine(t) // no SetMeteringHook
+
+	if _, err := e.CreateBucket(ctx, "plain", testOwner); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if _, err := e.PutObject(ctx, &PutObjectInput{
+		Bucket: "plain",
+		Key:    "k",
+		Body:   strings.NewReader("data"),
+		Owner:  testOwner,
+	}); err != nil {
+		t.Fatalf("put without meter: %v", err)
+	}
+	if err := e.DeleteObject(ctx, "plain", "k", testOwner); err != nil {
+		t.Fatalf("delete without meter: %v", err)
+	}
+}


### PR DESCRIPTION
## PAY-01 — Payment/escrow correctness + metering settlement

Fixes four payment-layer correctness gaps (Money-correctness milestone).

**1. Delegation ABI decoder mismatch (silent zero-decode).** The hand-typed `getDelegation` ABI tuple carried a phantom `rewardDebt`, wrong width (`uint256` vs on-chain `uint128`), and was missing `active bool` — so every `GetDelegation` decode silently returned zeros. ABI corrected to the deployed `DelegationInfo {address provider; uint128 amount; uint48 delegatedAt; bool active}`; decode uses a named tuple. (`TODO(ABIGEN-01)` marks it for generated bindings.)

**2. Escrow event watcher gap.** `watchEscrowEvents` only subscribed `ReservationCreated`; added `PaymentReleased`/`Refunded`/`ReservationFinalized` watchers (6 goroutines), widened the channel to a discriminated `EscrowEvent`, and wired a consumer in `main.go` that drives reservation-cache invalidation. Topic-position parsing extracted to named, unit-tested functions.

**3. Metering revenue leak.** `RecordStorageUpload/RecordProxySession/RecordCrawlJob/RecordAgentInvocation` had **zero callers** — every paid auxiliary service ran free. Wired nil-safe metering hooks into storage, proxy (incl. upload-byte accounting), crawl, and the agent invoke path.

**4. Escrow orphan recovery.** A crash between container-stop and `FinalizeJob` left escrows un-finalized forever (the in-memory reservation cache is lost on restart). Now persists the on-chain `ReservationID` at create time and rehydrates the cache before a startup reconcile sweep; `EscrowFinalized` is persisted to avoid re-submitting terminal txns. "Already-terminal" detection decodes the typed `InvalidStatus` custom error (only Completed/Refunded/Disputed are terminal) instead of a fragile substring match, so a live escrow is never abandoned.

**Verification:** `go build`+`vet`+linux cross-build + `gosec`(0) + `go test -race ./internal/payment/... ./internal/daemon/... ./internal/proxy/...` all green. New tests: delegation ABI decode, escrow event log-parsing, metering wiring, real-EscrowContract orphan-reconcile end-to-end, transient-vs-terminal error. Secret-scan clean.

Base: `main`. Independent of other Wave-1 PRs. ABIGEN-01 will later supersede the hand-typed delegation decode.
