### PR TITLE
RUN-01 Enforce real nftables policy, browser-exec E2E, doctor gate tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,3 +222,21 @@ jobs:
           # point it at the Linux runner's system containerd socket.
           COLIMA_CONTAINERD_SOCKET: /run/containerd/containerd.sock
         run: go test -tags colima -v -timeout 12m ./tests/e2e/colima/...
+
+      - name: Install nftables
+        # R13/R14: the nftables enforcer generates `nft -f -` scripts that the
+        # unit tests only validate against a fake exec. Install the real nft
+        # binary so the smoke test below pipes the real scripts to real nft and
+        # catches chain-name rejections and the delete-chain EBUSY teardown bug.
+        run: sudo apt-get update && sudo apt-get install -y nftables
+
+      - name: Run nftables enforcer smoke test (real nft, root)
+        # Needs CAP_NET_ADMIN; run as root via sudo. `-tags nftsmoke` selects the
+        # gated smoke test (skipped from the default suite, which has no nft).
+        # `go env GOFLAGS` are not inherited under sudo, so pass GOPATH/HOME so
+        # the module cache and toolchain resolve under the runner's user.
+        run: |
+          set -euxo pipefail
+          sudo env "PATH=$PATH" "HOME=$HOME" "GOPATH=$(go env GOPATH)" \
+            go test -tags nftsmoke -v -run TestSmoke_ApplyRemoveAgainstRealNft \
+            ./internal/networking/...

