### PR TITLE
SC-EDGE-01 Add BunkerEdgeRegistry stake-gated edge-provider role

### DIFF
--- a/contracts/src/BunkerEdgeRegistry.sol
+++ b/contracts/src/BunkerEdgeRegistry.sol
@@ -1,0 +1,553 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @notice Minimal read interface to BunkerStaking. Only `stakedAmount` is
+///         decoded from `getProviderInfo`; the remaining tuple fields are
+///         ignored so this contract never couples to the full ProviderInfo
+///         struct ABI. `slash` routes edge-provider penalties to the existing
+///         stake (no duplicate token custody).
+interface IBunkerStaking {
+    /// @dev Returns the full provider tuple; callers destructure only the
+    ///      leading `stakedAmount`. The trailing fields are intentionally
+    ///      decoded as their concrete types so the ABI selector matches.
+    function getProviderInfo(address provider)
+        external
+        view
+        returns (
+            uint128 stakedAmount,
+            uint128 totalUnbonding,
+            address beneficiary,
+            uint48 registeredAt,
+            bool active,
+            bytes32 nodeId,
+            bytes32 region,
+            uint64 capabilities,
+            bool frozen
+        );
+
+    /// @dev Slash a provider's stake. Requires SLASHER_ROLE on BunkerStaking,
+    ///      which must be granted to this contract during deployment setup.
+    function slash(address provider, uint256 amount) external;
+}
+
+/// @title BunkerEdgeRegistry
+/// @author Moltbunker
+/// @notice On-chain source of truth for edge-provider registration under
+///         Approach A (tiered edge nodes terminate TLS + run the L7 WAF).
+///         Edge providers must already hold a minimum BUNKER stake in the
+///         existing BunkerStaking contract, then register their static edge
+///         metadata here. They are slashing-eligible for SLA violations; the
+///         penalty is routed back to BunkerStaking.slash so it hits the same
+///         stake — no duplicate token custody.
+/// @dev Additive contract. Zero changes to BunkerStaking, BunkerRegistry, or any
+///      other deployed contract. Reuses the BunkerStaking conventions verbatim:
+///      OpenZeppelin v5 base set, SLASHER_ROLE, snapshotted appeal window
+///      (H-21/H-22 pattern), and the `slashingEnabled` monitor-mode gate.
+contract BunkerEdgeRegistry is Ownable2Step, AccessControl, ReentrancyGuard, Pausable {
+    // ──────────────────────────────────────────────
+    //  Constants
+    // ──────────────────────────────────────────────
+
+    /// @notice Contract version.
+    string public constant VERSION = "1.0.0";
+
+    /// @notice Role identifier for authorized slashers.
+    bytes32 public constant SLASHER_ROLE = keccak256("SLASHER_ROLE");
+
+    /// @notice Lower bound for minStakeForEdge (BunkerStaking Starter minimum, 1 M BUNKER).
+    uint256 public constant MIN_EDGE_STAKE_FLOOR = 1_000_000e18;
+
+    /// @notice Upper bound for minStakeForEdge (BunkerStaking Platinum minimum, 1 B BUNKER).
+    uint256 public constant MIN_EDGE_STAKE_CEILING = 1_000_000_000e18;
+
+    /// @notice Lower bound for the appeal window (12 hours).
+    uint256 public constant APPEAL_WINDOW_FLOOR = 12 hours;
+
+    /// @notice Upper bound for the appeal window (14 days).
+    uint256 public constant APPEAL_WINDOW_CEILING = 14 days;
+
+    // ──────────────────────────────────────────────
+    //  Configurable Parameters
+    // ──────────────────────────────────────────────
+
+    /// @notice Minimum BUNKER stake (in BunkerStaking) required to register as an
+    ///         edge provider. Default 50 M BUNKER — between Silver (10 M) and Gold
+    ///         (100 M) to create a meaningful edge-only capital hurdle.
+    uint256 public minStakeForEdge = 50_000_000e18;
+
+    /// @notice Appeal window for edge-slash proposals (default 48 hours).
+    uint256 public appealWindow = 48 hours;
+
+    /// @notice Whether slashing execution is enabled. When false, proposals can
+    ///         still be created (monitor mode) but execution reverts.
+    bool public slashingEnabled;
+
+    // ──────────────────────────────────────────────
+    //  Types
+    // ──────────────────────────────────────────────
+
+    /// @notice Static, on-chain edge-provider metadata. The fixed-size leading
+    ///         fields pack into two slots (32 + 32 + 6 + 1 + 1 bytes).
+    struct EdgeProviderInfo {
+        bytes32 nodeId; // SHA256 of the provider's Ed25519 public key
+        bytes32 region; // Geographic region identifier
+        uint48 registeredAt; // Block timestamp at registration
+        bool active; // Whether the provider is currently registered
+        bool frozen; // Whether the provider is frozen (emergency response)
+        string endpointURL; // Public TLS-terminating edge endpoint
+        bytes tlsPubkeyHash; // Hash of the edge node's TLS public key
+    }
+
+    /// @notice An edge-slash proposal subject to an appeal window.
+    struct EdgeSlashProposal {
+        address provider;
+        uint128 amount;
+        uint48 proposedAt;
+        bool executed;
+        bool appealed;
+        bool resolved;
+        uint256 appealWindowSnapshot; // Snapshot of appealWindow at proposal time
+        string reason;
+    }
+
+    // ──────────────────────────────────────────────
+    //  State
+    // ──────────────────────────────────────────────
+
+    /// @notice Read-only reference to the BunkerStaking contract (stake source of truth).
+    IBunkerStaking public immutable stakingContract;
+
+    /// @notice Edge-provider state by address.
+    mapping(address => EdgeProviderInfo) public edgeProviders;
+
+    /// @notice Reverse lookup from edge node ID to edge-provider address.
+    mapping(bytes32 => address) public nodeIdToEdgeProvider;
+
+    /// @notice Total number of edge-slash proposals created.
+    uint256 public slashProposalCount;
+
+    /// @notice Edge-slash proposals by ID.
+    mapping(uint256 => EdgeSlashProposal) public slashProposals;
+
+    // ──────────────────────────────────────────────
+    //  Errors
+    // ──────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InsufficientStake(uint256 actual, uint256 required);
+    error InsufficientSlashableBalance(uint256 amount, uint256 slashable);
+    error AlreadyRegistered(address provider);
+    error NotActive(address provider);
+    error NodeIdAlreadyClaimed(bytes32 nodeId);
+    error ProviderIsFrozen(address provider);
+    error SlashingNotEnabled();
+    error InvalidProposalId(uint256 proposalId);
+    error ProposalAlreadyExecuted(uint256 proposalId);
+    error AppealWindowNotElapsed(uint256 proposalId);
+    error AppealWindowElapsed(uint256 proposalId);
+    error ProposalAppealed(uint256 proposalId);
+    error ProposalNotAppealed(uint256 proposalId);
+    error ProposalAlreadyResolved(uint256 proposalId);
+    error NotProposalProvider(uint256 proposalId, address caller);
+    error InvalidMinStake(uint256 minStake);
+    error InvalidAppealWindow();
+
+    // ──────────────────────────────────────────────
+    //  Events
+    // ──────────────────────────────────────────────
+
+    /// @notice Emitted when an edge provider registers.
+    event EdgeProviderRegistered(address indexed provider, bytes32 nodeId, bytes32 region);
+
+    /// @notice Emitted when an edge provider deregisters.
+    event EdgeProviderDeregistered(address indexed provider);
+
+    /// @notice Emitted when an edge provider is frozen by the slasher.
+    event EdgeProviderFrozen(address indexed provider, address indexed by);
+
+    /// @notice Emitted when an edge provider is unfrozen by the owner.
+    event EdgeProviderUnfrozen(address indexed provider);
+
+    /// @notice Emitted when an edge provider updates its endpoint metadata.
+    event EdgeEndpointUpdated(address indexed provider, string endpointURL);
+
+    /// @notice Emitted when an edge-slash proposal is created.
+    event EdgeSlashProposed(
+        uint256 indexed proposalId, address indexed provider, uint256 amount, string reason
+    );
+
+    /// @notice Emitted when an edge-slash proposal is executed.
+    event EdgeSlashExecuted(uint256 indexed proposalId, address indexed provider, uint256 amount);
+
+    /// @notice Emitted when an edge provider appeals a slash proposal.
+    event EdgeSlashAppealed(uint256 indexed proposalId, address indexed provider);
+
+    /// @notice Emitted when an edge-slash appeal is resolved.
+    event EdgeAppealResolved(uint256 indexed proposalId, bool upheld);
+
+    /// @notice Emitted when the minimum edge stake threshold is updated.
+    event MinStakeUpdated(uint256 oldMinStake, uint256 newMinStake);
+
+    /// @notice Emitted when the appeal window is updated.
+    event AppealWindowUpdated(uint256 newWindow);
+
+    /// @notice Emitted when slashing is enabled or disabled.
+    event SlashingEnabledUpdated(bool enabled);
+
+    // ──────────────────────────────────────────────
+    //  Constructor
+    // ──────────────────────────────────────────────
+
+    /// @param _stakingContract Address of the deployed BunkerStaking contract.
+    /// @param _initialOwner Admin wallet address.
+    constructor(address _stakingContract, address _initialOwner) Ownable(_initialOwner) {
+        if (_stakingContract == address(0) || _initialOwner == address(0)) revert ZeroAddress();
+
+        stakingContract = IBunkerStaking(_stakingContract);
+
+        // Grant DEFAULT_ADMIN_ROLE to owner for managing SLASHER_ROLE.
+        _grantRole(DEFAULT_ADMIN_ROLE, _initialOwner);
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Edge-Provider Registration
+    // ──────────────────────────────────────────────
+
+    /// @notice Register as an edge provider. Requires an active BunkerStaking
+    ///         stake at least equal to `minStakeForEdge`.
+    /// @param nodeId SHA256 of the edge node's Ed25519 public key (must be unique).
+    /// @param region Geographic region identifier.
+    /// @param endpointURL Public TLS-terminating edge endpoint.
+    /// @param tlsPubkeyHash Hash of the edge node's TLS public key.
+    function registerEdgeProvider(
+        bytes32 nodeId,
+        bytes32 region,
+        string calldata endpointURL,
+        bytes calldata tlsPubkeyHash
+    ) external nonReentrant whenNotPaused {
+        EdgeProviderInfo storage info = edgeProviders[msg.sender];
+        if (info.active) revert AlreadyRegistered(msg.sender);
+        if (info.frozen) revert ProviderIsFrozen(msg.sender);
+        if (nodeId != bytes32(0) && nodeIdToEdgeProvider[nodeId] != address(0)) {
+            revert NodeIdAlreadyClaimed(nodeId);
+        }
+
+        _requireMinStake(msg.sender);
+
+        info.nodeId = nodeId;
+        info.region = region;
+        info.endpointURL = endpointURL;
+        info.tlsPubkeyHash = tlsPubkeyHash;
+        info.registeredAt = uint48(block.timestamp);
+        info.active = true;
+
+        if (nodeId != bytes32(0)) {
+            nodeIdToEdgeProvider[nodeId] = msg.sender;
+        }
+
+        emit EdgeProviderRegistered(msg.sender, nodeId, region);
+    }
+
+    /// @notice Self-deregister as an edge provider. Sets active=false, clears the
+    ///         nodeId mapping so the node ID can be re-claimed, and wipes the
+    ///         endpoint metadata so getEdgeProviderInfo never returns stale
+    ///         routing data for a deregistered provider. `frozen` is intentionally
+    ///         preserved so a frozen provider cannot escape the freeze by
+    ///         deregistering and re-registering.
+    function deregisterEdgeProvider() external nonReentrant {
+        EdgeProviderInfo storage info = edgeProviders[msg.sender];
+        if (!info.active) revert NotActive(msg.sender);
+
+        info.active = false;
+        if (info.nodeId != bytes32(0)) {
+            delete nodeIdToEdgeProvider[info.nodeId];
+            info.nodeId = bytes32(0);
+        }
+        info.region = bytes32(0);
+        delete info.endpointURL;
+        delete info.tlsPubkeyHash;
+
+        emit EdgeProviderDeregistered(msg.sender);
+    }
+
+    /// @notice Update the endpoint metadata for an active edge provider.
+    /// @param endpointURL New public edge endpoint.
+    /// @param tlsPubkeyHash New TLS public key hash.
+    function updateEndpoint(string calldata endpointURL, bytes calldata tlsPubkeyHash) external {
+        EdgeProviderInfo storage info = edgeProviders[msg.sender];
+        if (!info.active) revert NotActive(msg.sender);
+        if (info.frozen) revert ProviderIsFrozen(msg.sender);
+
+        info.endpointURL = endpointURL;
+        info.tlsPubkeyHash = tlsPubkeyHash;
+
+        emit EdgeEndpointUpdated(msg.sender, endpointURL);
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Graduated Emergency Response
+    // ──────────────────────────────────────────────
+
+    /// @notice Freeze an edge provider. A frozen provider cannot update its
+    ///         endpoint and is reported as inactive to consumers.
+    /// @param provider The edge provider to freeze.
+    function freezeEdgeProvider(address provider) external onlyRole(SLASHER_ROLE) {
+        EdgeProviderInfo storage info = edgeProviders[provider];
+        if (!info.active) revert NotActive(provider);
+
+        info.frozen = true;
+
+        emit EdgeProviderFrozen(provider, msg.sender);
+    }
+
+    /// @notice Unfreeze a previously frozen edge provider.
+    /// @param provider The edge provider to unfreeze.
+    function unfreezeEdgeProvider(address provider) external onlyOwner {
+        EdgeProviderInfo storage info = edgeProviders[provider];
+        info.frozen = false;
+
+        emit EdgeProviderUnfrozen(provider);
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Edge-Slash Proposal & Appeal System
+    // ──────────────────────────────────────────────
+
+    /// @notice Propose slashing an edge provider's stake. Subject to the appeal
+    ///         window snapshotted at proposal time.
+    /// @dev Least-privilege: the registry holds SLASHER_ROLE on BunkerStaking, so
+    ///      it must only ever propose slashes against providers it actually
+    ///      governs — i.e. registered, active edge providers. The active check
+    ///      prevents this contract from being used to slash arbitrary BunkerStaking
+    ///      stakers who never opted into the edge role. As a defensive pre-check
+    ///      (mirroring BunkerStaking.proposeSlash, H-05) the amount is also
+    ///      validated against the provider's current slashable balance
+    ///      (stakedAmount + totalUnbonding) at propose time; this is informational
+    ///      only — executeEdgeSlash relies on BunkerStaking's own re-validation at
+    ///      execution time for the binding check.
+    /// @param provider The edge provider to propose slashing.
+    /// @param amount Amount to slash (wei).
+    /// @param reason Human-readable reason for the slash.
+    /// @return proposalId The ID of the created proposal.
+    function proposeEdgeSlash(address provider, uint128 amount, string calldata reason)
+        external
+        onlyRole(SLASHER_ROLE)
+        returns (uint256 proposalId)
+    {
+        if (provider == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        if (!edgeProviders[provider].active) revert NotActive(provider);
+
+        // Defensive pre-check: reject proposals that exceed the provider's
+        // current slashable balance in BunkerStaking. Decodes stakedAmount +
+        // totalUnbonding from the existing getProviderInfo tuple (no new
+        // BunkerStaking surface coupled).
+        (uint128 stakedAmount, uint128 totalUnbonding,,,,,,,) =
+            stakingContract.getProviderInfo(provider);
+        uint256 slashable = uint256(stakedAmount) + uint256(totalUnbonding);
+        if (uint256(amount) > slashable) {
+            revert InsufficientSlashableBalance(uint256(amount), slashable);
+        }
+
+        proposalId = slashProposalCount++;
+        slashProposals[proposalId] = EdgeSlashProposal({
+            provider: provider,
+            amount: amount,
+            proposedAt: uint48(block.timestamp),
+            executed: false,
+            appealed: false,
+            resolved: false,
+            appealWindowSnapshot: appealWindow,
+            reason: reason
+        });
+
+        emit EdgeSlashProposed(proposalId, provider, amount, reason);
+    }
+
+    /// @notice Execute an edge-slash proposal after the appeal window has elapsed.
+    /// @dev Routes the slash to BunkerStaking.slash, which requires this contract
+    ///      to hold SLASHER_ROLE on BunkerStaking (granted at deployment setup).
+    /// @param proposalId The proposal to execute.
+    function executeEdgeSlash(uint256 proposalId) external onlyRole(SLASHER_ROLE) nonReentrant {
+        if (!slashingEnabled) revert SlashingNotEnabled();
+        EdgeSlashProposal storage proposal = _getValidProposal(proposalId);
+        if (proposal.executed) revert ProposalAlreadyExecuted(proposalId);
+        if (proposal.appealed) revert ProposalAppealed(proposalId);
+
+        uint256 windowEnd = uint256(proposal.proposedAt) + proposal.appealWindowSnapshot;
+        if (block.timestamp < windowEnd) revert AppealWindowNotElapsed(proposalId);
+
+        proposal.executed = true;
+
+        stakingContract.slash(proposal.provider, proposal.amount);
+
+        emit EdgeSlashExecuted(proposalId, proposal.provider, proposal.amount);
+    }
+
+    /// @notice Appeal an edge-slash proposal during the appeal window.
+    /// @dev Only the targeted provider can appeal.
+    /// @param proposalId The proposal to appeal.
+    function appealEdgeSlash(uint256 proposalId) external {
+        EdgeSlashProposal storage proposal = _getValidProposal(proposalId);
+        if (proposal.executed) revert ProposalAlreadyExecuted(proposalId);
+        if (proposal.appealed) revert ProposalAppealed(proposalId);
+        if (msg.sender != proposal.provider) {
+            revert NotProposalProvider(proposalId, msg.sender);
+        }
+
+        uint256 windowEnd = uint256(proposal.proposedAt) + proposal.appealWindowSnapshot;
+        if (block.timestamp >= windowEnd) revert AppealWindowElapsed(proposalId);
+
+        proposal.appealed = true;
+
+        emit EdgeSlashAppealed(proposalId, proposal.provider);
+    }
+
+    /// @notice Resolve an appealed edge-slash proposal.
+    /// @dev Only the owner can resolve. If upheld, the slash is executed.
+    /// @param proposalId The proposal to resolve.
+    /// @param uphold True to uphold the slash (execute it), false to dismiss.
+    function resolveEdgeSlashAppeal(uint256 proposalId, bool uphold)
+        external
+        onlyOwner
+        nonReentrant
+    {
+        EdgeSlashProposal storage proposal = _getValidProposal(proposalId);
+        if (!proposal.appealed) revert ProposalNotAppealed(proposalId);
+        if (proposal.resolved) revert ProposalAlreadyResolved(proposalId);
+        if (proposal.executed) revert ProposalAlreadyExecuted(proposalId);
+
+        proposal.resolved = true;
+
+        if (uphold) {
+            if (!slashingEnabled) revert SlashingNotEnabled();
+            proposal.executed = true;
+
+            stakingContract.slash(proposal.provider, proposal.amount);
+
+            emit EdgeSlashExecuted(proposalId, proposal.provider, proposal.amount);
+        }
+
+        emit EdgeAppealResolved(proposalId, uphold);
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Admin
+    // ──────────────────────────────────────────────
+
+    /// @notice Update the minimum BUNKER stake required to register as an edge
+    ///         provider. Bounded by the BunkerStaking Starter and Platinum minima.
+    /// @param newMinStake New minimum stake (wei).
+    function setMinStakeForEdge(uint256 newMinStake) external onlyOwner {
+        if (newMinStake < MIN_EDGE_STAKE_FLOOR || newMinStake > MIN_EDGE_STAKE_CEILING) {
+            revert InvalidMinStake(newMinStake);
+        }
+        uint256 old = minStakeForEdge;
+        minStakeForEdge = newMinStake;
+
+        emit MinStakeUpdated(old, newMinStake);
+    }
+
+    /// @notice Adjust the appeal window for edge-slash proposals.
+    /// @param newWindow New window in seconds (12 hours min, 14 days max).
+    function setAppealWindow(uint256 newWindow) external onlyOwner {
+        if (newWindow < APPEAL_WINDOW_FLOOR || newWindow > APPEAL_WINDOW_CEILING) {
+            revert InvalidAppealWindow();
+        }
+        appealWindow = newWindow;
+
+        emit AppealWindowUpdated(newWindow);
+    }
+
+    /// @notice Enable or disable slashing execution. When disabled, proposals can
+    ///         still be created for monitoring but execution reverts.
+    /// @param enabled True to enable slashing, false for monitor mode.
+    function setSlashingEnabled(bool enabled) external onlyOwner {
+        slashingEnabled = enabled;
+
+        emit SlashingEnabledUpdated(enabled);
+    }
+
+    /// @notice Pause edge-provider registration and updates (emergency).
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Unpause edge-provider registration and updates.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Views
+    // ──────────────────────────────────────────────
+
+    /// @notice Returns true if the provider is registered, active, and not frozen.
+    /// @param provider The edge-provider address to check.
+    /// @return active True when the address can serve edge traffic.
+    function isActiveEdgeProvider(address provider) external view returns (bool active) {
+        EdgeProviderInfo storage info = edgeProviders[provider];
+        return info.active && !info.frozen;
+    }
+
+    /// @notice Returns the full edge-provider metadata struct.
+    /// @param provider The edge-provider address to look up.
+    /// @return info The provider's registration metadata.
+    function getEdgeProviderInfo(address provider)
+        external
+        view
+        returns (EdgeProviderInfo memory info)
+    {
+        return edgeProviders[provider];
+    }
+
+    /// @notice Returns an edge-slash proposal by ID.
+    /// @param proposalId The proposal ID.
+    /// @return proposal The edge-slash proposal.
+    function getEdgeSlashProposal(uint256 proposalId)
+        external
+        view
+        returns (EdgeSlashProposal memory proposal)
+    {
+        return slashProposals[proposalId];
+    }
+
+    // ──────────────────────────────────────────────
+    //  Internal
+    // ──────────────────────────────────────────────
+
+    /// @dev Sync DEFAULT_ADMIN_ROLE when ownership is transferred (mirrors M-05
+    ///      in BunkerStaking).
+    function _transferOwnership(address newOwner) internal virtual override {
+        address oldOwner = owner();
+        super._transferOwnership(newOwner);
+        _revokeRole(DEFAULT_ADMIN_ROLE, oldOwner);
+        _grantRole(DEFAULT_ADMIN_ROLE, newOwner);
+    }
+
+    /// @dev Reverts unless the address holds at least `minStakeForEdge` staked in
+    ///      BunkerStaking. Reads storage (not pause-guarded), so the check still
+    ///      works while BunkerStaking is paused.
+    function _requireMinStake(address provider) internal view {
+        (uint128 stakedAmount,,,,,,,,) = stakingContract.getProviderInfo(provider);
+        if (uint256(stakedAmount) < minStakeForEdge) {
+            revert InsufficientStake(uint256(stakedAmount), minStakeForEdge);
+        }
+    }
+
+    /// @dev Validate a proposal ID and return the storage reference.
+    function _getValidProposal(uint256 proposalId)
+        internal
+        view
+        returns (EdgeSlashProposal storage)
+    {
+        if (proposalId >= slashProposalCount) revert InvalidProposalId(proposalId);
+        return slashProposals[proposalId];
+    }
+}

--- a/contracts/src/interfaces/IEdgeRegistry.sol
+++ b/contracts/src/interfaces/IEdgeRegistry.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title IEdgeRegistry
+/// @author Moltbunker
+/// @notice Minimal read-only interface for the BunkerEdgeRegistry, consumed by
+///         EDGE-02 (the daemon reverse-tunnel stake gate) and by the daemon Go
+///         bindings. The daemon's `EdgeRegistryReader` wraps these two functions
+///         so it never has to import the full contract ABI.
+interface IEdgeRegistry {
+    /// @notice Static, on-chain edge-provider metadata.
+    /// @dev Mirrored from BunkerEdgeRegistry so consumers can depend on the
+    ///      interface alone. The fixed-size leading fields pack into two slots.
+    struct EdgeProviderInfo {
+        bytes32 nodeId; // SHA256 of the provider's Ed25519 public key
+        bytes32 region; // Geographic region identifier
+        uint48 registeredAt; // Block timestamp at registration
+        bool active; // Whether the provider is currently registered
+        bool frozen; // Whether the provider is frozen (emergency response)
+        string endpointURL; // Public TLS-terminating edge endpoint
+        bytes tlsPubkeyHash; // Hash of the edge node's TLS public key
+    }
+
+    /// @notice Returns true if the provider is registered, active, and not frozen.
+    /// @param provider The edge-provider address to check.
+    /// @return active True when the address can serve edge traffic.
+    function isActiveEdgeProvider(address provider) external view returns (bool active);
+
+    /// @notice Returns the full edge-provider metadata struct.
+    /// @param provider The edge-provider address to look up.
+    /// @return info The provider's registration metadata.
+    function getEdgeProviderInfo(address provider)
+        external
+        view
+        returns (EdgeProviderInfo memory info);
+}

--- a/contracts/test/BunkerEdgeRegistry.t.sol
+++ b/contracts/test/BunkerEdgeRegistry.t.sol
@@ -1,0 +1,1055 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/BunkerToken.sol";
+import "../src/BunkerStaking.sol";
+import "../src/BunkerEdgeRegistry.sol";
+
+contract BunkerEdgeRegistryTest is Test {
+    BunkerToken public token;
+    BunkerStaking public staking;
+    BunkerEdgeRegistry public registry;
+
+    address public owner = makeAddr("owner");
+    address public treasury = makeAddr("treasury");
+    address public slasher = makeAddr("slasher");
+    address public edge1 = makeAddr("edge1");
+    address public edge2 = makeAddr("edge2");
+    address public lowStaker = makeAddr("lowStaker");
+    address public stranger = makeAddr("stranger");
+
+    // BunkerStaking tier minimums (mirrored from BunkerStaking constructor).
+    uint256 constant STARTER_MIN = 1_000_000e18;
+    uint256 constant SILVER_MIN = 10_000_000e18;
+    uint256 constant GOLD_MIN = 100_000_000e18;
+    uint256 constant PLATINUM_MIN = 1_000_000_000e18;
+
+    // BunkerEdgeRegistry defaults.
+    uint256 constant DEFAULT_MIN_EDGE_STAKE = 50_000_000e18;
+    uint256 constant DEFAULT_APPEAL_WINDOW = 48 hours;
+
+    bytes32 constant NODE_ID_1 = keccak256("edge1-node");
+    bytes32 constant NODE_ID_2 = keccak256("edge2-node");
+    bytes32 constant REGION_US = bytes32("us-east");
+    bytes32 constant REGION_EU = bytes32("eu-west");
+
+    string constant ENDPOINT_1 = "https://edge1.moltbunker.dev";
+    bytes constant TLS_HASH_1 = hex"0011223344556677";
+
+    function setUp() public {
+        vm.startPrank(owner);
+        token = new BunkerToken(owner);
+        staking = new BunkerStaking(address(token), treasury, owner);
+
+        // Grant slasher role on staking and enable slashing so routed slashes work.
+        staking.grantRole(staking.SLASHER_ROLE(), slasher);
+        staking.setSlashingEnabled(true);
+
+        // Mint enough for the edge providers to clear the 50 M threshold.
+        token.mint(edge1, 200_000_000e18);
+        token.mint(edge2, 200_000_000e18);
+        token.mint(lowStaker, 200_000_000e18);
+        vm.stopPrank();
+
+        // edge1 stakes 50 M (exactly at the edge threshold).
+        vm.startPrank(edge1);
+        token.approve(address(staking), type(uint256).max);
+        staking.stake(DEFAULT_MIN_EDGE_STAKE);
+        vm.stopPrank();
+
+        // edge2 stakes 100 M (comfortably above the threshold).
+        vm.startPrank(edge2);
+        token.approve(address(staking), type(uint256).max);
+        staking.stake(100_000_000e18);
+        vm.stopPrank();
+
+        // lowStaker stakes only 10 M (below the 50 M edge threshold).
+        vm.startPrank(lowStaker);
+        token.approve(address(staking), type(uint256).max);
+        staking.stake(SILVER_MIN);
+        vm.stopPrank();
+
+        // Deploy the edge registry and wire up the slasher role.
+        vm.startPrank(owner);
+        registry = new BunkerEdgeRegistry(address(staking), owner);
+        registry.grantRole(registry.SLASHER_ROLE(), slasher);
+
+        // Grant the registry SLASHER_ROLE on BunkerStaking so routed slashes work.
+        staking.grantRole(staking.SLASHER_ROLE(), address(registry));
+        vm.stopPrank();
+    }
+
+    // ================================================================
+    //  1. CONSTRUCTOR
+    // ================================================================
+
+    function test_constructor_setsStakingContract() public view {
+        assertEq(address(registry.stakingContract()), address(staking));
+    }
+
+    function test_constructor_setsOwner() public view {
+        assertEq(registry.owner(), owner);
+    }
+
+    function test_constructor_grantsDefaultAdminRole() public view {
+        assertTrue(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), owner));
+    }
+
+    function test_constructor_defaultMinStake() public view {
+        assertEq(registry.minStakeForEdge(), DEFAULT_MIN_EDGE_STAKE);
+    }
+
+    function test_constructor_defaultAppealWindow() public view {
+        assertEq(registry.appealWindow(), DEFAULT_APPEAL_WINDOW);
+    }
+
+    function test_constructor_slashingDisabledByDefault() public view {
+        assertFalse(registry.slashingEnabled());
+    }
+
+    function test_constructor_version() public view {
+        assertEq(registry.VERSION(), "1.0.0");
+    }
+
+    function test_constructor_revertsZeroStaking() public {
+        vm.prank(owner);
+        vm.expectRevert(BunkerEdgeRegistry.ZeroAddress.selector);
+        new BunkerEdgeRegistry(address(0), owner);
+    }
+
+    function test_constructor_revertsZeroOwner() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(bytes4(keccak256("OwnableInvalidOwner(address)")), address(0))
+        );
+        new BunkerEdgeRegistry(address(staking), address(0));
+    }
+
+    function test_constants() public view {
+        assertEq(registry.SLASHER_ROLE(), keccak256("SLASHER_ROLE"));
+        assertEq(registry.MIN_EDGE_STAKE_FLOOR(), STARTER_MIN);
+        assertEq(registry.MIN_EDGE_STAKE_CEILING(), PLATINUM_MIN);
+        assertEq(registry.APPEAL_WINDOW_FLOOR(), 12 hours);
+        assertEq(registry.APPEAL_WINDOW_CEILING(), 14 days);
+    }
+
+    // ================================================================
+    //  2. registerEdgeProvider
+    // ================================================================
+
+    function test_register_happyPath() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(edge1);
+        assertEq(info.nodeId, NODE_ID_1);
+        assertEq(info.region, REGION_US);
+        assertEq(info.endpointURL, ENDPOINT_1);
+        assertEq(info.tlsPubkeyHash, TLS_HASH_1);
+        assertTrue(info.active);
+        assertFalse(info.frozen);
+        assertGt(info.registeredAt, 0);
+    }
+
+    function test_register_emitsEvent() public {
+        vm.prank(edge1);
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeProviderRegistered(edge1, NODE_ID_1, REGION_US);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_register_setsNodeIdMapping() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        assertEq(registry.nodeIdToEdgeProvider(NODE_ID_1), edge1);
+    }
+
+    function test_register_secondTimeReverts() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.AlreadyRegistered.selector, edge1)
+        );
+        registry.registerEdgeProvider(NODE_ID_2, REGION_EU, ENDPOINT_1, TLS_HASH_1);
+        vm.stopPrank();
+    }
+
+    function test_register_duplicateNodeIdReverts() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(edge2);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.NodeIdAlreadyClaimed.selector, NODE_ID_1)
+        );
+        registry.registerEdgeProvider(NODE_ID_1, REGION_EU, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_register_insufficientStakeReverts() public {
+        vm.prank(lowStaker);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BunkerEdgeRegistry.InsufficientStake.selector, SILVER_MIN, DEFAULT_MIN_EDGE_STAKE
+            )
+        );
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_register_noStakeReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BunkerEdgeRegistry.InsufficientStake.selector, 0, DEFAULT_MIN_EDGE_STAKE
+            )
+        );
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_register_exactThresholdSucceeds() public {
+        // edge1 stakes exactly 50 M — must be allowed.
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_register_worksWhileStakingPaused() public {
+        // getProviderInfo reads storage and is not pause-guarded, so the stake
+        // check must still pass while BunkerStaking is paused (risk #1).
+        vm.prank(owner);
+        staking.pause();
+
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_register_zeroNodeIdSkipsMapping() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(bytes32(0), REGION_US, ENDPOINT_1, TLS_HASH_1);
+        // A zero node ID does not claim the mapping (so it stays re-usable).
+        assertEq(registry.nodeIdToEdgeProvider(bytes32(0)), address(0));
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_register_revertsWhenPaused() public {
+        vm.prank(owner);
+        registry.pause();
+
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("EnforcedPause()"))));
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    // ================================================================
+    //  3. deregisterEdgeProvider
+    // ================================================================
+
+    function test_deregister_happyPath() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(edge1);
+        assertFalse(info.active);
+        assertEq(info.nodeId, bytes32(0));
+        assertEq(registry.nodeIdToEdgeProvider(NODE_ID_1), address(0));
+    }
+
+    function test_deregister_clearsMetadata() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+
+        // No stale routing metadata must remain after deregistration.
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(edge1);
+        assertFalse(info.active);
+        assertEq(info.nodeId, bytes32(0));
+        assertEq(info.region, bytes32(0));
+        assertEq(info.endpointURL, "");
+        assertEq(info.tlsPubkeyHash, hex"");
+    }
+
+    function test_deregister_emitsEvent() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.expectEmit(true, false, false, false, address(registry));
+        emit BunkerEdgeRegistry.EdgeProviderDeregistered(edge1);
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+    }
+
+    function test_deregister_notActiveReverts() public {
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.deregisterEdgeProvider();
+    }
+
+    function test_deregister_twiceReverts() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.deregisterEdgeProvider();
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+    }
+
+    function test_deregister_allowsNodeIdReclaim() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+
+        // edge2 can now claim the released node ID.
+        vm.prank(edge2);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_EU, ENDPOINT_1, TLS_HASH_1);
+        assertEq(registry.nodeIdToEdgeProvider(NODE_ID_1), edge2);
+    }
+
+    // ================================================================
+    //  4. updateEndpoint
+    // ================================================================
+
+    function test_updateEndpoint_happyPath() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.updateEndpoint("https://new.edge.dev", hex"aabbcc");
+        vm.stopPrank();
+
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(edge1);
+        assertEq(info.endpointURL, "https://new.edge.dev");
+        assertEq(info.tlsPubkeyHash, hex"aabbcc");
+    }
+
+    function test_updateEndpoint_emitsEvent() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeEndpointUpdated(edge1, "https://new.edge.dev");
+        registry.updateEndpoint("https://new.edge.dev", hex"aabbcc");
+        vm.stopPrank();
+    }
+
+    function test_updateEndpoint_notActiveReverts() public {
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.updateEndpoint("https://x.dev", hex"00");
+    }
+
+    function test_updateEndpoint_frozenReverts() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProviderIsFrozen.selector, edge1));
+        registry.updateEndpoint("https://x.dev", hex"00");
+    }
+
+    // ================================================================
+    //  5. freeze / unfreeze
+    // ================================================================
+
+    function test_freeze_bySlasher() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        assertTrue(registry.getEdgeProviderInfo(edge1).frozen);
+        assertFalse(registry.isActiveEdgeProvider(edge1)); // frozen => not active to consumers
+    }
+
+    function test_freeze_emitsEvent() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(slasher);
+        vm.expectEmit(true, true, false, false, address(registry));
+        emit BunkerEdgeRegistry.EdgeProviderFrozen(edge1, slasher);
+        registry.freezeEdgeProvider(edge1);
+    }
+
+    function test_freeze_nonSlasherReverts() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        bytes32 slasherRole = registry.SLASHER_ROLE();
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("AccessControlUnauthorizedAccount(address,bytes32)")),
+                stranger,
+                slasherRole
+            )
+        );
+        registry.freezeEdgeProvider(edge1);
+    }
+
+    function test_freeze_notActiveReverts() public {
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.freezeEdgeProvider(edge1);
+    }
+
+    function test_unfreeze_byOwner() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        vm.prank(owner);
+        registry.unfreezeEdgeProvider(edge1);
+
+        assertFalse(registry.getEdgeProviderInfo(edge1).frozen);
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_unfreeze_emitsEvent() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        vm.prank(owner);
+        vm.expectEmit(true, false, false, false, address(registry));
+        emit BunkerEdgeRegistry.EdgeProviderUnfrozen(edge1);
+        registry.unfreezeEdgeProvider(edge1);
+    }
+
+    function test_unfreeze_nonOwnerReverts() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.unfreezeEdgeProvider(edge1);
+    }
+
+    function test_frozenProviderCannotReregister() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        // deregister first so 'active' is false, then re-register is blocked by frozen.
+        vm.startPrank(edge1);
+        registry.deregisterEdgeProvider();
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProviderIsFrozen.selector, edge1));
+        registry.registerEdgeProvider(NODE_ID_2, REGION_EU, ENDPOINT_1, TLS_HASH_1);
+        vm.stopPrank();
+    }
+
+    // ================================================================
+    //  6. proposeEdgeSlash
+    // ================================================================
+
+    function _register(address who, bytes32 nodeId, bytes32 region) internal {
+        vm.prank(who);
+        registry.registerEdgeProvider(nodeId, region, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_propose_happyPath() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        assertEq(id, 0);
+        assertEq(registry.slashProposalCount(), 1);
+
+        BunkerEdgeRegistry.EdgeSlashProposal memory p = registry.getEdgeSlashProposal(id);
+        assertEq(p.provider, edge1);
+        assertEq(p.amount, 1_000_000e18);
+        assertEq(p.reason, "downtime");
+        assertEq(p.appealWindowSnapshot, DEFAULT_APPEAL_WINDOW);
+        assertFalse(p.executed);
+        assertFalse(p.appealed);
+    }
+
+    function test_propose_emitsEvent() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(slasher);
+        vm.expectEmit(true, true, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeSlashProposed(0, edge1, 1_000_000e18, "downtime");
+        registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+    }
+
+    function test_propose_snapshotsAppealWindow() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        // Change the appeal window AFTER the proposal — snapshot must hold the old value.
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(owner);
+        registry.setAppealWindow(14 days);
+
+        assertEq(registry.getEdgeSlashProposal(id).appealWindowSnapshot, DEFAULT_APPEAL_WINDOW);
+    }
+
+    function test_propose_nonSlasherReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        bytes32 slasherRole = registry.SLASHER_ROLE();
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("AccessControlUnauthorizedAccount(address,bytes32)")),
+                stranger,
+                slasherRole
+            )
+        );
+        registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+    }
+
+    function test_propose_zeroAmountReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(slasher);
+        vm.expectRevert(BunkerEdgeRegistry.ZeroAmount.selector);
+        registry.proposeEdgeSlash(edge1, 0, "downtime");
+    }
+
+    function test_propose_zeroProviderReverts() public {
+        vm.prank(slasher);
+        vm.expectRevert(BunkerEdgeRegistry.ZeroAddress.selector);
+        registry.proposeEdgeSlash(address(0), 1_000_000e18, "downtime");
+    }
+
+    function test_propose_nonRegisteredProviderReverts() public {
+        // edge2 has plenty of BunkerStaking stake but never registered as an edge
+        // provider. The registry holds SLASHER_ROLE on BunkerStaking, so it must
+        // not be usable to propose slashes against stakers it does not govern.
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge2));
+        registry.proposeEdgeSlash(edge2, 1_000_000e18, "downtime");
+    }
+
+    function test_propose_deregisteredProviderReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(edge1);
+        registry.deregisterEdgeProvider();
+
+        // Once deregistered the provider is no longer active, so proposing a slash
+        // against it must revert even though its BunkerStaking stake persists.
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+    }
+
+    function test_propose_exceedingSlashableBalanceReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        // edge1 has exactly DEFAULT_MIN_EDGE_STAKE (50 M) staked and nothing
+        // unbonding, so the slashable balance is 50 M. A proposal for more must
+        // revert at propose time (defensive pre-check mirroring BunkerStaking H-05).
+        uint256 slashable = staking.getSlashableBalance(edge1);
+        assertEq(slashable, DEFAULT_MIN_EDGE_STAKE);
+
+        vm.prank(slasher);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BunkerEdgeRegistry.InsufficientSlashableBalance.selector,
+                slashable + 1,
+                slashable
+            )
+        );
+        registry.proposeEdgeSlash(edge1, uint128(slashable + 1), "downtime");
+    }
+
+    function test_propose_atSlashableBalanceSucceeds() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        uint256 slashable = staking.getSlashableBalance(edge1);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, uint128(slashable), "full slash");
+        assertEq(registry.getEdgeSlashProposal(id).amount, slashable);
+    }
+
+    // ================================================================
+    //  7. executeEdgeSlash
+    // ================================================================
+
+    function test_execute_slashingDisabledReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+
+        // registry.slashingEnabled defaults to false.
+        vm.expectRevert(BunkerEdgeRegistry.SlashingNotEnabled.selector);
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+    }
+
+    function test_execute_windowNotElapsedReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.AppealWindowNotElapsed.selector, id)
+        );
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+    }
+
+    function test_execute_happyPath_callsStakingSlash() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        uint256 slashAmount = 1_000_000e18;
+        uint256 stakedBefore = staking.getProviderInfo(edge1).stakedAmount;
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, uint128(slashAmount), "downtime");
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+
+        vm.expectEmit(true, true, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeSlashExecuted(id, edge1, slashAmount);
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+
+        // The slash actually hit BunkerStaking stake.
+        uint256 stakedAfter = staking.getProviderInfo(edge1).stakedAmount;
+        assertEq(stakedBefore - stakedAfter, slashAmount);
+        assertTrue(registry.getEdgeSlashProposal(id).executed);
+    }
+
+    function test_execute_twiceReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+        registry.executeEdgeSlash(id);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAlreadyExecuted.selector, id)
+        );
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+    }
+
+    function test_execute_appealedReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAppealed.selector, id));
+        registry.executeEdgeSlash(id);
+    }
+
+    function test_execute_invalidProposalIdReverts() public {
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.InvalidProposalId.selector, 99));
+        registry.executeEdgeSlash(99);
+    }
+
+    // ================================================================
+    //  8. appealEdgeSlash
+    // ================================================================
+
+    function test_appeal_byTargetedProvider() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(edge1);
+        vm.expectEmit(true, true, false, false, address(registry));
+        emit BunkerEdgeRegistry.EdgeSlashAppealed(id, edge1);
+        registry.appealEdgeSlash(id);
+
+        assertTrue(registry.getEdgeSlashProposal(id).appealed);
+    }
+
+    function test_appeal_nonProviderReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BunkerEdgeRegistry.NotProposalProvider.selector, id, stranger
+            )
+        );
+        registry.appealEdgeSlash(id);
+    }
+
+    function test_appeal_afterWindowReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.AppealWindowElapsed.selector, id));
+        registry.appealEdgeSlash(id);
+    }
+
+    function test_appeal_twiceReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.startPrank(edge1);
+        registry.appealEdgeSlash(id);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAppealed.selector, id));
+        registry.appealEdgeSlash(id);
+        vm.stopPrank();
+    }
+
+    function test_appeal_executedReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+
+        vm.prank(edge1);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAlreadyExecuted.selector, id)
+        );
+        registry.appealEdgeSlash(id);
+    }
+
+    // ================================================================
+    //  9. resolveEdgeSlashAppeal
+    // ================================================================
+
+    function test_resolve_upheldExecutesSlash() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        uint256 slashAmount = 1_000_000e18;
+        uint256 stakedBefore = staking.getProviderInfo(edge1).stakedAmount;
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, uint128(slashAmount), "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.prank(owner);
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeAppealResolved(id, true);
+        registry.resolveEdgeSlashAppeal(id, true);
+
+        uint256 stakedAfter = staking.getProviderInfo(edge1).stakedAmount;
+        assertEq(stakedBefore - stakedAfter, slashAmount);
+        assertTrue(registry.getEdgeSlashProposal(id).executed);
+        assertTrue(registry.getEdgeSlashProposal(id).resolved);
+    }
+
+    function test_resolve_dismissedDoesNotSlash() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        uint256 stakedBefore = staking.getProviderInfo(edge1).stakedAmount;
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.prank(owner);
+        registry.resolveEdgeSlashAppeal(id, false);
+
+        uint256 stakedAfter = staking.getProviderInfo(edge1).stakedAmount;
+        assertEq(stakedBefore, stakedAfter); // no slash applied
+        assertFalse(registry.getEdgeSlashProposal(id).executed);
+        assertTrue(registry.getEdgeSlashProposal(id).resolved);
+    }
+
+    function test_resolve_nonOwnerReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.resolveEdgeSlashAppeal(id, true);
+    }
+
+    function test_resolve_notAppealedReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProposalNotAppealed.selector, id));
+        registry.resolveEdgeSlashAppeal(id, true);
+    }
+
+    function test_resolve_twiceReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.startPrank(owner);
+        registry.resolveEdgeSlashAppeal(id, false);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAlreadyResolved.selector, id)
+        );
+        registry.resolveEdgeSlashAppeal(id, false);
+        vm.stopPrank();
+    }
+
+    function test_resolve_upheldWhileSlashingDisabledReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        // Disable slashing before resolving — upheld must revert.
+        vm.startPrank(owner);
+        registry.setSlashingEnabled(false);
+        vm.expectRevert(BunkerEdgeRegistry.SlashingNotEnabled.selector);
+        registry.resolveEdgeSlashAppeal(id, true);
+        vm.stopPrank();
+    }
+
+    // ================================================================
+    //  10. setMinStakeForEdge / setAppealWindow / setSlashingEnabled
+    // ================================================================
+
+    function test_setMinStake_byOwner() public {
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.MinStakeUpdated(DEFAULT_MIN_EDGE_STAKE, GOLD_MIN);
+        registry.setMinStakeForEdge(GOLD_MIN);
+        assertEq(registry.minStakeForEdge(), GOLD_MIN);
+    }
+
+    function test_setMinStake_nonOwnerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.setMinStakeForEdge(GOLD_MIN);
+    }
+
+    function test_setMinStake_belowFloorReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.InvalidMinStake.selector, STARTER_MIN - 1)
+        );
+        registry.setMinStakeForEdge(STARTER_MIN - 1);
+    }
+
+    function test_setMinStake_aboveCeilingReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.InvalidMinStake.selector, PLATINUM_MIN + 1)
+        );
+        registry.setMinStakeForEdge(PLATINUM_MIN + 1);
+    }
+
+    function test_setMinStake_atFloorSucceeds() public {
+        vm.prank(owner);
+        registry.setMinStakeForEdge(STARTER_MIN);
+        assertEq(registry.minStakeForEdge(), STARTER_MIN);
+    }
+
+    function test_setMinStake_atCeilingSucceeds() public {
+        vm.prank(owner);
+        registry.setMinStakeForEdge(PLATINUM_MIN);
+        assertEq(registry.minStakeForEdge(), PLATINUM_MIN);
+    }
+
+    function test_setAppealWindow_byOwner() public {
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.AppealWindowUpdated(7 days);
+        registry.setAppealWindow(7 days);
+        assertEq(registry.appealWindow(), 7 days);
+    }
+
+    function test_setAppealWindow_belowFloorReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(BunkerEdgeRegistry.InvalidAppealWindow.selector);
+        registry.setAppealWindow(12 hours - 1);
+    }
+
+    function test_setAppealWindow_aboveCeilingReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(BunkerEdgeRegistry.InvalidAppealWindow.selector);
+        registry.setAppealWindow(14 days + 1);
+    }
+
+    function test_setAppealWindow_nonOwnerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.setAppealWindow(7 days);
+    }
+
+    function test_setSlashingEnabled_byOwner() public {
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.SlashingEnabledUpdated(true);
+        registry.setSlashingEnabled(true);
+        assertTrue(registry.slashingEnabled());
+    }
+
+    function test_setSlashingEnabled_nonOwnerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.setSlashingEnabled(true);
+    }
+
+    // ================================================================
+    //  11. isActiveEdgeProvider view
+    // ================================================================
+
+    function test_isActive_falseWhenUnregistered() public view {
+        assertFalse(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_isActive_trueAfterRegister() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_isActive_falseAfterDeregister() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(edge1);
+        registry.deregisterEdgeProvider();
+        assertFalse(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_isActive_falseWhenFrozen() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+        assertFalse(registry.isActiveEdgeProvider(edge1));
+    }
+
+    // ================================================================
+    //  12. Ownership transfer syncs admin role
+    // ================================================================
+
+    function test_transferOwnership_syncsAdminRole() public {
+        address newOwner = makeAddr("newOwner");
+
+        vm.prank(owner);
+        registry.transferOwnership(newOwner);
+        vm.prank(newOwner);
+        registry.acceptOwnership();
+
+        assertEq(registry.owner(), newOwner);
+        assertTrue(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), newOwner));
+        assertFalse(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), owner));
+    }
+
+    // ================================================================
+    //  13. FUZZ
+    // ================================================================
+
+    function testFuzz_registerAndQuery(bytes32 nodeId, bytes32 region, uint128 stakeAmount)
+        public
+    {
+        // Bound the stake to a sane mintable range, then skip below-threshold runs.
+        stakeAmount = uint128(bound(uint256(stakeAmount), 0, 1_500_000_000e18));
+        vm.assume(nodeId != bytes32(0));
+        vm.assume(registry.nodeIdToEdgeProvider(nodeId) == address(0));
+
+        address fuzzEdge = makeAddr("fuzzEdge");
+        vm.prank(owner);
+        token.mint(fuzzEdge, uint256(stakeAmount) + 1);
+
+        if (stakeAmount > 0) {
+            vm.startPrank(fuzzEdge);
+            token.approve(address(staking), type(uint256).max);
+            // staking requires at least the Starter minimum to register.
+            if (stakeAmount >= STARTER_MIN) {
+                staking.stake(stakeAmount);
+            }
+            vm.stopPrank();
+        }
+
+        if (stakeAmount < DEFAULT_MIN_EDGE_STAKE) {
+            vm.prank(fuzzEdge);
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    BunkerEdgeRegistry.InsufficientStake.selector,
+                    stakeAmount >= STARTER_MIN ? uint256(stakeAmount) : 0,
+                    DEFAULT_MIN_EDGE_STAKE
+                )
+            );
+            registry.registerEdgeProvider(nodeId, region, ENDPOINT_1, TLS_HASH_1);
+            return;
+        }
+
+        vm.prank(fuzzEdge);
+        registry.registerEdgeProvider(nodeId, region, ENDPOINT_1, TLS_HASH_1);
+
+        assertTrue(registry.isActiveEdgeProvider(fuzzEdge));
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(fuzzEdge);
+        assertEq(info.nodeId, nodeId);
+        assertEq(info.region, region);
+        assertEq(registry.nodeIdToEdgeProvider(nodeId), fuzzEdge);
+    }
+}