--- a/internal/api/deploy_mapping_test.go
+++ b/internal/api/deploy_mapping_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/moltbunker/moltbunker/internal/client"
+)
+
+// TestBuildDaemonDeployRequest_ExecEnvelopeFlows verifies the E2E exec envelope
+// fields and exposed ports are copied from the REST DeployRequest into the
+// daemon client DeployRequest. Before RUN-01 the browser path dropped these,
+// forcing every REST-deployed container into plaintext exec.
+func TestBuildDaemonDeployRequest_ExecEnvelopeFlows(t *testing.T) {
+	req := &DeployRequest{
+		Image:                    "nginx:latest",
+		EncryptedExecKey:         []byte{0xaa, 0xbb, 0xcc},
+		ExecKeyNonce:             []byte{0x01, 0x02},
+		RequesterEphemeralPubKey: bytes.Repeat([]byte{0x07}, 32),
+		DeployNonce:              "deadbeefcafef00d",
+		ExposePorts:              []client.ExposedPort{{ContainerPort: 8080, Protocol: "tcp"}},
+	}
+
+	got := buildDaemonDeployRequest(req, "0xWallet")
+
+	if got.Owner != "0xWallet" {
+		t.Errorf("Owner = %q, want 0xWallet", got.Owner)
+	}
+	if !bytes.Equal(got.EncryptedExecKey, req.EncryptedExecKey) {
+		t.Errorf("EncryptedExecKey = %v, want %v", got.EncryptedExecKey, req.EncryptedExecKey)
+	}
+	if !bytes.Equal(got.ExecKeyNonce, req.ExecKeyNonce) {
+		t.Errorf("ExecKeyNonce not forwarded")
+	}
+	if !bytes.Equal(got.RequesterEphemeralPubKey, req.RequesterEphemeralPubKey) {
+		t.Errorf("RequesterEphemeralPubKey not forwarded")
+	}
+	if got.DeployNonce != "deadbeefcafef00d" {
+		t.Errorf("DeployNonce = %q, want deadbeefcafef00d", got.DeployNonce)
+	}
+	if len(got.ExposePorts) != 1 || got.ExposePorts[0].ContainerPort != 8080 {
+		t.Errorf("ExposePorts = %+v, want [{8080 tcp}]", got.ExposePorts)
+	}
+}
+
+// TestBuildDaemonDeployRequest_OmittedEnvelopeIsLegacy verifies that a request
+// with no exec envelope produces empty fields, so the daemon injects no
+// exec-agent — identical to pre-SEC-10 behavior. No regression for older
+// browsers / API clients.
+func TestBuildDaemonDeployRequest_OmittedEnvelopeIsLegacy(t *testing.T) {
+	got := buildDaemonDeployRequest(&DeployRequest{Image: "alpine"}, "")
+	if len(got.EncryptedExecKey) != 0 || len(got.ExecKeyNonce) != 0 ||
+		len(got.RequesterEphemeralPubKey) != 0 || got.DeployNonce != "" {
+		t.Errorf("omitted exec envelope must stay empty, got %+v", got)
+	}
+	if len(got.ExposePorts) != 0 {
+		t.Errorf("omitted ExposePorts must stay empty, got %+v", got.ExposePorts)
+	}
+}
+
+// TestBuildDeployResponse_EchoesExecFields verifies the response surfaces
+// ExecAgentEnabled + DeployNonce so the browser knows whether to run the exec
+// handshake.
+func TestBuildDeployResponse_EchoesExecFields(t *testing.T) {
+	result := &client.DeployResponse{
+		ContainerID:      "dep-123",
+		Status:           "running",
+		ExecAgentEnabled: true,
+		DeployNonce:      "abc123",
+	}
+	got := buildDeployResponse(result)
+	if got.ContainerID != "dep-123" {
+		t.Errorf("ContainerID = %q, want dep-123", got.ContainerID)
+	}
+	if !got.ExecAgentEnabled {
+		t.Error("ExecAgentEnabled should be echoed as true")
+	}
+	if got.DeployNonce != "abc123" {
+		t.Errorf("DeployNonce = %q, want abc123", got.DeployNonce)
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -21,10 +21,10 @@ import (
 
 // ReserveRequest matches POST /reserve
 type ReserveRequest struct {
-	Tier         string `json:"tier"`          // minimal, standard, performance, enterprise
-	DurationHours int   `json:"duration_hours"`
-	Region       string `json:"region,omitempty"`
-	TorOnly      bool   `json:"tor_only,omitempty"`
+	Tier          string `json:"tier"` // minimal, standard, performance, enterprise
+	DurationHours int    `json:"duration_hours"`
+	Region        string `json:"region,omitempty"`
+	TorOnly       bool   `json:"tor_only,omitempty"`
 }
 
 // ReserveResponse is the response for POST /reserve
@@ -49,6 +49,22 @@ type DeployRequest struct {
 	ReservationID   string               `json:"reservation_id,omitempty"`
 	MinProviderTier string               `json:"min_provider_tier,omitempty"`
 	Spot            bool                 `json:"spot,omitempty"`
+
+	// E2E exec encryption (optional). When the browser wants encrypted exec it
+	// fetches the provider's stable X25519 public key, generates a fresh 32-byte
+	// exec_key, ECIES-seals it to that key, and sends the resulting envelope
+	// below. When these are omitted the daemon injects no exec-agent and exec
+	// falls back to the legacy plaintext PTY — identical to prior behavior. This
+	// mirrors the CLI (unix-socket) path post-SEC-10 so browser-exec is E2E
+	// encrypted too.
+	EncryptedExecKey         []byte `json:"encrypted_exec_key,omitempty"`          // ECIES envelope ciphertext
+	ExecKeyNonce             []byte `json:"exec_key_nonce,omitempty"`              // GCM nonce (also prefixed in ciphertext)
+	RequesterEphemeralPubKey []byte `json:"requester_ephemeral_pub_key,omitempty"` // Sender's ephemeral X25519 public key (32 bytes)
+	DeployNonce              string `json:"deploy_nonce,omitempty"`                // Hex-encoded deploy nonce for exec_key derivation
+
+	// ExposePorts lists container ports to expose publicly via ingress. Required
+	// so a browser deploy can request HTTP exposure the same way the CLI can.
+	ExposePorts []client.ExposedPort `json:"expose_ports,omitempty"`
 }
 
 // DeployResponse is the response for POST /deploy
@@ -59,6 +75,12 @@ type DeployResponse struct {
 	Regions      []string  `json:"regions"`
 	ReplicaCount int       `json:"replica_count"`
 	CreatedAt    time.Time `json:"created_at"`
+	// ExecAgentEnabled tells the browser whether the container has an E2E exec
+	// agent (and thus whether the exec WebSocket must do the KEY_INIT/KEY_ACK
+	// handshake). DeployNonce is the HKDF salt the browser stores to re-derive
+	// the exec_key for that handshake. Both are echoed straight from the daemon.
+	ExecAgentEnabled bool   `json:"exec_agent_enabled,omitempty"`
+	DeployNonce      string `json:"deploy_nonce,omitempty"`
 }
 
 // CloneRequest matches POST /clone
@@ -139,11 +161,11 @@ type RestoreResponse struct {
 
 // ThreatResponse matches GET /threat
 type ThreatResponse struct {
-	Score          float64         `json:"score"`
-	Level          string          `json:"level"`
-	ActiveSignals  []SignalInfo    `json:"active_signals"`
-	Recommendation string          `json:"recommendation"`
-	Timestamp      time.Time       `json:"timestamp"`
+	Score          float64      `json:"score"`
+	Level          string       `json:"level"`
+	ActiveSignals  []SignalInfo `json:"active_signals"`
+	Recommendation string       `json:"recommendation"`
+	Timestamp      time.Time    `json:"timestamp"`
 }
 
 // SignalInfo is a simplified signal for API response
@@ -156,9 +178,9 @@ type SignalInfo struct {
 
 // AggregatedCapacity contains aggregated node resource capacity
 type AggregatedCapacity struct {
-	CPUTotal       int     `json:"cpu_total"`
-	MemoryTotalGB  int     `json:"memory_total_gb"`
-	StorageTotalGB int     `json:"storage_total_gb"`
+	CPUTotal       int `json:"cpu_total"`
+	MemoryTotalGB  int `json:"memory_total_gb"`
+	StorageTotalGB int `json:"storage_total_gb"`
 
 	CPUUsed       int     `json:"cpu_used"`
 	MemoryUsedGB  float64 `json:"memory_used_gb"`
@@ -186,21 +208,21 @@ type SecurityStatus struct {
 
 // NodeProfile represents a known node in the network
 type NodeProfile struct {
-	NodeID           string    `json:"node_id"`
-	Address          string    `json:"address,omitempty"`
-	WalletAddress    string    `json:"wallet_address,omitempty"`
-	Region           string    `json:"region"`
-	Country          string    `json:"country,omitempty"`
-	Online           bool      `json:"online"`
-	LastSeen         time.Time `json:"last_seen"`
+	NodeID           string          `json:"node_id"`
+	Address          string          `json:"address,omitempty"`
+	WalletAddress    string          `json:"wallet_address,omitempty"`
+	Region           string          `json:"region"`
+	Country          string          `json:"country,omitempty"`
+	Online           bool            `json:"online"`
+	LastSeen         time.Time       `json:"last_seen"`
 	Capacity         CapacityProfile `json:"capacity"`
-	Tier             string    `json:"tier"`
-	Role             string    `json:"role"`
-	ReputationScore  int       `json:"reputation_score"`
-	StakingAmount    uint64    `json:"staking_amount"`
-	ActiveContainers int       `json:"active_containers"`
-	EncryptedCount   int       `json:"encrypted_containers"`
-	Version          string    `json:"version,omitempty"`
+	Tier             string          `json:"tier"`
+	Role             string          `json:"role"`
+	ReputationScore  int             `json:"reputation_score"`
+	StakingAmount    uint64          `json:"staking_amount"`
+	ActiveContainers int             `json:"active_containers"`
+	EncryptedCount   int             `json:"encrypted_containers"`
+	Version          string          `json:"version,omitempty"`
 
 	// Admin-assigned metadata
 	Badges  []string `json:"badges,omitempty"`
@@ -430,12 +452,12 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 			TotalNodes:     1,
 		}
 		response.Security = &SecurityStatus{
-			TLSVersion:          "1.3",
-			EncryptionAlgo:      "AES-256-GCM",
-			SeccompEnabled:      true,
-			TorEnabled:          cfg.Tor.Enabled,
-			SEVSNPSupported:     cfg.Node.Provider.Hardware.SEVSNPSupported,
-			SEVSNPActive:        cfg.Node.Provider.Hardware.SEVSNPLevel == "snp",
+			TLSVersion:      "1.3",
+			EncryptionAlgo:  "AES-256-GCM",
+			SeccompEnabled:  true,
+			TorEnabled:      cfg.Tor.Enabled,
+			SEVSNPSupported: cfg.Node.Provider.Hardware.SEVSNPSupported,
+			SEVSNPActive:    cfg.Node.Provider.Hardware.SEVSNPLevel == "snp",
 		}
 		// Map config hardware to API hardware profile
 		cfgHW := cfg.Node.Provider.Hardware
@@ -513,24 +535,7 @@ func (s *Server) handleDeploy(w http.ResponseWriter, r *http.Request) {
 
 	// Forward to daemon via bridge
 	if s.daemonBridge != nil {
-		daemonReq := &client.DeployRequest{
-			Image:           req.Image,
-			CodeHash:        req.CodeHash,
-			TorOnly:         req.TorOnly,
-			OnionService:    req.OnionService,
-			ReservationID:   req.ReservationID,
-			Owner:           wallet,
-			MinProviderTier: req.MinProviderTier,
-			Spot:            req.Spot,
-		}
-		if req.Resources.CPUQuota > 0 || req.Resources.MemoryLimit > 0 {
-			daemonReq.Resources = &client.ResourceLimits{
-				CPUShares:   req.Resources.CPUQuota,
-				MemoryMB:    req.Resources.MemoryLimit / (1024 * 1024), // Convert bytes to MB
-				StorageMB:   req.Resources.DiskLimit / (1024 * 1024),   // Convert bytes to MB
-				NetworkMbps: int(req.Resources.NetworkBW / 125000),     // Convert bytes/sec to Mbps
-			}
-		}
+		daemonReq := buildDaemonDeployRequest(&req, wallet)
 
 		result, err := s.daemonBridge.Deploy(daemonReq)
 		if err != nil {
@@ -541,20 +546,65 @@ func (s *Server) handleDeploy(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		response := DeployResponse{
-			ContainerID:  result.ContainerID,
-			Status:       result.Status,
-			OnionAddress: result.OnionAddress,
-			Regions:      result.Regions,
-			ReplicaCount: result.ReplicaCount,
-			CreatedAt:    result.CreatedAt,
-		}
-		s.writeJSON(w, http.StatusCreated, response)
+		s.writeJSON(w, http.StatusCreated, buildDeployResponse(result))
 		return
 	}
 
 	// Daemon bridge not available — cannot deploy
 	s.writeError(w, http.StatusServiceUnavailable, "daemon not connected: cannot process deployment")
+}
+
+// buildDaemonDeployRequest maps the public REST DeployRequest onto the daemon
+// client DeployRequest. It is a pure function (no I/O) so the field mapping —
+// in particular the E2E exec envelope and the exposed-ports plumbing — can be
+// unit-tested without a live daemon. The exec envelope fields carry only
+// ECIES-sealed ciphertext / public material; when the caller omits them the
+// daemon injects no exec-agent (legacy plaintext-exec behavior).
+func buildDaemonDeployRequest(req *DeployRequest, wallet string) *client.DeployRequest {
+	daemonReq := &client.DeployRequest{
+		Image:           req.Image,
+		CodeHash:        req.CodeHash,
+		TorOnly:         req.TorOnly,
+		OnionService:    req.OnionService,
+		ReservationID:   req.ReservationID,
+		Owner:           wallet,
+		MinProviderTier: req.MinProviderTier,
+		Spot:            req.Spot,
+		// E2E exec envelope: forward the sealed exec_key so a container deployed
+		// through the REST API gets the SAME E2E-encrypted exec the CLI path
+		// provides (post-SEC-10).
+		EncryptedExecKey:         req.EncryptedExecKey,
+		ExecKeyNonce:             req.ExecKeyNonce,
+		RequesterEphemeralPubKey: req.RequesterEphemeralPubKey,
+		DeployNonce:              req.DeployNonce,
+		ExposePorts:              req.ExposePorts,
+	}
+	if req.Resources.CPUQuota > 0 || req.Resources.MemoryLimit > 0 {
+		daemonReq.Resources = &client.ResourceLimits{
+			CPUShares:   req.Resources.CPUQuota,
+			MemoryMB:    req.Resources.MemoryLimit / (1024 * 1024), // Convert bytes to MB
+			StorageMB:   req.Resources.DiskLimit / (1024 * 1024),   // Convert bytes to MB
+			NetworkMbps: int(req.Resources.NetworkBW / 125000),     // Convert bytes/sec to Mbps
+		}
+	}
+	return daemonReq
+}
+
+// buildDeployResponse maps the daemon client DeployResponse back onto the public
+// REST DeployResponse, echoing ExecAgentEnabled + DeployNonce so the browser can
+// decide whether the exec WebSocket must perform the KEY_INIT/KEY_ACK handshake
+// and store the nonce needed to re-derive the exec_key.
+func buildDeployResponse(result *client.DeployResponse) DeployResponse {
+	return DeployResponse{
+		ContainerID:      result.ContainerID,
+		Status:           result.Status,
+		OnionAddress:     result.OnionAddress,
+		Regions:          result.Regions,
+		ReplicaCount:     result.ReplicaCount,
+		CreatedAt:        result.CreatedAt,
+		ExecAgentEnabled: result.ExecAgentEnabled,
+		DeployNonce:      result.DeployNonce,
+	}
 }
 
 // handleReserve handles POST /v1/reserve
@@ -1168,9 +1218,9 @@ type BotRequest struct {
 
 // ResourceRequest is resource configuration in requests
 type ResourceRequest struct {
-	CPUShares  int `json:"cpu_shares,omitempty"`
-	MemoryMB   int `json:"memory_mb,omitempty"`
-	StorageMB  int `json:"storage_mb,omitempty"`
+	CPUShares   int `json:"cpu_shares,omitempty"`
+	MemoryMB    int `json:"memory_mb,omitempty"`
+	StorageMB   int `json:"storage_mb,omitempty"`
 	NetworkMbps int `json:"network_mbps,omitempty"`
 }
 
@@ -1457,8 +1507,8 @@ func (s *Server) handleRuntimeReserve(w http.ResponseWriter, r *http.Request) {
 		Region:    req.Region,
 		ExpiresAt: time.Now().Add(time.Duration(durationHours) * time.Hour),
 		Resources: &ResourceRequest{
-			CPUShares:  req.MinCPUShares,
-			MemoryMB:   req.MinMemoryMB,
+			CPUShares: req.MinCPUShares,
+			MemoryMB:  req.MinMemoryMB,
 		},
 	}
 
@@ -1541,15 +1591,15 @@ type DeploymentRequest struct {
 
 // DeploymentResponse is the response for deployment operations
 type DeploymentResponse struct {
-	ID           string    `json:"id"`
-	BotID        string    `json:"bot_id"`
-	RuntimeID    string    `json:"runtime_id"`
-	ContainerID  string    `json:"container_id"`
-	Status       string    `json:"status"`
-	Region       string    `json:"region"`
-	NodeID       string    `json:"node_id"`
-	OnionAddress string    `json:"onion_address,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
+	ID           string     `json:"id"`
+	BotID        string     `json:"bot_id"`
+	RuntimeID    string     `json:"runtime_id"`
+	ContainerID  string     `json:"container_id"`
+	Status       string     `json:"status"`
+	Region       string     `json:"region"`
+	NodeID       string     `json:"node_id"`
+	OnionAddress string     `json:"onion_address,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
 	StartedAt    *time.Time `json:"started_at,omitempty"`
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -37,9 +37,9 @@ type APIResponse struct {
 
 // AggregatedCapacity contains aggregated node resource capacity
 type AggregatedCapacity struct {
-	CPUTotal       int     `json:"cpu_total"`
-	MemoryTotalGB  int     `json:"memory_total_gb"`
-	StorageTotalGB int     `json:"storage_total_gb"`
+	CPUTotal       int `json:"cpu_total"`
+	MemoryTotalGB  int `json:"memory_total_gb"`
+	StorageTotalGB int `json:"storage_total_gb"`
 
 	CPUUsed       int     `json:"cpu_used"`
 	MemoryUsedGB  float64 `json:"memory_used_gb"`
@@ -67,21 +67,21 @@ type SecurityStatus struct {
 
 // NodeProfile represents a known node in the network
 type NodeProfile struct {
-	NodeID           string    `json:"node_id"`
-	Address          string    `json:"address,omitempty"`
-	WalletAddress    string    `json:"wallet_address,omitempty"`
-	Region           string    `json:"region"`
-	Country          string    `json:"country,omitempty"`
-	Online           bool      `json:"online"`
-	LastSeen         time.Time `json:"last_seen"`
+	NodeID           string          `json:"node_id"`
+	Address          string          `json:"address,omitempty"`
+	WalletAddress    string          `json:"wallet_address,omitempty"`
+	Region           string          `json:"region"`
+	Country          string          `json:"country,omitempty"`
+	Online           bool            `json:"online"`
+	LastSeen         time.Time       `json:"last_seen"`
 	Capacity         CapacityProfile `json:"capacity"`
-	Tier             string    `json:"tier"`
-	Role             string    `json:"role"`
-	ReputationScore  int       `json:"reputation_score"`
-	StakingAmount    uint64    `json:"staking_amount"`
-	ActiveContainers int       `json:"active_containers"`
-	EncryptedCount   int       `json:"encrypted_containers"`
-	Version          string    `json:"version,omitempty"`
+	Tier             string          `json:"tier"`
+	Role             string          `json:"role"`
+	ReputationScore  int             `json:"reputation_score"`
+	StakingAmount    uint64          `json:"staking_amount"`
+	ActiveContainers int             `json:"active_containers"`
+	EncryptedCount   int             `json:"encrypted_containers"`
+	Version          string          `json:"version,omitempty"`
 
 	// Admin-assigned metadata
 	Badges  []string `json:"badges,omitempty"`
@@ -171,7 +171,7 @@ type DeployRequest struct {
 	WaitForReplicas bool            `json:"wait_for_replicas,omitempty"` // If true, wait for at least 1 replica ack before returning
 	ReservationID   string          `json:"reservation_id,omitempty"`    // On-chain escrow reservation ID (user-created)
 	Owner           string          `json:"owner,omitempty"`             // Wallet address of the deployer
-	MinProviderTier  string          `json:"min_provider_tier,omitempty"` // Minimum provider tier ("confidential", "standard", "dev")
+	MinProviderTier string          `json:"min_provider_tier,omitempty"` // Minimum provider tier ("confidential", "standard", "dev")
 	// E2E exec encryption (optional). The exec_key is sealed to the provider's
 	// stable X25519 public key via ECIES (ephemeral-static X25519 -> HKDF-SHA256
 	// -> AES-256-GCM). The fields below carry the resulting envelope.
@@ -193,6 +193,13 @@ type DeployResponse struct {
 	ReplicaCount    int       `json:"replica_count"` // Number of successful replica acks received
 	PublicURLs      []string  `json:"public_urls,omitempty"`
 	CreatedAt       time.Time `json:"created_at,omitempty"`
+	// ExecAgentEnabled reports whether the deploy carried a valid E2E exec
+	// envelope and the exec-agent was injected. Callers use this to decide
+	// whether the exec session must perform the KEY_INIT/KEY_ACK handshake.
+	ExecAgentEnabled bool `json:"exec_agent_enabled,omitempty"`
+	// DeployNonce is the hex-encoded HKDF salt used to derive the exec_key.
+	// Required to re-derive the key for the E2E exec handshake. Non-secret.
+	DeployNonce string `json:"deploy_nonce,omitempty"`
 }
 
 // ContainerInfo contains container information
@@ -213,7 +220,7 @@ type ContainerInfo struct {
 
 // HealthResponse contains health information
 type HealthResponse struct {
-	Healthy             bool           `json:"healthy"`
+	Healthy             bool             `json:"healthy"`
 	UnhealthyContainers map[string][]int `json:"unhealthy_containers,omitempty"`
 }
 

--- a/internal/daemon/api_handlers.go
+++ b/internal/daemon/api_handlers.go
@@ -151,14 +151,16 @@ func (s *APIServer) handleDeploy(ctx context.Context, req *APIRequest) *APIRespo
 	}
 
 	response := DeployResponse{
-		ContainerID:     result.Deployment.ID,
-		Status:          string(result.Deployment.Status),
-		OnionAddress:    result.Deployment.OnionAddress,
-		EncryptedVolume: result.Deployment.EncryptedVolume,
-		Regions:         result.Deployment.Regions,
-		Locations:       result.Deployment.Locations,
-		ReplicaCount:    result.ReplicaCount,
-		PublicURLs:      result.Deployment.PublicURLs,
+		ContainerID:      result.Deployment.ID,
+		Status:           string(result.Deployment.Status),
+		OnionAddress:     result.Deployment.OnionAddress,
+		EncryptedVolume:  result.Deployment.EncryptedVolume,
+		Regions:          result.Deployment.Regions,
+		Locations:        result.Deployment.Locations,
+		ReplicaCount:     result.ReplicaCount,
+		PublicURLs:       result.Deployment.PublicURLs,
+		ExecAgentEnabled: result.Deployment.ExecAgentEnabled,
+		DeployNonce:      result.Deployment.DeployNonce,
 	}
 
 	return &APIResponse{

--- a/internal/daemon/api_types.go
+++ b/internal/daemon/api_types.go
@@ -88,7 +88,7 @@ type StatusResponse struct {
 type DeployRequest struct {
 	Image           string               `json:"image"`
 	Resources       types.ResourceLimits `json:"resources,omitempty"`
-	Duration        string               `json:"duration,omitempty"`          // Job duration (e.g. "24h", "720h"); default: 720h (30 days)
+	Duration        string               `json:"duration,omitempty"` // Job duration (e.g. "24h", "720h"); default: 720h (30 days)
 	TorOnly         bool                 `json:"tor_only"`
 	OnionService    bool                 `json:"onion_service"`
 	OnionPort       int                  `json:"onion_port,omitempty"`        // Port to expose via Tor (default: 80)
@@ -103,10 +103,10 @@ type DeployRequest struct {
 	// provider's stable X25519 public key using ECIES (ephemeral-static X25519 ->
 	// HKDF-SHA256 -> AES-256-GCM). The envelope below carries everything the
 	// daemon needs to unwrap it with its stable private key.
-	EncryptedExecKey         []byte `json:"encrypted_exec_key,omitempty"`           // ECIES envelope ciphertext: gcm_nonce(12) || ciphertext || tag(16)
-	ExecKeyNonce             []byte `json:"exec_key_nonce,omitempty"`               // GCM nonce (also prefixed in EncryptedExecKey; carried for transport parity)
-	RequesterEphemeralPubKey []byte `json:"requester_ephemeral_pub_key,omitempty"`  // Sender's ephemeral X25519 public key (32 bytes)
-	DeployNonce              string `json:"deploy_nonce,omitempty"`                 // Deploy nonce used to derive exec_key
+	EncryptedExecKey         []byte `json:"encrypted_exec_key,omitempty"`          // ECIES envelope ciphertext: gcm_nonce(12) || ciphertext || tag(16)
+	ExecKeyNonce             []byte `json:"exec_key_nonce,omitempty"`              // GCM nonce (also prefixed in EncryptedExecKey; carried for transport parity)
+	RequesterEphemeralPubKey []byte `json:"requester_ephemeral_pub_key,omitempty"` // Sender's ephemeral X25519 public key (32 bytes)
+	DeployNonce              string `json:"deploy_nonce,omitempty"`                // Deploy nonce used to derive exec_key
 
 	// Spot pricing (optional — lower cost, preemptible)
 	Spot bool `json:"spot,omitempty"`
@@ -118,9 +118,9 @@ type DeployRequest struct {
 	// All fields zero/empty => no verification (identical to legacy behavior).
 	// RequireSignature only takes effect when at least one TrustedPublisher is
 	// provided, otherwise it would deny-all (see DeployRequest.toTrustPolicy).
-	RequireSignature  bool               `json:"require_signature,omitempty"`  // Enforce a valid signature before create
-	TrustedPublishers []string           `json:"trusted_publishers,omitempty"` // Hex-encoded Ed25519 pubkeys allowed to sign
-	ImageSignature    *ImageSignatureSpec `json:"image_signature,omitempty"`   // Caller-supplied signature for the image digest
+	RequireSignature  bool                `json:"require_signature,omitempty"`  // Enforce a valid signature before create
+	TrustedPublishers []string            `json:"trusted_publishers,omitempty"` // Hex-encoded Ed25519 pubkeys allowed to sign
+	ImageSignature    *ImageSignatureSpec `json:"image_signature,omitempty"`    // Caller-supplied signature for the image digest
 
 	// R4 — image vulnerability scan policy (optional). When unset, the daemon's
 	// default scan policy applies (block HIGH/CRITICAL, never RequireScan).
@@ -174,8 +174,17 @@ type DeployResponse struct {
 	EncryptedVolume string            `json:"encrypted_volume,omitempty"`
 	Regions         []string          `json:"regions"`
 	Locations       []ReplicaLocation `json:"locations,omitempty"`
-	ReplicaCount    int               `json:"replica_count"`             // Number of successful replica acks received
-	PublicURLs      []string          `json:"public_urls,omitempty"`     // Public URLs if ports are exposed
+	ReplicaCount    int               `json:"replica_count"`         // Number of successful replica acks received
+	PublicURLs      []string          `json:"public_urls,omitempty"` // Public URLs if ports are exposed
+	// ExecAgentEnabled reports whether the deploy carried a valid E2E exec
+	// envelope and the exec-agent was injected. The caller (CLI or browser) uses
+	// this to decide whether the exec WebSocket must perform the KEY_INIT/KEY_ACK
+	// handshake and encrypt terminal I/O.
+	ExecAgentEnabled bool `json:"exec_agent_enabled,omitempty"`
+	// DeployNonce is the hex-encoded nonce used as the HKDF salt when deriving
+	// the container's exec_key; required to re-derive the key for the exec
+	// handshake. Non-secret.
+	DeployNonce string `json:"deploy_nonce,omitempty"`
 }
 
 // LogsRequest contains log streaming parameters
@@ -341,23 +350,23 @@ type MoltDeployResponse struct {
 
 // MoltInfo describes a deployed Molt for list/get responses.
 type MoltInfo struct {
-	ID           string                        `json:"id"`
-	ModuleCID    string                        `json:"module_cid"`
-	Status       string                        `json:"status"`
-	CreatedAt    time.Time                     `json:"created_at"`
-	Owner        string                        `json:"owner,omitempty"`
+	ID            string                       `json:"id"`
+	ModuleCID     string                       `json:"module_cid"`
+	Status        string                       `json:"status"`
+	CreatedAt     time.Time                    `json:"created_at"`
+	Owner         string                       `json:"owner,omitempty"`
 	MemoryLimitMB uint32                       `json:"memory_limit_mb,omitempty"`
-	TimeoutMs    int                           `json:"timeout_ms,omitempty"`
-	Metrics      *types.MoltDeploymentMetrics  `json:"metrics,omitempty"`
+	TimeoutMs     int                          `json:"timeout_ms,omitempty"`
+	Metrics       *types.MoltDeploymentMetrics `json:"metrics,omitempty"`
 }
 
 // MoltInvokeRequest is the API request to invoke a Molt directly.
 type MoltInvokeRequest struct {
 	DeploymentID string            `json:"deployment_id"`
-	Method       string            `json:"method"`                // HTTP method (default: GET)
-	Path         string            `json:"path"`                  // HTTP path (default: /)
+	Method       string            `json:"method"` // HTTP method (default: GET)
+	Path         string            `json:"path"`   // HTTP path (default: /)
 	Headers      map[string]string `json:"headers,omitempty"`
-	Body         []byte            `json:"body,omitempty"`        // Request body
+	Body         []byte            `json:"body,omitempty"` // Request body
 }
 
 // MoltInvokeResponse is the API response from a Molt invocation.

--- a/internal/daemon/container_manager.go
+++ b/internal/daemon/container_manager.go
@@ -689,7 +689,21 @@ func (cm *ContainerManager) deployLocally(ctx context.Context, deploymentID stri
 	if len(req.EncryptedExecKey) > 0 {
 		mounts, keyPath, err := cm.prepareExecAgent(deploymentID, req.EncryptedExecKey, req.RequesterEphemeralPubKey)
 		if err != nil {
-			logging.Warn("failed to prepare exec-agent, continuing without E2E exec",
+			// SECURITY-RELEVANT DOWNGRADE: an exec envelope WAS supplied but
+			// could not be unwrapped (tampered/misconfigured envelope or wrong
+			// provider key). We fail open to the legacy plaintext-exec PTY and
+			// signal the downgrade via deployment.ExecAgentEnabled=false in the
+			// response, so a client that checks the flag can refuse. The
+			// requester sealed a key expecting E2E exec; this is more likely
+			// tampering/misconfig than an intentional plaintext request.
+			//
+			// TODO(RUN-01-execmetric, deferred LOW): emit a dedicated counter
+			// (e.g. exec_agent_prepare_failures_total) on this path so a fleet
+			// of silent downgrades is observable, not just log-visible. Tracked
+			// alongside the R5 "fail-open encrypt has only a Warn" gap in
+			// daemon-todo.md; deferred here because it requires threading the
+			// metrics registry into ContainerManager (out of scope for this PR).
+			logging.Warn("SECURITY: exec envelope supplied but unwrap failed; downgrading to plaintext exec (E2E exec disabled for this deployment)",
 				logging.ContainerID(deploymentID),
 				logging.Err(err))
 		} else {
@@ -768,7 +782,7 @@ func (cm *ContainerManager) deployLocally(ctx context.Context, deploymentID stri
 	// P1-10: Track deploy success
 	cm.deploysTotal.Add(1)
 
-	// Set up networking for exposed ports
+	// Set up networking for exposed ports.
 	if len(req.ExposePorts) > 0 && cm.networkManager != nil {
 		netPorts := convertExposedPorts(req.ExposePorts)
 		containerNet, err := cm.networkManager.SetupNetwork(deploymentID, netPorts)
@@ -778,11 +792,6 @@ func (cm *ContainerManager) deployLocally(ctx context.Context, deploymentID stri
 				logging.Err(err))
 		} else {
 			deployment.ExposedPorts = req.ExposePorts
-			// R13/R14: apply per-deployment network/egress policy once the
-			// container IP is known. nil/empty policy => allow-all (no-op).
-			// Real nft enforcement is a Linux-only stub; off-Linux this only
-			// records intent.
-			cm.applyNetworkPolicy(deploymentID, containerNet.ContainerIP(), req.NetworkPolicy)
 			// no-op: ingress domain currently hardcoded; future versions may
 			// derive it from cm.node.nodeInfo when config plumbing is added.
 			ingressDomain := "moltbunker.dev"
@@ -799,7 +808,53 @@ func (cm *ContainerManager) deployLocally(ctx context.Context, deploymentID stri
 		}
 	}
 
+	// R13/R14: apply the per-deployment network/egress policy for EVERY primary
+	// deploy, not just port-exposing ones. A no-port container still shares the
+	// 10.88.0.0/16 bridge and must get its lateral-isolation + egress rules.
+	// enforceDeployNetworkPolicy allocates a network (with no DNAT rules) when
+	// none was set up above so the policy has an IP to key on. A nil/empty policy
+	// is a no-op (allow-all), matching legacy behavior.
+	cm.enforceDeployNetworkPolicy(deploymentID, req.NetworkPolicy)
+
 	return nil
+}
+
+// enforceDeployNetworkPolicy applies the R13/R14 network policy for a deployment
+// running on this node. It resolves the container IP from any network created
+// for exposed ports; if none exists (no-port deploy or replica) it sets up a
+// port-less network purely to allocate an IP. When the policy spec is nil the
+// whole thing is skipped (applyNetworkPolicy treats nil as allow-all/no-op), so
+// no-port deploys without a policy incur no extra IP allocation.
+func (cm *ContainerManager) enforceDeployNetworkPolicy(deploymentID string, spec *NetworkPolicySpec) {
+	if spec == nil || cm.policyEnforcer == nil {
+		return
+	}
+	containerIP := cm.resolveContainerIP(deploymentID)
+	cm.applyNetworkPolicy(deploymentID, containerIP, spec)
+}
+
+// resolveContainerIP returns the intra-host IP for a deployment. It prefers an
+// already-allocated ContainerNetwork; failing that it provisions a port-less
+// network (no DNAT rules) so a policy can be keyed on the allocated IP. Returns
+// "" if no IP can be obtained — applyNetworkPolicy logs and skips in that case.
+func (cm *ContainerManager) resolveContainerIP(deploymentID string) string {
+	if cm.networkManager == nil {
+		return ""
+	}
+	if net, ok := cm.networkManager.GetNetwork(deploymentID); ok {
+		return net.ContainerIP()
+	}
+	// No network yet (no-port primary or replica): allocate one with no ports so
+	// the container gets an intra-host IP for policy enforcement. Released by
+	// TeardownNetwork on stop.
+	net, err := cm.networkManager.SetupNetwork(deploymentID, nil)
+	if err != nil {
+		logging.Warn("network setup for policy IP failed",
+			logging.ContainerID(deploymentID),
+			logging.Err(err))
+		return ""
+	}
+	return net.ContainerIP()
 }
 
 // prepareExecAgent unwraps the ECIES-sealed exec key with the daemon's stable

--- a/internal/daemon/replication.go
+++ b/internal/daemon/replication.go
@@ -386,6 +386,14 @@ func (cm *ContainerManager) deployReplica(ctx context.Context, deployment *Deplo
 	deployment.StartedAt = time.Now()
 	cm.mu.Unlock()
 
+	// R13/R14: replicas get the same per-deployment network/egress policy the
+	// originator chose (it gossips on the Deployment struct). Previously replicas
+	// received zero enforcement because they expose no ports and never called
+	// SetupNetwork. enforceDeployNetworkPolicy provisions a port-less network to
+	// allocate an intra-host IP, then applies the policy. A nil policy is a no-op
+	// (allow-all), so this incurs no extra work for deployments without a policy.
+	cm.enforceDeployNetworkPolicy(deployment.ID, deployment.NetworkPolicy)
+
 	logging.Info("replica container started successfully",
 		logging.ContainerID(deployment.ID))
 

--- a/internal/daemon/security_policy_test.go
+++ b/internal/daemon/security_policy_test.go
@@ -182,3 +182,70 @@ func TestApplyNetworkPolicy_RecordsSuppliedPolicy(t *testing.T) {
 		t.Error("removeNetworkPolicy should drop the recorded policy")
 	}
 }
+
+// TestEnforceDeployNetworkPolicy_NoPortDeploy verifies the no-port / replica
+// path: enforceDeployNetworkPolicy allocates a port-less network to obtain a
+// container IP and then applies the policy, so a container with no exposed
+// ports still gets R13/R14 enforcement.
+func TestEnforceDeployNetworkPolicy_NoPortDeploy(t *testing.T) {
+	store := networking.NewPolicyStore()
+	enf := networking.NewNftPolicyEnforcer(store)
+	cm := &ContainerManager{
+		policyStore:    store,
+		policyEnforcer: enf,
+		networkManager: networking.NewNetworkManager(),
+	}
+
+	spec := &NetworkPolicySpec{EgressDeny: true}
+	cm.enforceDeployNetworkPolicy("dep-noport", spec)
+
+	got, ok := store.Get("dep-noport")
+	if !ok {
+		t.Fatal("no-port deploy should still have its policy recorded in the store")
+	}
+	if got.EgressMode != networking.EgressDefaultDeny {
+		t.Errorf("recorded EgressMode = %v, want EgressDefaultDeny", got.EgressMode)
+	}
+	// A port-less network must have been provisioned so the policy has an IP.
+	if _, ok := cm.networkManager.GetNetwork("dep-noport"); !ok {
+		t.Error("enforceDeployNetworkPolicy should provision a network for a no-port deploy")
+	}
+}
+
+// TestEnforceDeployNetworkPolicy_NilPolicyNoNetwork verifies that a deploy with
+// no policy does NOT provision a port-less network (no extra IP consumption)
+// and records nothing — identical to legacy allow-all behavior.
+func TestEnforceDeployNetworkPolicy_NilPolicyNoNetwork(t *testing.T) {
+	store := networking.NewPolicyStore()
+	enf := networking.NewNftPolicyEnforcer(store)
+	cm := &ContainerManager{
+		policyStore:    store,
+		policyEnforcer: enf,
+		networkManager: networking.NewNetworkManager(),
+	}
+
+	cm.enforceDeployNetworkPolicy("dep-nopolicy", nil)
+
+	if _, ok := cm.networkManager.GetNetwork("dep-nopolicy"); ok {
+		t.Error("a nil policy must not provision a network (no extra IP allocation)")
+	}
+	if _, ok := store.Get("dep-nopolicy"); ok {
+		t.Error("a nil policy must not be recorded")
+	}
+}
+
+// TestResolveContainerIP_ReusesExistingNetwork verifies that when a network
+// already exists (port-exposing deploy) resolveContainerIP returns its IP
+// rather than provisioning a second one.
+func TestResolveContainerIP_ReusesExistingNetwork(t *testing.T) {
+	cm := &ContainerManager{networkManager: networking.NewNetworkManager()}
+
+	first, err := cm.networkManager.SetupNetwork("dep-existing", []networking.ExposedPort{{ContainerPort: 80}})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	got := cm.resolveContainerIP("dep-existing")
+	if got != first.ContainerIP() {
+		t.Errorf("resolveContainerIP = %q, want existing network IP %q", got, first.ContainerIP())
+	}
+}

--- a/internal/doctor/checker_security_tools.go
+++ b/internal/doctor/checker_security_tools.go
@@ -1,0 +1,185 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// checker_security_tools.go — RUN-01 doctor checks for the host tooling that the
+// expose-to-internet security gates depend on. Each gate (R3 image-signature
+// verify, R4 CVE scan, R13/R14 nftables enforcement) is built to FAIL OPEN when
+// its tool is missing: rather than break a deploy, the gate silently no-ops.
+// That is the right runtime default, but it means an operator can enable a gate
+// in config and get zero protection with no signal. These checkers turn that
+// silent no-op into a visible `moltbunker doctor` Warning.
+//
+// Severity is Warning (not Error): a missing tool only disables an opt-in gate;
+// it never breaks a working node. This matches buildImageScanner's fail-open
+// philosophy.
+
+// providerRoles is the role set for tooling that only matters on nodes that run
+// containers. Pure requesters never enforce these gates.
+func providerRoles() []string { return []string{"provider", "hybrid"} }
+
+// runVersion runs `<bin> <args...>` and returns the trimmed first line of
+// combined output, or "" if the command fails. Used to confirm a tool actually
+// responds (not just that the binary exists on PATH).
+func runVersion(ctx context.Context, bin string, args ...string) string {
+	// #nosec G204 -- exec.CommandContext (no shell); bin is a path already
+	// resolved via exec.LookPath by the caller and args are package constants.
+	out, err := exec.CommandContext(ctx, bin, args...).CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	line := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)
+	if len(line) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(line[0])
+}
+
+// ---------------------------------------------------------------------------
+// TrivyChecker — R4 image vulnerability scanning.
+// ---------------------------------------------------------------------------
+
+// TrivyChecker verifies the trivy image scanner is installed. The R4 CVE gate
+// (config.Security image scanning) silently no-ops to a NoopScanner when trivy
+// is absent, so this surfaces the missing dependency.
+type TrivyChecker struct{}
+
+func NewTrivyChecker() *TrivyChecker { return &TrivyChecker{} }
+
+func (c *TrivyChecker) Name() string       { return "trivy (image scanner)" }
+func (c *TrivyChecker) Category() Category { return CategoryRuntime }
+func (c *TrivyChecker) CanFix() bool       { return true }
+func (c *TrivyChecker) Roles() []string    { return providerRoles() }
+
+func (c *TrivyChecker) Check(ctx context.Context) CheckResult {
+	result := CheckResult{Name: c.Name(), Category: c.Category()}
+
+	path, err := exec.LookPath("trivy")
+	if err != nil {
+		result.Status = StatusWarning
+		result.Fixable = true
+		result.FixPackage = "trivy"
+		result.Message = "trivy not on PATH; the R4 image-scan gate will silently no-op when enabled"
+		result.Details = "Install: https://aquasecurity.github.io/trivy"
+		return result
+	}
+
+	version := runVersion(ctx, path, "--version")
+	result.Status = StatusOK
+	if version != "" {
+		result.Message = "trivy: " + version
+	} else {
+		result.Message = "trivy: installed"
+	}
+	return result
+}
+
+func (c *TrivyChecker) Fix(ctx context.Context, pm PackageManager) error {
+	if runtime.GOOS == "linux" {
+		return fmt.Errorf("install trivy: https://aquasecurity.github.io/trivy")
+	}
+	if pm == nil {
+		return fmt.Errorf("no package manager available to install trivy")
+	}
+	return pm.Install(ctx, "trivy")
+}
+
+// ---------------------------------------------------------------------------
+// NftChecker — R13/R14 nftables network-policy enforcement.
+// ---------------------------------------------------------------------------
+
+// NftChecker verifies the `nft` binary is installed and responds. R13/R14
+// network-policy enforcement pipes rule sets to `nft -f -`; without it the
+// enforcer errors per-deploy (non-fatal) and policy is never installed. On
+// non-Linux platforms nftables does not apply, so the check is Skipped.
+type NftChecker struct{}
+
+func NewNftChecker() *NftChecker { return &NftChecker{} }
+
+func (c *NftChecker) Name() string       { return "nft (nftables)" }
+func (c *NftChecker) Category() Category { return CategoryRuntime }
+func (c *NftChecker) CanFix() bool       { return false }
+func (c *NftChecker) Roles() []string    { return providerRoles() }
+
+func (c *NftChecker) Check(ctx context.Context) CheckResult {
+	result := CheckResult{Name: c.Name(), Category: c.Category()}
+
+	if runtime.GOOS != "linux" {
+		result.Status = StatusSkipped
+		result.Message = "nftables not applicable on this platform"
+		return result
+	}
+
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		result.Status = StatusWarning
+		result.Message = "nft not on PATH; R13/R14 network-policy enforcement will fail per-deploy when a policy is set"
+		result.Details = "Install nftables, e.g. apt install nftables"
+		return result
+	}
+
+	version := runVersion(ctx, path, "--version")
+	if version == "" {
+		result.Status = StatusWarning
+		result.Message = "nft found on PATH but did not respond to --version"
+		result.Details = "Ensure nft is runnable (may require CAP_NET_ADMIN / root at enforcement time)"
+		return result
+	}
+	result.Status = StatusOK
+	result.Message = "nft: " + version
+	return result
+}
+
+func (c *NftChecker) Fix(ctx context.Context, pm PackageManager) error {
+	return fmt.Errorf("nftables installation is platform-specific; install via your distro (e.g. apt install nftables)")
+}
+
+// ---------------------------------------------------------------------------
+// ImageSignatureToolingChecker — R3 image signature verification.
+// ---------------------------------------------------------------------------
+
+// ImageSignatureToolingChecker verifies cosign (sigstore) is installed. R3
+// signature verification can be driven by caller-supplied signatures, but the
+// surrounding tooling/signing workflow relies on cosign; absent it, operators
+// who enable signature requirements get a gate that cannot source signatures.
+type ImageSignatureToolingChecker struct{}
+
+func NewImageSignatureToolingChecker() *ImageSignatureToolingChecker {
+	return &ImageSignatureToolingChecker{}
+}
+
+func (c *ImageSignatureToolingChecker) Name() string       { return "cosign (image signature tooling)" }
+func (c *ImageSignatureToolingChecker) Category() Category { return CategoryRuntime }
+func (c *ImageSignatureToolingChecker) CanFix() bool       { return false }
+func (c *ImageSignatureToolingChecker) Roles() []string    { return providerRoles() }
+
+func (c *ImageSignatureToolingChecker) Check(ctx context.Context) CheckResult {
+	result := CheckResult{Name: c.Name(), Category: c.Category()}
+
+	path, err := exec.LookPath("cosign")
+	if err != nil {
+		result.Status = StatusWarning
+		result.Message = "cosign not on PATH; the R3 signature-verification gate will silently no-op without it"
+		result.Details = "Install cosign: https://docs.sigstore.dev/cosign/installation"
+		return result
+	}
+
+	version := runVersion(ctx, path, "version")
+	result.Status = StatusOK
+	if version != "" {
+		result.Message = "cosign: " + version
+	} else {
+		result.Message = "cosign: installed"
+	}
+	return result
+}
+
+func (c *ImageSignatureToolingChecker) Fix(ctx context.Context, pm PackageManager) error {
+	return fmt.Errorf("install cosign: https://docs.sigstore.dev/cosign/installation")
+}

--- a/internal/doctor/checker_security_tools_test.go
+++ b/internal/doctor/checker_security_tools_test.go
@@ -1,0 +1,121 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// emptyPATH points PATH at an empty temp dir so exec.LookPath finds nothing.
+func emptyPATH(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+// fakeBinOnPATH writes an executable script named `name` that prints `output`
+// and puts its dir on PATH. Returns nothing; the binary is discoverable by
+// exec.LookPath for the duration of the test.
+func fakeBinOnPATH(t *testing.T, name, output string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-binary shim relies on a POSIX shell")
+	}
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho \"" + output + "\"\n"
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil { // #nosec G306 -- test fixture must be executable
+		t.Fatalf("write fake %s: %v", name, err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+func TestTrivyChecker_AbsentReturnsWarning(t *testing.T) {
+	emptyPATH(t)
+	res := NewTrivyChecker().Check(context.Background())
+	if res.Status != StatusWarning {
+		t.Errorf("status = %q, want warning when trivy absent", res.Status)
+	}
+	if !res.Fixable {
+		t.Error("absent trivy should be marked fixable")
+	}
+}
+
+func TestTrivyChecker_PresentReturnsOK(t *testing.T) {
+	fakeBinOnPATH(t, "trivy", "Version: 0.50.0")
+	res := NewTrivyChecker().Check(context.Background())
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q (%s), want ok when trivy present", res.Status, res.Message)
+	}
+	if res.Message == "" {
+		t.Error("present trivy should report a message")
+	}
+}
+
+func TestNftChecker_NonLinuxReturnsSkipped(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("nft check is active on linux; skipped-behavior test is for non-linux")
+	}
+	res := NewNftChecker().Check(context.Background())
+	if res.Status != StatusSkipped {
+		t.Errorf("status = %q, want skipped on non-linux", res.Status)
+	}
+}
+
+func TestImageSignatureToolingChecker_AbsentReturnsWarning(t *testing.T) {
+	emptyPATH(t)
+	res := NewImageSignatureToolingChecker().Check(context.Background())
+	if res.Status != StatusWarning {
+		t.Errorf("status = %q, want warning when cosign absent", res.Status)
+	}
+}
+
+func TestImageSignatureToolingChecker_PresentReturnsOK(t *testing.T) {
+	fakeBinOnPATH(t, "cosign", "GitVersion: v2.2.0")
+	res := NewImageSignatureToolingChecker().Check(context.Background())
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q (%s), want ok when cosign present", res.Status, res.Message)
+	}
+}
+
+// TestSecurityToolCheckers_RoleAware confirms all three checkers are
+// provider/hybrid scoped so pure requesters do not see them.
+func TestSecurityToolCheckers_RoleAware(t *testing.T) {
+	checkers := []RoleAware{
+		NewTrivyChecker(),
+		NewNftChecker(),
+		NewImageSignatureToolingChecker(),
+	}
+	for _, c := range checkers {
+		roles := c.Roles()
+		if len(roles) != 2 {
+			t.Errorf("%T roles = %v, want provider+hybrid", c, roles)
+			continue
+		}
+		want := map[string]bool{"provider": true, "hybrid": true}
+		for _, r := range roles {
+			if !want[r] {
+				t.Errorf("%T unexpected role %q", c, r)
+			}
+		}
+	}
+}
+
+// TestSecurityToolCheckers_Interface confirms basic Checker conformance.
+func TestSecurityToolCheckers_Interface(t *testing.T) {
+	var _ Checker = NewTrivyChecker()
+	var _ Checker = NewNftChecker()
+	var _ Checker = NewImageSignatureToolingChecker()
+
+	if NewTrivyChecker().Category() != CategoryRuntime {
+		t.Error("trivy checker should be runtime category")
+	}
+	// nft/cosign are not auto-fixable.
+	if NewNftChecker().CanFix() {
+		t.Error("nft checker should not be fixable")
+	}
+	if NewImageSignatureToolingChecker().CanFix() {
+		t.Error("cosign checker should not be fixable")
+	}
+}

--- a/internal/doctor/platform_darwin.go
+++ b/internal/doctor/platform_darwin.go
@@ -21,6 +21,12 @@ func (d *Doctor) registerPlatformCheckers() {
 		NewContainerdChecker(),
 		NewIPFSChecker(),
 		NewSocketPermissionChecker(),
+		// RUN-01: expose-to-internet security-gate tooling. trivy/cosign can be
+		// present on darwin dev machines; nft is Skipped on non-Linux but stays
+		// visible in `moltbunker doctor` output.
+		NewTrivyChecker(),                 // R4 image scanning
+		NewNftChecker(),                   // R13/R14 (Skipped on darwin)
+		NewImageSignatureToolingChecker(), // R3 image signature verification
 		// Optional services
 		NewTorChecker(),
 	}

--- a/internal/doctor/platform_linux.go
+++ b/internal/doctor/platform_linux.go
@@ -13,6 +13,12 @@ func (d *Doctor) registerPlatformCheckers() {
 		NewFileDescriptorChecker(),
 		// Provider-only checks (filtered by RoleAware)
 		NewKataRuntimeChecker(),
+		// RUN-01: tooling for the expose-to-internet security gates. Each warns
+		// (not errors) if its binary is absent so an operator does not enable a
+		// gate that then silently no-ops.
+		NewTrivyChecker(),                 // R4 image scanning
+		NewNftChecker(),                   // R13/R14 nftables enforcement
+		NewImageSignatureToolingChecker(), // R3 image signature verification
 	}
 }
 

--- a/internal/networking/networking_test.go
+++ b/internal/networking/networking_test.go
@@ -173,6 +173,36 @@ func TestNetworkManager_SetupTeardown(t *testing.T) {
 	}
 }
 
+func TestSetupNetwork_NilPorts(t *testing.T) {
+	// The no-port / replica path: SetupNetwork is called with no exposed ports
+	// purely to allocate a ContainerNetwork (and thus a container IP) so the
+	// per-deployment network policy can be applied. It must succeed and return a
+	// network with a non-empty ContainerIP.
+	nm := NewNetworkManager()
+
+	net, err := nm.SetupNetwork("dep-x", nil)
+	if err != nil {
+		t.Fatalf("SetupNetwork(nil ports): %v", err)
+	}
+	if net == nil {
+		t.Fatal("network should not be nil for a no-port deployment")
+	}
+	// On non-Linux the fallback network reports 127.0.0.1; on Linux the veth
+	// setup assigns an address. Either way it must be non-empty so policy can be
+	// keyed on it.
+	if runtime.GOOS != "linux" && net.ContainerIP() == "" {
+		t.Error("ContainerIP() should be non-empty after a no-port SetupNetwork")
+	}
+
+	// It must be retrievable and tear down cleanly.
+	if _, ok := nm.GetNetwork("dep-x"); !ok {
+		t.Error("no-port network should be retrievable")
+	}
+	if err := nm.TeardownNetwork("dep-x"); err != nil {
+		t.Fatalf("teardown no-port network: %v", err)
+	}
+}
+
 func TestNetworkManager_TeardownNonexistent(t *testing.T) {
 	nm := NewNetworkManager()
 	// Should not error
@@ -185,7 +215,7 @@ func TestNetworkManager_PortAllocation(t *testing.T) {
 	nm := NewNetworkManager()
 
 	ports := []ExposedPort{
-		{ContainerPort: 8080}, // auto-assign
+		{ContainerPort: 8080},                  // auto-assign
 		{ContainerPort: 9090, HostPort: 30000}, // fixed
 	}
 

--- a/internal/networking/policy.go
+++ b/internal/networking/policy.go
@@ -24,8 +24,42 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 )
+
+// policyTable is the single inet table that holds all moltbunker policy chains.
+// Defined here (platform-agnostic) because ComputeEgressRules emits chain names
+// on every platform, including the non-Linux stub path.
+const policyTable = "moltbunker_policy"
+
+// intraHostCIDR is the private network every container veth lands on. Lateral
+// (intra-host) traffic is filtered against this range — a container may only
+// reach explicitly allowed peers inside it; everything else is dropped.
+const intraHostCIDR = "10.88.0.0/16"
+
+// sanitizeID maps a deploymentID into a valid unquoted nftables identifier.
+// deploymentIDs are "dep-<hex>" (generateDeploymentID), and the '-' is not a
+// reliably-accepted character in an unquoted nft chain identifier across nft
+// versions/kernels — an unquoted '-' can be rejected by `nft -f -`, which would
+// make Apply error and silently no-op lateral isolation (the caller only logs a
+// Warn). Replacing '-' with '_' keeps the name to [A-Za-z0-9_], which every nft
+// version accepts unquoted. The mapping is deterministic and collision-safe for
+// the hex-only suffix produced by generateDeploymentID.
+//
+// Defined here (not in the Linux-only file) so the chain names emitted by
+// ComputeEgressRules — which runs on every platform — are sanitized identically
+// to the names the Linux enforcer creates, flushes, and deletes. A mismatch
+// would create a chain under one name and add rules to another.
+func sanitizeID(deploymentID string) string {
+	return strings.ReplaceAll(deploymentID, "-", "_")
+}
+
+// inChain returns the per-deployment ingress chain name.
+func inChain(deploymentID string) string { return "mb_" + sanitizeID(deploymentID) + "_in" }
+
+// outChain returns the per-deployment egress chain name.
+func outChain(deploymentID string) string { return "mb_" + sanitizeID(deploymentID) + "_out" }
 
 // EgressMode controls outbound traffic from a container to addresses OUTSIDE
 // the 10.88.0.0/16 intra-host network — i.e., the public internet and the
@@ -302,7 +336,7 @@ func ComputeEgressRules(deploymentID, containerIP string, policy NetworkPolicy) 
 		return nil
 	}
 
-	chain := "mb_" + deploymentID + "_out"
+	chain := outChain(deploymentID)
 	var rules []string
 
 	// 1. Explicit deny CIDRs (highest precedence)
@@ -339,10 +373,24 @@ func ComputeEgressRules(deploymentID, containerIP string, policy NetworkPolicy) 
 }
 
 // DefaultRestrictiveEgressPolicy returns a baseline EgressDefaultDeny policy
-// with carve-outs for common safe destinations (loopback, DNS via Cloudflare
-// 1.1.1.1 and Google 8.8.8.8). Tenants who want full lockdown should start
-// here and remove allow entries; tenants who want broad access should NOT
-// start here.
+// with carve-outs for public DNS resolvers (Cloudflare 1.1.1.1 and Google
+// 8.8.8.8). Tenants who want full lockdown should start here and remove allow
+// entries; tenants who want broad access should NOT start here.
+//
+// Note on loopback: loopback (127.0.0.0/8) is intentionally NOT in EgressAllow.
+// It does not need one — loopback traffic never traverses the netfilter forward
+// hook that these egress rules attach to, so it is unaffected by the deny rules.
+//
+// Note on intra-host peers: EgressDeny includes 10.0.0.0/8, which subsumes the
+// intra-host 10.88.0.0/16 range. Because peer ACLs (AllowedPeers) are wired only
+// on the INGRESS chain, a container using this policy has its egress to allowed
+// peers dropped on the egress side. Note that ComputeEgressRules emits all deny
+// CIDRs BEFORE allow CIDRs (deny is highest precedence and a drop is terminal),
+// so simply appending 10.88.0.0/16 to EgressAllow is NOT sufficient — the
+// 10.0.0.0/8 deny still matches first. Operators relying on AllowedPeers for
+// bidirectional intra-host traffic must instead narrow the RFC1918 deny (e.g.
+// replace 10.0.0.0/8 with the specific subnets they want blocked, excluding
+// 10.88.0.0/16) so the broad deny no longer shadows intra-host egress.
 //
 // This is intentionally a starting-point, not a one-size-fits-all default —
 // the actual default in DefaultNetworkPolicy() remains EgressDefaultAllow

--- a/internal/networking/policy_linux.go
+++ b/internal/networking/policy_linux.go
@@ -1,45 +1,89 @@
 //go:build linux
 
-// R13 — Linux nftables enforcer for NetworkPolicy.
+// R13/R14 — Linux nftables enforcer for NetworkPolicy.
 //
-// This file would invoke `nft` (or use netlink directly via vishvananda/nftables)
-// to install the rules described by a NetworkPolicy. Following the existing
-// veth_linux.go convention, the actual exec is left as a documented stub —
-// the structure, plumbing, and state tracking are real and tested; turning on
-// real enforcement is a separate ops change after Linux runtime testing (R11).
+// This enforcer translates a NetworkPolicy into an `nft -f -` script and pipes
+// it to the nft binary. The external command is injected (execFn) so the
+// enforcement logic is unit-testable on any platform without a real nft binary;
+// production uses DefaultNftExec, which resolves `nft` via exec.LookPath.
+//
+// Table layout (single shared inet table, per-deployment chains):
+//
+//	table inet moltbunker_policy {
+//	  chain forward { type filter hook forward priority filter; policy accept; }
+//	  chain mb_<deploymentID>_in  { ... ingress (lateral isolation) ... }
+//	  chain mb_<deploymentID>_out { ... egress (R14) ... }
+//	}
+//
+// Apply is idempotent: the table/forward chain are created with `add` (a no-op
+// if they already exist), the per-deployment chains are flushed before rules are
+// re-added, and the shared forward chain is rebuilt-from-state (flushed, then
+// re-populated with jumps for every currently-applied deployment) on every
+// Apply and Remove. The rebuild-from-state design is load-bearing for two
+// reasons: (1) a re-Apply for the same deployment does not duplicate its forward
+// jumps, and (2) Remove can delete a per-deployment chain without nftables
+// returning EBUSY, because the rebuild has already removed the only forward jump
+// that targeted it (nft does NOT auto-remove jump references to a deleted
+// chain — `delete chain` on a still-referenced chain fails).
 package networking
 
 import (
+	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
+	"time"
 )
 
-// NftPolicyEnforcer is the Linux implementation of PolicyEnforcer using
-// nftables. The current implementation tracks state and emits the rule sets
-// that WOULD be applied; toggle realExec=true to actually run `nft -f`.
-type NftPolicyEnforcer struct {
-	store *PolicyStore
+// nftApplyTimeout bounds a single nft invocation so a wedged nft cannot block a
+// deploy or stop indefinitely.
+const nftApplyTimeout = 10 * time.Second
 
-	mu       sync.Mutex
-	applied  map[string]bool     // deploymentID → has rules installed
-	lastRule map[string][]string // deploymentID → last computed nft rule set (for audit/debug)
+// NftPolicyEnforcer is the Linux implementation of PolicyEnforcer using
+// nftables. It pipes computed rule sets to nft via the injected execFn.
+type NftPolicyEnforcer struct {
+	store  *PolicyStore
+	execFn NftExecFn
+
+	mu        sync.Mutex
+	applied   map[string]bool     // deploymentID → has rules installed
+	appliedIP map[string]string   // deploymentID → containerIP (for forward-jump rebuild)
+	lastRule  map[string][]string // deploymentID → last computed nft rule set (for audit/debug)
 }
 
-// NewNftPolicyEnforcer returns a Linux-native enforcer backed by `store`.
+// NewNftPolicyEnforcer returns a Linux-native enforcer backed by `store` that
+// applies rules by running the real `nft` binary (DefaultNftExec).
 func NewNftPolicyEnforcer(store *PolicyStore) *NftPolicyEnforcer {
+	return NewNftPolicyEnforcerWithExec(store, DefaultNftExec)
+}
+
+// NewNftPolicyEnforcerWithExec returns an enforcer that pipes its scripts to the
+// supplied execFn. Tests inject a capturing func so they can assert on the
+// generated nft script without a real nft binary. A nil execFn falls back to
+// DefaultNftExec.
+func NewNftPolicyEnforcerWithExec(store *PolicyStore, execFn NftExecFn) *NftPolicyEnforcer {
 	if store == nil {
 		store = NewPolicyStore()
 	}
+	if execFn == nil {
+		execFn = DefaultNftExec
+	}
 	return &NftPolicyEnforcer{
-		store:    store,
-		applied:  make(map[string]bool),
-		lastRule: make(map[string][]string),
+		store:     store,
+		execFn:    execFn,
+		applied:   make(map[string]bool),
+		appliedIP: make(map[string]string),
+		lastRule:  make(map[string][]string),
 	}
 }
 
-// Apply installs the policy for one container. It records intent in the store
-// and emits the corresponding nft rule set (currently as a stub, matching the
-// existing addDNATRule/createVethPair pattern).
+// Apply installs the policy for one container. It records intent in the store,
+// computes the ingress (lateral isolation) and egress (R14) rule sets, and pipes
+// a single atomic nft script that (a) idempotently creates the table + chains,
+// (b) flushes the per-deployment chains, (c) re-adds the ingress + egress rule
+// lines, and (d) rebuilds the shared forward chain's jump wiring from the full
+// applied set (so a re-Apply never duplicates the forward jumps).
 func (e *NftPolicyEnforcer) Apply(deploymentID, containerIP string, policy NetworkPolicy) error {
 	if deploymentID == "" {
 		return fmt.Errorf("%w: empty deploymentID", ErrInvalidPolicy)
@@ -53,48 +97,149 @@ func (e *NftPolicyEnforcer) Apply(deploymentID, containerIP string, policy Netwo
 
 	e.store.Set(deploymentID, containerIP, policy)
 
+	// Only peers that reciprocally allow this deployment may reach it.
 	allowedIPs := e.store.ResolveAllowedPeerIPs(deploymentID, policy, false)
-
-	// Emit (but don't execute) the rule set that would be applied. In the
-	// shipped version this becomes an `nft -f -` invocation. Documenting the
-	// commands inline keeps the runbook honest.
-	//
-	// Table layout:
-	//   table inet moltbunker_policy {
-	//     chain forward { type filter hook forward priority filter; policy accept; }
-	//     chain mb_<deploymentID>_in { ... }
-	//     chain mb_<deploymentID>_out { ... }
-	//   }
-	//
-	// Rules emitted per container:
-	//   - Default-deny intra-host: drop traffic from <containerIP> to 10.88.0.0/16
-	//     EXCEPT to allowedIPs.
-	//   - Egress:
-	//       if EgressDefaultDeny: drop traffic to non-10.88.0.0/16 EXCEPT EgressAllow.
-	//       if EgressDefaultAllow: only drop EgressDeny CIDRs.
-	_ = allowedIPs
-
-	// R14 — compute the egress rule set this policy would install. We keep it
-	// around for auditing/debugging even when realExec is off.
+	ingressRules := ComputeIngressRules(deploymentID, containerIP, allowedIPs)
 	egressRules := ComputeEgressRules(deploymentID, containerIP, policy)
 
+	// Serialize all nft mutations: concurrent Apply/Remove calls share the
+	// global table + forward chain, and nft -f is not safe to interleave. The
+	// forward-chain rebuild reads the applied set, so the script must be built
+	// under the same lock that guards that set.
 	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Build the forward-jump set from the full applied set PLUS this deployment.
+	// We add it to the map before building so the rebuild includes it, and roll
+	// it back if the exec fails (so a failed Apply leaves no phantom jump).
+	prevIP, hadPrev := e.appliedIP[deploymentID]
+	e.appliedIP[deploymentID] = containerIP
+	script := e.buildApplyScript(deploymentID, ingressRules, egressRules)
+
+	ctx, cancel := context.WithTimeout(context.Background(), nftApplyTimeout)
+	defer cancel()
+	if err := e.execFn(ctx, script); err != nil {
+		if hadPrev {
+			e.appliedIP[deploymentID] = prevIP
+		} else {
+			delete(e.appliedIP, deploymentID)
+		}
+		return fmt.Errorf("nft apply for %s: %w", deploymentID, err)
+	}
+
 	e.applied[deploymentID] = true
-	e.lastRule[deploymentID] = egressRules
-	e.mu.Unlock()
+	combined := make([]string, 0, len(ingressRules)+len(egressRules))
+	combined = append(combined, ingressRules...)
+	combined = append(combined, egressRules...)
+	e.lastRule[deploymentID] = combined
 	return nil
 }
 
-// Remove tears down rules for one container.
+// buildApplyScript assembles the full idempotent `nft -f -` script for one
+// deployment: init block, flush of the per-deployment chains, the ingress +
+// egress rule lines, and a rebuild-from-state of the shared forward chain's
+// jump wiring. Callers must hold e.mu (it reads e.appliedIP).
+//
+// The forward chain is flushed and re-populated with jumps for every currently
+// applied deployment on every Apply. This is what makes re-Apply idempotent:
+// the prior pair of forward jumps for this deployment is cleared by the flush
+// and re-added exactly once, so a policy update never doubles the jumps.
+func (e *NftPolicyEnforcer) buildApplyScript(deploymentID string, ingressRules, egressRules []string) string {
+	var b strings.Builder
+	b.WriteString(buildInitScript(deploymentID))
+	// Flush the per-deployment chains so a re-Apply (policy update) replaces the
+	// prior rule set rather than appending to it.
+	fmt.Fprintf(&b, "flush chain inet %s %s\n", policyTable, inChain(deploymentID))
+	fmt.Fprintf(&b, "flush chain inet %s %s\n", policyTable, outChain(deploymentID))
+	for _, r := range ingressRules {
+		b.WriteString(r)
+		b.WriteByte('\n')
+	}
+	for _, r := range egressRules {
+		b.WriteString(r)
+		b.WriteByte('\n')
+	}
+	b.WriteString(e.buildForwardRebuild())
+	return b.String()
+}
+
+// buildForwardRebuild emits a flush of the shared forward chain followed by the
+// jump wiring for every currently-applied deployment (read from e.appliedIP).
+// Callers must hold e.mu.
+//
+// Rebuilding the forward chain from state on every Apply/Remove is the
+// mechanism that (a) keeps re-Apply from duplicating jumps and (b) lets Remove
+// delete a per-deployment chain without hitting EBUSY: by the time the chain is
+// deleted, the flush has already removed the only forward jump that targeted it
+// (contrary to the earlier belief that nft auto-removes references to a deleted
+// chain — it does not; `delete chain` on a chain that is still a jump target
+// returns "Device or resource busy").
+//
+// Deployments are emitted in sorted order so the generated script is
+// deterministic (stable for tests and audit diffs).
+func (e *NftPolicyEnforcer) buildForwardRebuild() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "flush chain inet %s forward\n", policyTable)
+	ids := make([]string, 0, len(e.appliedIP))
+	for id := range e.appliedIP {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		for _, r := range jumpRules(id, e.appliedIP[id]) {
+			b.WriteString(r)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// Remove tears down rules for one container. It first drops the deployment from
+// the applied set and rebuilds the shared forward chain from the remaining
+// applied deployments — this deletes the two forward jumps that targeted this
+// deployment's chains. Only THEN are the per-deployment chains flushed and
+// deleted, because nftables refuses to `delete chain` while any jump/goto still
+// targets it (it returns "Device or resource busy" / EBUSY). The shared table +
+// forward chain are left in place (other deployments may still use them).
+// Safe to call even if Apply was never called.
 func (e *NftPolicyEnforcer) Remove(deploymentID string) error {
 	e.store.Remove(deploymentID)
+
 	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	wasApplied := e.applied[deploymentID]
 	delete(e.applied, deploymentID)
 	delete(e.lastRule, deploymentID)
-	e.mu.Unlock()
+	prevIP, hadIP := e.appliedIP[deploymentID]
+	delete(e.appliedIP, deploymentID)
 
-	// nft delete chain inet moltbunker_policy mb_<deploymentID>_in
-	// nft delete chain inet moltbunker_policy mb_<deploymentID>_out
+	if !wasApplied {
+		// Nothing was installed for this deployment; deleting a non-existent
+		// chain would make nft error, so skip the exec entirely.
+		return nil
+	}
+
+	var b strings.Builder
+	// Rebuild the forward chain WITHOUT this deployment's jumps first, so the
+	// subsequent delete chain does not hit EBUSY (no forward jump references the
+	// chains being deleted anymore).
+	b.WriteString(e.buildForwardRebuild())
+	fmt.Fprintf(&b, "flush chain inet %s %s\n", policyTable, inChain(deploymentID))
+	fmt.Fprintf(&b, "flush chain inet %s %s\n", policyTable, outChain(deploymentID))
+	fmt.Fprintf(&b, "delete chain inet %s %s\n", policyTable, inChain(deploymentID))
+	fmt.Fprintf(&b, "delete chain inet %s %s\n", policyTable, outChain(deploymentID))
+
+	ctx, cancel := context.WithTimeout(context.Background(), nftApplyTimeout)
+	defer cancel()
+	if err := e.execFn(ctx, b.String()); err != nil {
+		// Restore applied-set tracking so a later retry can rebuild correctly.
+		e.applied[deploymentID] = true
+		if hadIP {
+			e.appliedIP[deploymentID] = prevIP
+		}
+		return fmt.Errorf("nft remove for %s: %w", deploymentID, err)
+	}
 	return nil
 }
 

--- a/internal/networking/policy_linux_exec.go
+++ b/internal/networking/policy_linux_exec.go
@@ -1,0 +1,128 @@
+//go:build linux
+
+// R13/R14 — Linux nftables exec helpers.
+//
+// This file contains the pieces that turn a NetworkPolicy into a concrete
+// `nft -f -` script and the default function that actually runs `nft`. The exec
+// function is injected into NftPolicyEnforcer at construction time (see
+// NewNftPolicyEnforcerWithExec) so the enforcer can be unit-tested on any
+// platform without a real `nft` binary on PATH.
+package networking
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// NftExecFn pipes an `nft -f -` script to the nft binary. Implementations must
+// return a non-nil error (including any stderr output) when nft exits non-zero.
+type NftExecFn func(ctx context.Context, script string) error
+
+// DefaultNftExec resolves `nft` via exec.LookPath at call time and pipes the
+// supplied script to its stdin (`nft -f -`). It returns the combined stderr on
+// a non-zero exit so the daemon can log exactly which rule set failed.
+//
+// nft is resolved lazily (per call) rather than cached so that a provider that
+// installs nftables after the daemon starts does not need a restart, and so the
+// enforcer can be constructed on hosts that do not yet have nft installed
+// (Apply then surfaces a clear error that the doctor NftChecker also flags).
+func DefaultNftExec(ctx context.Context, script string) error {
+	nftPath, err := exec.LookPath("nft")
+	if err != nil {
+		return fmt.Errorf("nft binary not found on PATH: %w", err)
+	}
+
+	// #nosec G204 -- exec.CommandContext (no shell); nftPath is resolved via
+	// exec.LookPath and the only arguments are the constants "-f" and "-". The
+	// rule set is supplied on stdin, never as a shell-interpolated argument, and
+	// is built solely from internal container IPs and operator-validated CIDRs.
+	cmd := exec.CommandContext(ctx, nftPath, "-f", "-")
+	cmd.Stdin = bytes.NewReader([]byte(script))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("nft -f - failed: %w: %s", err, stderr.String())
+		}
+		return fmt.Errorf("nft -f - failed: %w", err)
+	}
+	return nil
+}
+
+// buildInitScript returns an idempotent table/chain creation block. `add table`
+// and `add chain` silently succeed if the object already exists, so this is safe
+// to run on every Apply and safe to run concurrently for different deployments
+// (the shared table + forward chain creation is idempotent; per-deployment
+// chains are namespaced by deploymentID).
+//
+// The forward chain is hooked into netfilter's forward path; the per-deployment
+// chains are populated by Apply and jumped into from the forward chain by the
+// jump rules added alongside the policy rules.
+func buildInitScript(deploymentID string) string {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "add table inet %s\n", policyTable)
+	fmt.Fprintf(&b, "add chain inet %s forward { type filter hook forward priority filter; policy accept; }\n", policyTable)
+	fmt.Fprintf(&b, "add chain inet %s %s\n", policyTable, inChain(deploymentID))
+	fmt.Fprintf(&b, "add chain inet %s %s\n", policyTable, outChain(deploymentID))
+	return b.String()
+}
+
+// ComputeIngressRules translates the lateral (intra-host) isolation model into
+// nftables rule lines for one container's ingress chain. The container may be
+// reached from each allowed peer IP; every other source inside the intra-host
+// range is dropped. Traffic to/from outside the intra-host range is not the
+// ingress chain's concern (that is egress, handled by ComputeEgressRules).
+//
+// Rule ordering matters: accept rules for allowed peers come first, then a
+// terminal drop for the rest of the intra-host range. Returns nil for empty
+// deploymentID or containerIP.
+func ComputeIngressRules(deploymentID, containerIP string, allowedIPs []string) []string {
+	if deploymentID == "" || containerIP == "" {
+		return nil
+	}
+	chain := inChain(deploymentID)
+	var rules []string
+
+	// Allow each reciprocally-approved peer to reach this container.
+	for _, peer := range allowedIPs {
+		if peer == "" {
+			continue
+		}
+		rules = append(rules, fmt.Sprintf(
+			"add rule inet %s %s ip saddr %s ip daddr %s accept",
+			policyTable, chain, peer, containerIP,
+		))
+	}
+
+	// Drop all other intra-host traffic destined for this container. This is the
+	// default-deny lateral isolation rule: a compromised neighbour cannot reach
+	// this container unless its tenant reciprocally opted in above.
+	rules = append(rules, fmt.Sprintf(
+		"add rule inet %s %s ip saddr %s ip daddr %s drop",
+		policyTable, chain, intraHostCIDR, containerIP,
+	))
+
+	return rules
+}
+
+// jumpRules wire the shared forward chain into the per-deployment chains so the
+// kernel actually evaluates the policy. Ingress is selected by destination IP
+// (traffic TO the container), egress by source IP (traffic FROM the container).
+//
+// The forward chain is rebuilt-from-state on every Apply/Remove (it is flushed,
+// then these jumps are re-emitted for every currently-applied deployment), so
+// these are always `add` (append to a freshly-flushed chain) and never need
+// handle-based deletion: a Remove simply omits the removed deployment from the
+// rebuild. This keeps re-Apply from duplicating jumps and lets Remove delete the
+// per-deployment chains without hitting EBUSY (no forward jump still targets
+// them once the chain has been flushed).
+func jumpRules(deploymentID, containerIP string) []string {
+	return []string{
+		fmt.Sprintf("add rule inet %s forward ip daddr %s jump %s",
+			policyTable, containerIP, inChain(deploymentID)),
+		fmt.Sprintf("add rule inet %s forward ip saddr %s jump %s",
+			policyTable, containerIP, outChain(deploymentID)),
+	}
+}

--- a/internal/networking/policy_linux_test.go
+++ b/internal/networking/policy_linux_test.go
@@ -1,0 +1,295 @@
+//go:build linux
+
+package networking
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// scriptCapture is a test NftExecFn that records every script piped to it.
+type scriptCapture struct {
+	mu      sync.Mutex
+	scripts []string
+	err     error // if non-nil, returned from every call
+}
+
+func (c *scriptCapture) exec(_ context.Context, script string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.scripts = append(c.scripts, script)
+	return c.err
+}
+
+func (c *scriptCapture) all() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.scripts, "\n---\n")
+}
+
+func (c *scriptCapture) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.scripts)
+}
+
+func TestNftPolicyEnforcer_Apply_EmitsInitAndRules(t *testing.T) {
+	cap := &scriptCapture{}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	policy := NetworkPolicy{EgressMode: EgressDefaultDeny}
+	if err := e.Apply("dep-1", "10.88.0.5", policy); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if cap.count() == 0 {
+		t.Fatal("Apply emitted no nft script")
+	}
+	got := cap.all()
+	// Chain names are sanitized ('-' -> '_') so they are valid unquoted nft
+	// identifiers: deploymentID "dep-1" -> chain suffix "dep_1".
+	for _, want := range []string{policyTable, "10.88.0.5", "drop", "add table", "mb_dep_1_out"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("script missing %q\nscript:\n%s", want, got)
+		}
+	}
+	// The unsanitized hyphenated chain name must NOT appear (an unquoted '-' can
+	// be rejected by nft and silently no-op enforcement).
+	if strings.Contains(got, "mb_dep-1_") {
+		t.Errorf("script must not contain unsanitized hyphenated chain name; script:\n%s", got)
+	}
+	if !e.HasRules("dep-1") {
+		t.Error("HasRules(dep-1) should be true after Apply")
+	}
+}
+
+func TestNftPolicyEnforcer_Apply_IdempotentSecondApply(t *testing.T) {
+	cap := &scriptCapture{}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	if err := e.Apply("dep-2", "10.88.0.9", NetworkPolicy{EgressMode: EgressDefaultAllow}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	// Re-apply with a changed policy: must flush + re-add (idempotent update).
+	if err := e.Apply("dep-2", "10.88.0.9", NetworkPolicy{EgressMode: EgressDefaultDeny}); err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+
+	if cap.count() != 2 {
+		t.Fatalf("expected 2 script invocations, got %d", cap.count())
+	}
+	got := cap.all()
+	if !strings.Contains(got, "flush chain") {
+		t.Errorf("re-Apply must flush the chain before re-adding; script:\n%s", got)
+	}
+
+	// The forward chain is rebuilt-from-state: it must be flushed before the
+	// jumps are re-added, otherwise a re-Apply appends a duplicate pair of
+	// forward jumps for the same deployment.
+	second := lastScript(t, cap)
+	if !strings.Contains(second, "flush chain inet "+policyTable+" forward") {
+		t.Errorf("re-Apply must flush the forward chain before re-adding jumps; script:\n%s", second)
+	}
+	if n := strings.Count(second, "jump "+inChain("dep-2")); n != 1 {
+		t.Errorf("re-Apply must add exactly one ingress forward jump for dep-2, got %d; script:\n%s", n, second)
+	}
+	if n := strings.Count(second, "jump "+outChain("dep-2")); n != 1 {
+		t.Errorf("re-Apply must add exactly one egress forward jump for dep-2, got %d; script:\n%s", n, second)
+	}
+}
+
+// lastScript returns the most recently captured nft script.
+func lastScript(t *testing.T, c *scriptCapture) string {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.scripts) == 0 {
+		t.Fatal("no scripts captured")
+	}
+	return c.scripts[len(c.scripts)-1]
+}
+
+func TestNftPolicyEnforcer_ForwardJumpsRebuiltFromState(t *testing.T) {
+	cap := &scriptCapture{}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	if err := e.Apply("dep-a", "10.88.0.2", NetworkPolicy{EgressMode: EgressDefaultDeny}); err != nil {
+		t.Fatalf("Apply dep-a: %v", err)
+	}
+	// Applying a second deployment must re-emit dep-a's jumps too (rebuild from
+	// the full applied set), so a single flush+rebuild keeps all live jumps.
+	if err := e.Apply("dep-b", "10.88.0.3", NetworkPolicy{EgressMode: EgressDefaultDeny}); err != nil {
+		t.Fatalf("Apply dep-b: %v", err)
+	}
+	second := lastScript(t, cap)
+	for _, want := range []string{
+		"jump " + inChain("dep-a"), "jump " + outChain("dep-a"),
+		"jump " + inChain("dep-b"), "jump " + outChain("dep-b"),
+	} {
+		if !strings.Contains(second, want) {
+			t.Errorf("second Apply must rebuild jumps for ALL applied deployments; missing %q\nscript:\n%s", want, second)
+		}
+	}
+
+	// Removing dep-a must rebuild the forward chain WITHOUT dep-a's jumps (so
+	// the subsequent delete chain does not hit EBUSY) but KEEP dep-b's jumps.
+	cap.mu.Lock()
+	cap.scripts = nil
+	cap.mu.Unlock()
+	if err := e.Remove("dep-a"); err != nil {
+		t.Fatalf("Remove dep-a: %v", err)
+	}
+	rm := lastScript(t, cap)
+	if !strings.Contains(rm, "flush chain inet "+policyTable+" forward") {
+		t.Errorf("Remove must flush the forward chain before deleting the per-deployment chains; script:\n%s", rm)
+	}
+	// dep-a's jumps must be GONE from the rebuilt forward chain...
+	if strings.Contains(rm, "jump "+inChain("dep-a")) || strings.Contains(rm, "jump "+outChain("dep-a")) {
+		t.Errorf("Remove must NOT re-add the removed deployment's forward jumps; script:\n%s", rm)
+	}
+	// ...while dep-b's jumps must still be present (it is still applied).
+	if !strings.Contains(rm, "jump "+inChain("dep-b")) || !strings.Contains(rm, "jump "+outChain("dep-b")) {
+		t.Errorf("Remove must preserve the still-applied deployment's forward jumps; script:\n%s", rm)
+	}
+	// The forward flush+rebuild must come BEFORE the delete chain for dep-a,
+	// otherwise nft returns EBUSY (chain still targeted by a jump).
+	flushIdx := strings.Index(rm, "flush chain inet "+policyTable+" forward")
+	delIdx := strings.Index(rm, "delete chain inet "+policyTable+" "+inChain("dep-a"))
+	if flushIdx < 0 || delIdx < 0 || flushIdx > delIdx {
+		t.Errorf("forward flush/rebuild must precede the delete chain for dep-a (EBUSY otherwise); script:\n%s", rm)
+	}
+}
+
+func TestNftPolicyEnforcer_RemoveLastDeployment_EmptyForwardRebuild(t *testing.T) {
+	cap := &scriptCapture{}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	if err := e.Apply("dep-solo", "10.88.0.42", NetworkPolicy{EgressMode: EgressDefaultDeny}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	cap.mu.Lock()
+	cap.scripts = nil
+	cap.mu.Unlock()
+	if err := e.Remove("dep-solo"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	rm := lastScript(t, cap)
+	// With no deployments left, the forward chain is flushed and left empty (no
+	// stray jumps), then the per-deployment chains are deleted.
+	if !strings.Contains(rm, "flush chain inet "+policyTable+" forward") {
+		t.Errorf("Remove of last deployment must still flush the forward chain; script:\n%s", rm)
+	}
+	if strings.Contains(rm, "jump ") {
+		t.Errorf("Remove of last deployment must leave no forward jumps; script:\n%s", rm)
+	}
+	if !strings.Contains(rm, "delete chain inet "+policyTable+" "+inChain("dep-solo")) {
+		t.Errorf("Remove must delete the per-deployment chain; script:\n%s", rm)
+	}
+}
+
+func TestNftPolicyEnforcer_Remove_DeletesChains(t *testing.T) {
+	cap := &scriptCapture{}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	if err := e.Apply("dep-3", "10.88.0.12", NetworkPolicy{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if err := e.Remove("dep-3"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	got := cap.all()
+	if !strings.Contains(got, "delete chain") {
+		t.Errorf("Remove must emit delete chain; script:\n%s", got)
+	}
+	if !strings.Contains(got, "mb_dep_3_in") || !strings.Contains(got, "mb_dep_3_out") {
+		t.Errorf("Remove must delete both _in and _out chains; script:\n%s", got)
+	}
+	if e.HasRules("dep-3") {
+		t.Error("HasRules(dep-3) should be false after Remove")
+	}
+}
+
+func TestNftPolicyEnforcer_Remove_NeverApplied_NoExec(t *testing.T) {
+	cap := &scriptCapture{}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	// Removing a deployment that was never applied must not invoke nft (deleting
+	// a non-existent chain would error).
+	if err := e.Remove("never-applied"); err != nil {
+		t.Fatalf("Remove of never-applied deployment: %v", err)
+	}
+	if cap.count() != 0 {
+		t.Errorf("Remove of never-applied deployment should not exec nft; got %d invocations", cap.count())
+	}
+}
+
+func TestNftPolicyEnforcer_Apply_ExecError_ReturnsError(t *testing.T) {
+	sentinel := errors.New("nft boom")
+	cap := &scriptCapture{err: sentinel}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	err := e.Apply("dep-4", "10.88.0.20", NetworkPolicy{EgressMode: EgressDefaultDeny})
+	if err == nil {
+		t.Fatal("Apply should return the execFn error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Apply error = %v, want wrap of %v", err, sentinel)
+	}
+	// On exec failure the deployment must NOT be marked applied (so a later
+	// Remove won't try to delete chains that were never created).
+	if e.HasRules("dep-4") {
+		t.Error("HasRules(dep-4) should be false when Apply exec failed")
+	}
+}
+
+func TestNftPolicyEnforcer_Apply_NoPortContainer(t *testing.T) {
+	// The replica / no-port path: a container with no exposed ports still gets a
+	// policy applied. This must succeed and still emit egress rules.
+	cap := &scriptCapture{}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	policy := DefaultRestrictiveEgressPolicy()
+	if err := e.Apply("dep-replica", "10.88.1.7", policy); err != nil {
+		t.Fatalf("Apply (no-port replica): %v", err)
+	}
+	got := cap.all()
+	if !strings.Contains(got, "10.88.1.7") {
+		t.Errorf("no-port Apply must reference the container IP; script:\n%s", got)
+	}
+	if !strings.Contains(got, "169.254.169.254") {
+		t.Errorf("restrictive policy egress-deny CIDR missing from script:\n%s", got)
+	}
+}
+
+func TestNftPolicyEnforcer_Apply_InvalidInputs(t *testing.T) {
+	cap := &scriptCapture{}
+	e := NewNftPolicyEnforcerWithExec(NewPolicyStore(), cap.exec)
+
+	if err := e.Apply("", "10.88.0.1", NetworkPolicy{}); err == nil {
+		t.Error("empty deploymentID should error")
+	}
+	if err := e.Apply("dep-x", "", NetworkPolicy{}); err == nil {
+		t.Error("empty containerIP should error")
+	}
+	if cap.count() != 0 {
+		t.Errorf("invalid Apply must not invoke nft; got %d invocations", cap.count())
+	}
+}
+
+func TestComputeIngressRules(t *testing.T) {
+	rules := ComputeIngressRules("dep-a", "10.88.0.5", []string{"10.88.0.6", "10.88.0.7"})
+	if len(rules) != 3 { // 2 accepts + 1 terminal drop
+		t.Fatalf("expected 3 ingress rules, got %d: %v", len(rules), rules)
+	}
+	last := rules[len(rules)-1]
+	if !strings.Contains(last, "drop") || !strings.Contains(last, intraHostCIDR) {
+		t.Errorf("terminal rule should drop intra-host range; got %q", last)
+	}
+	if ComputeIngressRules("", "10.88.0.5", nil) != nil {
+		t.Error("empty deploymentID should yield nil ingress rules")
+	}
+}

--- a/internal/networking/policy_nftsmoke_test.go
+++ b/internal/networking/policy_nftsmoke_test.go
@@ -1,0 +1,69 @@
+//go:build linux && nftsmoke
+
+// Real-nft smoke test for the nftables enforcer (R13/R14).
+//
+// Unit tests inject a fake exec (scriptCapture) and never model real nft
+// semantics, so a generated script that nft rejects — an invalid chain
+// identifier (e.g. an unquoted '-'), or a `delete chain` that hits EBUSY
+// because a forward jump still targets it — passes the unit tests yet fails
+// the moment R13/R14 runs on a provider. This test pipes the REAL generated
+// scripts to the REAL `nft` binary so those failures are caught in CI, not in
+// production where applyNetworkPolicy only logs a Warn.
+//
+// Gated behind the `nftsmoke` build tag because it requires a real nft binary
+// and CAP_NET_ADMIN (root). The OPS-04 runtime-e2e CI job runs it as root after
+// `apt-get install nftables`. It is skipped from the default `go test ./...`.
+package networking
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func requireNft(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("nft"); err != nil {
+		t.Skip("nft binary not on PATH; install nftables to run the smoke test")
+	}
+}
+
+// TestSmoke_ApplyRemoveAgainstRealNft exercises the full Apply -> re-Apply ->
+// Remove lifecycle against the real nft binary. It is the regression guard for:
+//   - the HIGH EBUSY teardown bug (delete chain while a forward jump targets it),
+//   - the MEDIUM duplicate-jump-on-reapply,
+//   - the LOW hyphenated chain-name rejection (deploymentID "dep-<hex>").
+func TestSmoke_ApplyRemoveAgainstRealNft(t *testing.T) {
+	requireNft(t)
+
+	e := NewNftPolicyEnforcer(NewPolicyStore())
+	// Best-effort cleanup of the shared table regardless of outcome.
+	t.Cleanup(func() {
+		_ = DefaultNftExec(context.Background(), "delete table inet "+policyTable+"\n")
+	})
+
+	// A hyphenated deploymentID is the production shape (generateDeploymentID).
+	// If chain-name sanitization were wrong, the real nft would reject this.
+	const depA = "dep-aaaa1111"
+	const depB = "dep-bbbb2222"
+
+	if err := e.Apply(depA, "10.88.0.5", NetworkPolicy{EgressMode: EgressDefaultDeny}); err != nil {
+		t.Fatalf("Apply %s against real nft: %v", depA, err)
+	}
+	// Re-Apply (policy update) must not duplicate forward jumps or error.
+	if err := e.Apply(depA, "10.88.0.5", NetworkPolicy{EgressMode: EgressDefaultAllow}); err != nil {
+		t.Fatalf("re-Apply %s against real nft: %v", depA, err)
+	}
+	if err := e.Apply(depB, "10.88.0.6", NetworkPolicy{EgressMode: EgressDefaultDeny}); err != nil {
+		t.Fatalf("Apply %s against real nft: %v", depB, err)
+	}
+
+	// The critical regression: Remove must NOT hit EBUSY. With the old code
+	// (delete chain while the forward jump still targets it) this errored.
+	if err := e.Remove(depA); err != nil {
+		t.Fatalf("Remove %s against real nft (EBUSY regression?): %v", depA, err)
+	}
+	if err := e.Remove(depB); err != nil {
+		t.Fatalf("Remove %s against real nft: %v", depB, err)
+	}
+}

--- a/internal/networking/policy_other.go
+++ b/internal/networking/policy_other.go
@@ -2,11 +2,19 @@
 
 package networking
 
-// R13 — non-Linux stub. nftables is Linux-only; on macOS/Colima we keep a
+// R13/R14 — non-Linux stub. nftables is Linux-only; on macOS/Colima we keep a
 // no-op enforcer that satisfies the interface so the rest of the daemon can
 // be developed cross-platform.
 
-import "sync"
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// NftExecFn mirrors the Linux signature so callers (and tests) can reference it
+// cross-platform. On non-Linux it is never invoked.
+type NftExecFn func(ctx context.Context, script string) error
 
 // NftPolicyEnforcer is the cross-platform stub for the Linux nftables
 // enforcer. On non-Linux platforms it just records intent.
@@ -20,6 +28,12 @@ type NftPolicyEnforcer struct {
 
 // NewNftPolicyEnforcer returns a no-op enforcer outside of Linux.
 func NewNftPolicyEnforcer(store *PolicyStore) *NftPolicyEnforcer {
+	return NewNftPolicyEnforcerWithExec(store, nil)
+}
+
+// NewNftPolicyEnforcerWithExec returns a no-op enforcer outside of Linux. The
+// execFn is accepted for API parity with the Linux build but is never called.
+func NewNftPolicyEnforcerWithExec(store *PolicyStore, _ NftExecFn) *NftPolicyEnforcer {
 	if store == nil {
 		store = NewPolicyStore()
 	}
@@ -31,7 +45,18 @@ func NewNftPolicyEnforcer(store *PolicyStore) *NftPolicyEnforcer {
 }
 
 // Apply records the policy in the store; no OS-level enforcement happens.
+//
+// The empty-deploymentID/empty-containerIP guards mirror the Linux Apply
+// (policy_linux.go) so the stub rejects the same malformed inputs on dev
+// machines — without this parity a caller bug would surface only in production
+// on Linux.
 func (e *NftPolicyEnforcer) Apply(deploymentID, containerIP string, policy NetworkPolicy) error {
+	if deploymentID == "" {
+		return fmt.Errorf("%w: empty deploymentID", ErrInvalidPolicy)
+	}
+	if containerIP == "" {
+		return fmt.Errorf("%w: empty containerIP", ErrInvalidPolicy)
+	}
 	if err := policy.Validate(deploymentID); err != nil {
 		return err
 	}

--- a/internal/networking/policy_other_test.go
+++ b/internal/networking/policy_other_test.go
@@ -1,0 +1,68 @@
+//go:build !linux
+
+package networking
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestStubApply_InvalidInputs asserts the non-Linux stub enforcer rejects the
+// same malformed inputs the Linux enforcer rejects (empty deploymentID / empty
+// containerIP). Without this parity, a caller bug that passes an empty ID would
+// be silently accepted on dev machines and only surface in production on Linux.
+func TestStubApply_InvalidInputs(t *testing.T) {
+	e := NewNftPolicyEnforcer(NewPolicyStore())
+
+	if err := e.Apply("", "10.88.0.1", NetworkPolicy{}); err == nil {
+		t.Error("stub Apply: empty deploymentID should error")
+	} else if !errors.Is(err, ErrInvalidPolicy) {
+		t.Errorf("stub Apply: empty deploymentID error = %v, want wrap of ErrInvalidPolicy", err)
+	}
+
+	if err := e.Apply("dep-x", "", NetworkPolicy{}); err == nil {
+		t.Error("stub Apply: empty containerIP should error")
+	} else if !errors.Is(err, ErrInvalidPolicy) {
+		t.Errorf("stub Apply: empty containerIP error = %v, want wrap of ErrInvalidPolicy", err)
+	}
+
+	// A self-referencing peer list must still be rejected by policy.Validate.
+	if err := e.Apply("dep-x", "10.88.0.1", NetworkPolicy{AllowedPeers: []string{"dep-x"}}); err == nil {
+		t.Error("stub Apply: self-referencing peer should error")
+	}
+
+	// A valid Apply must succeed and record intent.
+	if err := e.Apply("dep-ok", "10.88.0.5", NetworkPolicy{EgressMode: EgressDefaultDeny}); err != nil {
+		t.Fatalf("stub Apply (valid): %v", err)
+	}
+	if !e.HasRules("dep-ok") {
+		t.Error("stub HasRules(dep-ok) should be true after a valid Apply")
+	}
+}
+
+// TestStubEgressRules_ChainNameSanitized asserts that the platform-agnostic
+// ComputeEgressRules produces sanitized (hyphen-free) chain names, so the names
+// match what the Linux enforcer creates/flushes/deletes.
+func TestStubEgressRules_ChainNameSanitized(t *testing.T) {
+	rules := ComputeEgressRules("dep-7f3a", "10.88.0.9", NetworkPolicy{EgressMode: EgressDefaultDeny})
+	if len(rules) == 0 {
+		t.Fatal("expected egress rules")
+	}
+	for _, r := range rules {
+		if !contains(r, "mb_dep_7f3a_out") {
+			t.Errorf("egress rule must reference the sanitized chain mb_dep_7f3a_out; got %q", r)
+		}
+		if contains(r, "mb_dep-7f3a_out") {
+			t.Errorf("egress rule must NOT contain the unsanitized hyphenated chain name; got %q", r)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## RUN-01 — Close the expose-to-internet runtime gates

- **Real nftables enforcement for R13/R14** (was a documented stub): linux build-tagged `nft -f` exec (darwin no-op), exec injected for tests. The shared `forward` chain is **rebuilt-from-state** on every Apply/Remove (fixes a real `delete chain` EBUSY teardown bug + duplicate-jump-on-reapply caught in review); chain names sanitized to valid nft identifiers. `applyNetworkPolicy` now also covers replica/no-port deploys.
- **HTTP/browser deploy path now carries the exec envelope** (sealed key + nonce) so browser-exec is E2E-encrypted like the CLI route (closes the SEC-10 follow-up).
- **Doctor checks** for `trivy` (R4), `nft` (R13), `cosign` (R3) so enabling a gate without host tooling warns instead of silently no-opping.
- Added a real-`nft` smoke test (`-tags nftsmoke`) wired into the OPS-04 runtime-e2e CI job.

Verification: build + vet + linux cross-build + gosec(0) + networking/daemon/api/doctor tests green. Secret-scan clean. One LOW deferred (exec fail-open metric) with an explicit SECURITY log + tracked TODO.

> **Stacked PR — base `PAY-01` (#35).** Merge order: PAY-01 → **RUN-01**.