--- a/internal/payment/edge_registry.go
+++ b/internal/payment/edge_registry.go
@@ -1,0 +1,251 @@
+package payment
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// EdgeRegistryABI is the minimal read-only ABI for the BunkerEdgeRegistry
+// contract. It contains only the two view functions EDGE-02 needs
+// (isActiveEdgeProvider, getEdgeProviderInfo). Keeping the surface tiny avoids
+// coupling the daemon to the full contract ABI.
+// #nosec G101 -- not a credential: this is a Solidity contract ABI (JSON interface definition)
+const EdgeRegistryABI = `[
+	{
+		"inputs": [{"name": "provider", "type": "address"}],
+		"name": "isActiveEdgeProvider",
+		"outputs": [{"name": "active", "type": "bool"}],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [{"name": "provider", "type": "address"}],
+		"name": "getEdgeProviderInfo",
+		"outputs": [
+			{
+				"name": "info",
+				"type": "tuple",
+				"components": [
+					{"name": "nodeId", "type": "bytes32"},
+					{"name": "region", "type": "bytes32"},
+					{"name": "registeredAt", "type": "uint48"},
+					{"name": "active", "type": "bool"},
+					{"name": "frozen", "type": "bool"},
+					{"name": "endpointURL", "type": "string"},
+					{"name": "tlsPubkeyHash", "type": "bytes"}
+				]
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]`
+
+// EdgeProviderData is the daemon-side representation of an edge provider's
+// on-chain registration metadata. It mirrors BunkerEdgeRegistry.EdgeProviderInfo
+// but uses Go-native types.
+type EdgeProviderData struct {
+	NodeID        [32]byte
+	Region        [32]byte
+	EndpointURL   string
+	TLSPubkeyHash []byte
+	RegisteredAt  time.Time
+	Active        bool
+	Frozen        bool
+}
+
+// EdgeRegistryReader is the read-only seam EDGE-02 consumes to gate reverse
+// tunnels on edge-provider registration. Both the production contract reader
+// and the in-memory mock implement it, so EDGE-02 can be developed and tested
+// on darwin without a deployed contract.
+type EdgeRegistryReader interface {
+	// IsActiveEdgeProvider reports whether the address is a registered,
+	// active, and unfrozen edge provider.
+	IsActiveEdgeProvider(ctx context.Context, addr common.Address) (bool, error)
+
+	// GetEdgeProviderInfo returns the edge provider's metadata. For an
+	// unregistered address it returns (nil, nil) rather than an error.
+	GetEdgeProviderInfo(ctx context.Context, addr common.Address) (*EdgeProviderData, error)
+}
+
+// edgeProviderInfoTuple matches the on-chain getEdgeProviderInfo tuple return
+// for ABI decoding. The field order and Go types must mirror the tuple
+// components positionally — go-ethereum copies the decoded tuple into this
+// struct field-by-field (see edgeInfoResult), so no `abi` struct tags are
+// required; uint48 registeredAt decodes to *big.Int.
+type edgeProviderInfoTuple struct {
+	NodeId        [32]byte
+	Region        [32]byte
+	RegisteredAt  *big.Int
+	Active        bool
+	Frozen        bool
+	EndpointURL   string
+	TlsPubkeyHash []byte
+}
+
+// EdgeRegistryContract is the production EdgeRegistryReader backed by an on-chain
+// BunkerEdgeRegistry deployment. The contract address is supplied at runtime
+// (from config), never hard-coded.
+type EdgeRegistryContract struct {
+	baseClient   *BaseClient
+	contract     *bind.BoundContract
+	contractABI  abi.ABI
+	contractAddr common.Address
+}
+
+// NewEdgeRegistryContract creates a production edge-registry reader. The address
+// is sourced from config at runtime (address-as-parameter, never a source
+// constant). Returns an error if baseClient is nil or not connected.
+func NewEdgeRegistryContract(baseClient *BaseClient, contractAddr common.Address) (*EdgeRegistryContract, error) {
+	if baseClient == nil {
+		return nil, fmt.Errorf("base client is required (use NewMockEdgeRegistryReader for testing)")
+	}
+	if !baseClient.IsConnected() {
+		return nil, fmt.Errorf("base client not connected to RPC")
+	}
+
+	parsedABI, err := abi.JSON(strings.NewReader(EdgeRegistryABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse edge registry ABI: %w", err)
+	}
+
+	client := baseClient.Client()
+	return &EdgeRegistryContract{
+		baseClient:   baseClient,
+		contract:     bind.NewBoundContract(contractAddr, parsedABI, client, client, client),
+		contractABI:  parsedABI,
+		contractAddr: contractAddr,
+	}, nil
+}
+
+// IsActiveEdgeProvider implements EdgeRegistryReader against the on-chain contract.
+func (ec *EdgeRegistryContract) IsActiveEdgeProvider(ctx context.Context, addr common.Address) (bool, error) {
+	callOpts := &bind.CallOpts{Context: ctx}
+	var result []interface{}
+	if err := ec.contract.Call(callOpts, &result, "isActiveEdgeProvider", addr); err != nil {
+		return false, fmt.Errorf("isActiveEdgeProvider failed: %w", err)
+	}
+	if len(result) < 1 {
+		return false, fmt.Errorf("unexpected result length")
+	}
+	active, ok := result[0].(bool)
+	if !ok {
+		return false, fmt.Errorf("unexpected result type for isActiveEdgeProvider")
+	}
+	return active, nil
+}
+
+// edgeInfoResult wraps the single tuple output of getEdgeProviderInfo. Decoding
+// the tuple into a struct requires a wrapper whose first field is the tuple
+// struct: bind.BoundContract.Call routes a single-element results slice through
+// abi.UnpackIntoInterface, whose copyAtomic step sets dst.Field(0) from the
+// decoded tuple. Pointing Field(0) at edgeProviderInfoTuple makes go-ethereum
+// copy the tuple field-by-field (positionally, no struct tags required).
+// Decoding directly into edgeProviderInfoTuple instead would mis-target only
+// its first field and panic.
+type edgeInfoResult struct {
+	Info edgeProviderInfoTuple
+}
+
+// GetEdgeProviderInfo implements EdgeRegistryReader against the on-chain contract.
+func (ec *EdgeRegistryContract) GetEdgeProviderInfo(ctx context.Context, addr common.Address) (*EdgeProviderData, error) {
+	callOpts := &bind.CallOpts{Context: ctx}
+	out := edgeInfoResult{}
+	results := []interface{}{&out}
+	if err := ec.contract.Call(callOpts, &results, "getEdgeProviderInfo", addr); err != nil {
+		return nil, fmt.Errorf("getEdgeProviderInfo failed: %w", err)
+	}
+	return out.Info.toEdgeProviderData(), nil
+}
+
+// toEdgeProviderData converts the ABI-decoded tuple into the daemon-side
+// representation. Kept separate from the RPC call so the struct-tag decode +
+// type translation can be unit-tested without a live backend.
+func (t edgeProviderInfoTuple) toEdgeProviderData() *EdgeProviderData {
+	var registeredAt time.Time
+	if t.RegisteredAt != nil && t.RegisteredAt.Sign() > 0 {
+		registeredAt = time.Unix(t.RegisteredAt.Int64(), 0)
+	}
+
+	return &EdgeProviderData{
+		NodeID:        t.NodeId,
+		Region:        t.Region,
+		EndpointURL:   t.EndpointURL,
+		TLSPubkeyHash: t.TlsPubkeyHash,
+		RegisteredAt:  registeredAt,
+		Active:        t.Active,
+		Frozen:        t.Frozen,
+	}
+}
+
+// MockEdgeRegistryReader is an in-memory EdgeRegistryReader for tests and darwin
+// builds. It is safe for concurrent use.
+type MockEdgeRegistryReader struct {
+	mu        sync.RWMutex
+	providers map[common.Address]*EdgeProviderData
+}
+
+// NewMockEdgeRegistryReader creates an empty in-memory edge-registry reader.
+func NewMockEdgeRegistryReader() *MockEdgeRegistryReader {
+	return &MockEdgeRegistryReader{
+		providers: make(map[common.Address]*EdgeProviderData),
+	}
+}
+
+// RegisterMock adds or replaces an edge provider in the mock store. A nil data
+// pointer is ignored.
+func (m *MockEdgeRegistryReader) RegisterMock(addr common.Address, data *EdgeProviderData) {
+	if data == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Store a copy so callers cannot mutate the stored record after the fact.
+	cp := *data
+	m.providers[addr] = &cp
+}
+
+// UnregisterMock removes an edge provider from the mock store.
+func (m *MockEdgeRegistryReader) UnregisterMock(addr common.Address) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.providers, addr)
+}
+
+// IsActiveEdgeProvider implements EdgeRegistryReader against the in-memory store.
+func (m *MockEdgeRegistryReader) IsActiveEdgeProvider(_ context.Context, addr common.Address) (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	data, ok := m.providers[addr]
+	if !ok {
+		return false, nil
+	}
+	return data.Active && !data.Frozen, nil
+}
+
+// GetEdgeProviderInfo implements EdgeRegistryReader against the in-memory store.
+// An unregistered address returns (nil, nil), not an error.
+func (m *MockEdgeRegistryReader) GetEdgeProviderInfo(_ context.Context, addr common.Address) (*EdgeProviderData, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	data, ok := m.providers[addr]
+	if !ok {
+		return nil, nil
+	}
+	cp := *data
+	return &cp, nil
+}
+
+// Compile-time assertions that both implementations satisfy the interface.
+var (
+	_ EdgeRegistryReader = (*EdgeRegistryContract)(nil)
+	_ EdgeRegistryReader = (*MockEdgeRegistryReader)(nil)
+)

--- a/internal/payment/edge_registry_test.go
+++ b/internal/payment/edge_registry_test.go
@@ -1,0 +1,298 @@
+package payment
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func sampleEdgeData() *EdgeProviderData {
+	var nodeID, region [32]byte
+	copy(nodeID[:], []byte("edge-node-1"))
+	copy(region[:], []byte("us-east"))
+	return &EdgeProviderData{
+		NodeID:        nodeID,
+		Region:        region,
+		EndpointURL:   "https://edge1.moltbunker.dev",
+		TLSPubkeyHash: []byte{0x00, 0x11, 0x22, 0x33},
+		RegisteredAt:  time.Unix(1_700_000_000, 0),
+		Active:        true,
+		Frozen:        false,
+	}
+}
+
+func TestMockEdgeRegistry_IsActive(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+	addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	// Unknown address returns false, no error.
+	active, err := m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error for unknown address: %v", err)
+	}
+	if active {
+		t.Fatalf("expected unknown address to be inactive")
+	}
+
+	// After registration, returns true.
+	m.RegisterMock(addr, sampleEdgeData())
+	active, err = m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error after register: %v", err)
+	}
+	if !active {
+		t.Fatalf("expected registered active provider to be active")
+	}
+
+	// A frozen provider is reported inactive.
+	frozen := sampleEdgeData()
+	frozen.Frozen = true
+	m.RegisterMock(addr, frozen)
+	active, err = m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error for frozen provider: %v", err)
+	}
+	if active {
+		t.Fatalf("expected frozen provider to be inactive")
+	}
+
+	// An explicitly inactive provider is reported inactive.
+	inactive := sampleEdgeData()
+	inactive.Active = false
+	m.RegisterMock(addr, inactive)
+	active, _ = m.IsActiveEdgeProvider(ctx, addr)
+	if active {
+		t.Fatalf("expected inactive provider to be inactive")
+	}
+
+	// After unregister, returns false.
+	m.RegisterMock(addr, sampleEdgeData())
+	m.UnregisterMock(addr)
+	active, err = m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error after unregister: %v", err)
+	}
+	if active {
+		t.Fatalf("expected unregistered address to be inactive")
+	}
+}
+
+func TestMockEdgeRegistry_GetInfo(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+	addr := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	want := sampleEdgeData()
+	m.RegisterMock(addr, want)
+
+	got, err := m.GetEdgeProviderInfo(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil edge provider data")
+	}
+	if got.NodeID != want.NodeID {
+		t.Errorf("NodeID mismatch: got %x want %x", got.NodeID, want.NodeID)
+	}
+	if got.Region != want.Region {
+		t.Errorf("Region mismatch: got %x want %x", got.Region, want.Region)
+	}
+	if got.EndpointURL != want.EndpointURL {
+		t.Errorf("EndpointURL mismatch: got %q want %q", got.EndpointURL, want.EndpointURL)
+	}
+	if string(got.TLSPubkeyHash) != string(want.TLSPubkeyHash) {
+		t.Errorf("TLSPubkeyHash mismatch: got %x want %x", got.TLSPubkeyHash, want.TLSPubkeyHash)
+	}
+	if !got.RegisteredAt.Equal(want.RegisteredAt) {
+		t.Errorf("RegisteredAt mismatch: got %v want %v", got.RegisteredAt, want.RegisteredAt)
+	}
+
+	// RegisterMock must store a copy: mutating the caller's struct afterward
+	// must not change the stored record.
+	want.EndpointURL = "https://mutated.example"
+	got2, _ := m.GetEdgeProviderInfo(ctx, addr)
+	if got2.EndpointURL == "https://mutated.example" {
+		t.Errorf("stored record was mutated through the caller's pointer")
+	}
+}
+
+func TestMockEdgeRegistry_ZeroAddress(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+
+	got, err := m.GetEdgeProviderInfo(ctx, common.Address{})
+	if err != nil {
+		t.Fatalf("expected nil error for zero address, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil data for zero address, got %+v", got)
+	}
+}
+
+func TestMockEdgeRegistry_Concurrency(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(n int) {
+			defer wg.Done()
+			addr := common.BigToAddress(big.NewInt(int64(n) + 1))
+			data := sampleEdgeData()
+			for j := 0; j < 100; j++ {
+				m.RegisterMock(addr, data)
+				_, _ = m.IsActiveEdgeProvider(ctx, addr)
+				_, _ = m.GetEdgeProviderInfo(ctx, addr)
+				if j%2 == 0 {
+					m.UnregisterMock(addr)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// abiEdgeProviderInfo mirrors the on-chain getEdgeProviderInfo tuple components
+// in declaration order. It is only used by the ABI encoder in the test below to
+// produce wire bytes; the decode under test happens through edgeProviderInfoTuple.
+type abiEdgeProviderInfo struct {
+	NodeId        [32]byte
+	Region        [32]byte
+	RegisteredAt  *big.Int
+	Active        bool
+	Frozen        bool
+	EndpointURL   string
+	TlsPubkeyHash []byte
+}
+
+// TestEdgeProviderInfo_ABIDecode exercises the on-chain decode path of
+// GetEdgeProviderInfo without a live backend: it ABI-encodes a sample
+// EdgeProviderInfo tuple with EdgeRegistryABI's getEdgeProviderInfo output
+// arguments, then runs the exact production decode — abi.Unpack followed by the
+// decodeEdgeProviderInfoResult type-assert + translation that
+// GetEdgeProviderInfo performs on result[0]. This confirms the struct decode is
+// correct, in particular the uint48 registeredAt (decoded as *big.Int) and the
+// two bool fields, which previously had zero coverage. (It also pins the
+// regression where the original results-slice form panicked on this tuple.)
+func TestEdgeProviderInfo_ABIDecode(t *testing.T) {
+	parsedABI, err := abi.JSON(strings.NewReader(EdgeRegistryABI))
+	if err != nil {
+		t.Fatalf("failed to parse edge registry ABI: %v", err)
+	}
+	method, ok := parsedABI.Methods["getEdgeProviderInfo"]
+	if !ok {
+		t.Fatalf("getEdgeProviderInfo not present in ABI")
+	}
+
+	var nodeID, region [32]byte
+	copy(nodeID[:], []byte("edge-node-abc"))
+	copy(region[:], []byte("eu-west"))
+
+	const registeredAtUnix int64 = 1_700_000_123
+	sample := abiEdgeProviderInfo{
+		NodeId:        nodeID,
+		Region:        region,
+		RegisteredAt:  big.NewInt(registeredAtUnix),
+		Active:        true,
+		Frozen:        true,
+		EndpointURL:   "https://edge-abc.moltbunker.dev",
+		TlsPubkeyHash: []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x99},
+	}
+
+	// Encode exactly as the contract would return it (the tuple is the single
+	// output argument of getEdgeProviderInfo).
+	encoded, err := method.Outputs.Pack(sample)
+	if err != nil {
+		t.Fatalf("failed to ABI-encode sample tuple: %v", err)
+	}
+
+	// Decode through the exact production path bind.BoundContract.Call drives:
+	// UnpackIntoInterface into &edgeInfoResult{} (its Info field is the tuple),
+	// then the tuple->EdgeProviderData translation.
+	out := edgeInfoResult{}
+	if err := parsedABI.UnpackIntoInterface(&out, "getEdgeProviderInfo", encoded); err != nil {
+		t.Fatalf("UnpackIntoInterface failed: %v", err)
+	}
+	data := out.Info.toEdgeProviderData()
+
+	// Production translation into the daemon-side struct.
+	if data.NodeID != nodeID {
+		t.Errorf("data.NodeID mismatch: got %x want %x", data.NodeID, nodeID)
+	}
+	if data.Region != region {
+		t.Errorf("data.Region mismatch: got %x want %x", data.Region, region)
+	}
+	if !data.RegisteredAt.Equal(time.Unix(registeredAtUnix, 0)) {
+		t.Errorf("data.RegisteredAt mismatch: got %v want %v", data.RegisteredAt, time.Unix(registeredAtUnix, 0))
+	}
+	if !data.Active {
+		t.Errorf("data.Active mismatch: got false want true")
+	}
+	if !data.Frozen {
+		t.Errorf("data.Frozen mismatch: got false want true")
+	}
+	if data.EndpointURL != sample.EndpointURL {
+		t.Errorf("data.EndpointURL mismatch: got %q want %q", data.EndpointURL, sample.EndpointURL)
+	}
+	if string(data.TLSPubkeyHash) != string(sample.TlsPubkeyHash) {
+		t.Errorf("data.TLSPubkeyHash mismatch: got %x want %x", data.TLSPubkeyHash, sample.TlsPubkeyHash)
+	}
+}
+
+// TestEdgeProviderInfo_ABIDecode_ZeroRegisteredAt confirms a zero uint48
+// registeredAt maps to the Go zero time (not a 1970 epoch timestamp).
+func TestEdgeProviderInfo_ABIDecode_ZeroRegisteredAt(t *testing.T) {
+	parsedABI, err := abi.JSON(strings.NewReader(EdgeRegistryABI))
+	if err != nil {
+		t.Fatalf("failed to parse edge registry ABI: %v", err)
+	}
+	method := parsedABI.Methods["getEdgeProviderInfo"]
+
+	sample := abiEdgeProviderInfo{
+		RegisteredAt:  big.NewInt(0),
+		TlsPubkeyHash: []byte{},
+	}
+	encoded, err := method.Outputs.Pack(sample)
+	if err != nil {
+		t.Fatalf("failed to ABI-encode sample tuple: %v", err)
+	}
+
+	out := edgeInfoResult{}
+	if err := parsedABI.UnpackIntoInterface(&out, "getEdgeProviderInfo", encoded); err != nil {
+		t.Fatalf("UnpackIntoInterface failed: %v", err)
+	}
+	data := out.Info.toEdgeProviderData()
+	if !data.RegisteredAt.IsZero() {
+		t.Errorf("expected zero RegisteredAt for unset uint48, got %v", data.RegisteredAt)
+	}
+	if data.Active || data.Frozen {
+		t.Errorf("expected false bools for empty tuple, got active=%v frozen=%v", data.Active, data.Frozen)
+	}
+}
+
+func TestMockEdgeRegistry_NilDataIgnored(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+	addr := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	// Registering nil data is a no-op (no panic, address stays unknown).
+	m.RegisterMock(addr, nil)
+	active, err := m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active {
+		t.Fatalf("expected address to stay inactive after nil register")
+	}
+}

--- a/pkg/types/edge_types.go
+++ b/pkg/types/edge_types.go
@@ -1,0 +1,42 @@
+package types
+
+// This file holds edge-provider (L7 edge layer, Approach A) types. Per the
+// types zone rule, a new topic gets its own file — these constants are NOT
+// appended to economics.go or types.go.
+
+// StakingTierEdge is the edge-provider role tier. It is distinct from the
+// compute-provider staking tiers (starter/bronze/silver/gold/platinum) because
+// edge providers stake against a separate on-chain registry (BunkerEdgeRegistry)
+// with its own minimum and slashing semantics, rather than the BunkerStaking
+// tier enum.
+const StakingTierEdge StakingTier = "edge"
+
+// IsEdgeTier reports whether the given staking tier is the edge-provider role.
+func IsEdgeTier(t StakingTier) bool {
+	return t == StakingTierEdge
+}
+
+// EdgeProviderCapability is a bitmask describing the L7 edge features a provider
+// advertises. EDGE-02's tunnel gate logic references these bits without locking
+// the on-chain registry to a specific bitmask encoding (the contract stores
+// opaque metadata; the daemon interprets capabilities off-chain).
+type EdgeProviderCapability uint64
+
+const (
+	// EdgeCapWAF indicates the edge node runs an application-layer WAF.
+	EdgeCapWAF EdgeProviderCapability = 1 << 0
+
+	// EdgeCapDDoSMitigation indicates the edge node performs L3/L4/L7 DDoS mitigation.
+	EdgeCapDDoSMitigation EdgeProviderCapability = 1 << 1
+
+	// EdgeCapTLSTermination indicates the edge node terminates TLS for tenants.
+	EdgeCapTLSTermination EdgeProviderCapability = 1 << 2
+
+	// EdgeCapACME indicates the edge node issues/renews certificates via ACME.
+	EdgeCapACME EdgeProviderCapability = 1 << 3
+)
+
+// Has reports whether the capability set includes the given capability bit.
+func (c EdgeProviderCapability) Has(cap EdgeProviderCapability) bool {
+	return c&cap == cap
+}


### PR DESCRIPTION
## SC-EDGE-01 — On-chain edge-provider stake tier

Adds the stake-gated **edge-provider** role required by the Approach-A edge architecture (EDGE-02 consumes it). **Additive only** — no existing contract modified. **Not deployed.**

- `BunkerEdgeRegistry.sol` (+ `IEdgeRegistry.sol`): stake-gated edge-provider registration, endpoint/region/TLS-pubkey metadata, and slashing-eligibility for edge SLA. `proposeEdgeSlash` is least-privilege-scoped (only registered/active providers) and clears stale metadata on deregister.
- Go side: `EdgeRegistryReader` interface + `MockEdgeRegistryReader` + `pkg/types/edge_types.go`, so EDGE-02 can gate the daemon-side edge role against a mock until the contract is deployed (fixed a real single-tuple ABI-decode panic in the on-chain reader path, now covered by an encode→unpack test).

**Verification:** `forge build` clean; `forge test` = **972 passed / 0 failed**; `go build`+`vet`+`gosec`(0)+`go test ./internal/payment/... ./pkg/types/...` green. Secret-scan clean.

Base: `main`. Blocks EDGE-02 (Wave 3).
