### PR TITLE
KEY-01 Harden snapshot + storage key management (X25519 DEK, keyring, rotation)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -88,14 +88,28 @@ func main() {
 	detectorCfg := threat.DefaultDetectorConfig()
 	detector := threat.NewDetector(detectorCfg)
 
-	// Initialize snapshot manager
+	// Initialize snapshot manager. KEY-01: DefaultSnapshotConfig enables
+	// encryption, which now REQUIRES an explicit KeyProvider (no silent-ephemeral
+	// fallback). Build the same file/keyring/env provider cmd/daemon uses so the
+	// api binary's snapshots are encrypted with a stable, restart-survivable key
+	// rather than starting with snapshots silently disabled. Failure is fatal:
+	// continuing with a nil manager would disable snapshots without the operator
+	// noticing.
 	snapshotCfg := snapshot.DefaultSnapshotConfig()
-	snapshotCfg.StoragePath = cfg.Daemon.DataDir + "/snapshots"
-	snapshotMgr, err := snapshot.NewManager(snapshotCfg)
+	snapshotCfg.StoragePath = filepath.Join(cfg.Daemon.DataDir, "snapshots")
+	var snapshotKeyProvider snapshot.KeyProvider
+	if snapshotCfg.EncryptionEnabled {
+		kp, kpErr := snapshot.NewKeyProviderFromConfig(snapshotCfg, cfg.Daemon.DataDir)
+		if kpErr != nil {
+			fmt.Fprintf(os.Stderr, "Failed to build snapshot key provider: %v\n", kpErr)
+			os.Exit(1)
+		}
+		snapshotKeyProvider = kp
+	}
+	snapshotMgr, err := snapshot.NewManager(snapshotCfg, snapshotKeyProvider)
 	if err != nil {
-		logging.Warn("Failed to initialize snapshot manager",
-			"error", err.Error(),
-			logging.Component("api"))
+		fmt.Fprintf(os.Stderr, "Failed to initialize snapshot manager: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Initialize cloning manager

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -149,6 +149,23 @@ func main() {
 			logging.Err(err), logging.Component("daemon"))
 	}
 
+	// KEY-01: optional eager state-key rotation sweep. Re-encrypts every value
+	// with the current key and bumps the on-disk magic to MBENC2 (idempotent;
+	// retags legacy MBENC1 values). Off by default — lazy migration on next
+	// write is the norm.
+	if stateEncKey != nil && cfg.Security.StateKeyRotationSweep {
+		if m, rerr := stateStore.RotateKey(ctx, stateEncKey); rerr != nil {
+			logging.Warn("state key rotation sweep failed, continuing",
+				logging.Err(rerr), logging.Component("daemon"))
+		} else {
+			logging.Info("state key rotation sweep complete",
+				"buckets", m.Buckets,
+				"values_rotated", m.ValuesRotated,
+				"values_skipped", m.ValuesSkipped,
+				logging.Component("daemon"))
+		}
+	}
+
 	// Handle signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -661,12 +678,23 @@ func main() {
 		logging.Warn("failed to start threat detector", logging.Err(err), logging.Component("daemon"))
 	}
 
-	// Initialize snapshot manager
+	// Initialize snapshot manager. KEY-01: the master encryption key is sourced
+	// via an explicit KeyProvider (file/keyring/env) — never a silent ephemeral
+	// key that would orphan snapshots on restart. When encryption is enabled and
+	// the provider cannot be built/read, startup fails closed.
 	snapshotCfg := snapshot.DefaultSnapshotConfig()
 	snapshotCfg.StoragePath = filepath.Join(cfg.Daemon.DataDir, "snapshots")
-	snapshotMgr, err := snapshot.NewManager(snapshotCfg)
+	var snapshotKeyProvider snapshot.KeyProvider
+	if snapshotCfg.EncryptionEnabled {
+		kp, kpErr := snapshot.NewKeyProviderFromConfig(snapshotCfg, cfg.Daemon.DataDir)
+		if kpErr != nil {
+			log.Fatalf("Failed to build snapshot key provider: %v", kpErr)
+		}
+		snapshotKeyProvider = kp
+	}
+	snapshotMgr, err := snapshot.NewManager(snapshotCfg, snapshotKeyProvider)
 	if err != nil {
-		logging.Warn("failed to initialize snapshot manager", logging.Err(err), logging.Component("daemon"))
+		log.Fatalf("Failed to initialize snapshot manager: %v", err)
 	}
 
 	// Initialize checkpoint system
@@ -731,11 +759,41 @@ func main() {
 				storageDataDir = filepath.Join(cfg.Daemon.DataDir, "storage")
 			}
 			storageEngine, storageErr := storage.NewStorageEngine(storageDataDir, stateStore, storage.EngineConfig{
-				MaxBuckets:    cfg.Storage.MaxBuckets,
-				MaxObjectSize: cfg.Storage.MaxObjectSize,
+				MaxBuckets:                cfg.Storage.MaxBuckets,
+				MaxObjectSize:             cfg.Storage.MaxObjectSize,
+				EncryptedMaxInMemoryBytes: cfg.Storage.EncryptedMaxInMemoryBytes,
 			})
 			if storageErr != nil {
 				log.Fatalf("Failed to create storage engine: %v", storageErr)
+			}
+			// KEY-01: opt-in at-rest object encryption. Each object's DEK is
+			// sealed to the provider's own stable X25519 key (self-recipient
+			// model, same key file as exec/R5). LoadOrCreateProviderKey reads the
+			// same persisted DataDir/provider_x25519.key the ContainerManager uses,
+			// so the keys match.
+			if cfg.Storage.EncryptionEnabled {
+				pk, pkErr := daemon.LoadOrCreateProviderKey(cfg.Daemon.DataDir)
+				if pkErr != nil {
+					log.Fatalf("Failed to load provider key for storage encryption: %v", pkErr)
+				}
+				ks, ksErr := storage.NewProviderKeyStore(pk)
+				if ksErr != nil {
+					log.Fatalf("Failed to build storage owner key store: %v", ksErr)
+				}
+				storageEngine.WithOwnerKeyStore(ks)
+				// KEY-01 (operator caveat): objects are sealed to the provider's own
+				// X25519 key at DataDir/provider_x25519.key (self-recipient model,
+				// same limitation as R5 image encryption). There is currently NO key
+				// rotation and NO recovery path: if that key file is lost or
+				// regenerated, every previously-encrypted object becomes permanently
+				// undecryptable (a GetObject would fail at decrypt time, not at
+				// startup). Surface this loudly at startup so the key file is backed
+				// up alongside other daemon secrets.
+				logging.Warn("object storage at-rest encryption enabled — KEY LOSS IS DATA LOSS: "+
+					"objects are sealed to provider_x25519.key with no rotation/recovery path; "+
+					"back up DataDir/provider_x25519.key",
+					"key_file", filepath.Join(cfg.Daemon.DataDir, "provider_x25519.key"),
+					logging.Component("daemon"))
 			}
 			// Wire storage usage metering for billing (PaymentService satisfies
 			// storage.MeteringHook structurally).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -420,6 +420,13 @@ type SecurityConfig struct {
 	// ciphertext; decryption happens in-process just before unpack. See
 	// internal/runtime/image_encrypt.go for the threat model and boundaries.
 	ImageEncryptionEnabled bool `yaml:"image_encryption_enabled"`
+
+	// KEY-01 — at-rest state key rotation sweep. When true, the daemon runs an
+	// idempotent RotateKey pass over the bbolt store on startup, re-encrypting
+	// every value with the current state key and bumping the on-disk magic to
+	// MBENC2. Default false (lazy migration on next write). Use after a key
+	// change or to eagerly retag a legacy (MBENC1) database.
+	StateKeyRotationSweep bool `yaml:"state_key_rotation_sweep"`
 }
 
 // RedundancyConfig contains redundancy settings
@@ -526,6 +533,21 @@ type StorageConfig struct {
 	MaxObjectSize int64  `yaml:"max_object_size"` // Max single object size in bytes (default: 5GB)
 	S3Port        int    `yaml:"s3_port"`         // S3-compatible API port (default: 9300)
 	EnableS3      bool   `yaml:"enable_s3"`       // Enable S3-compatible endpoint
+
+	// KEY-01 — at-rest object encryption. When true (and the provider X25519
+	// key is available), object blobs are encrypted with a per-object DEK sealed
+	// to the provider's own X25519 key (self-recipient model, matching R5 image
+	// encryption). Default false: blobs are stored as plaintext. Objects written
+	// before this was enabled remain readable (back-compat read path).
+	EncryptionEnabled bool `yaml:"encryption_enabled"`
+
+	// KEY-01 — in-memory ceiling for the (non-streaming) encrypted object path.
+	// When EncryptionEnabled is true, encrypted PutObject/GetObject buffer the
+	// whole object in memory to seal/open it, so an object larger than this is
+	// rejected to avoid OOM. Only consulted when encryption is enabled. Zero
+	// falls back to the engine default (256MB). A streaming/chunked AEAD that
+	// removes this ceiling is a follow-up.
+	EncryptedMaxInMemoryBytes int64 `yaml:"encrypted_max_in_memory_bytes"`
 }
 
 // DefaultStorageConfig returns the default storage configuration.

--- a/internal/daemon/provider_key.go
+++ b/internal/daemon/provider_key.go
@@ -96,3 +96,13 @@ func (pm *ProviderKeyManager) privateKey() []byte {
 	copy(out, pm.privKey)
 	return out
 }
+
+// PrivateKey returns a COPY of the 32-byte X25519 private key for daemon-internal
+// at-rest decryption (e.g. storage DEK unwrapping in the self-recipient model).
+// It is a thin exported wrapper over privateKey() so other in-process packages
+// (storage) can unwrap DEKs sealed to this provider; the secret still never
+// leaves the daemon process and is never logged or serialized. Each call returns
+// a fresh copy so the live key slice is never aliased.
+func (pm *ProviderKeyManager) PrivateKey() []byte {
+	return pm.privateKey()
+}

--- a/internal/snapshot/keyprovider.go
+++ b/internal/snapshot/keyprovider.go
@@ -1,0 +1,298 @@
+package snapshot
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/99designs/keyring"
+
+	"github.com/moltbunker/moltbunker/internal/logging"
+	"github.com/moltbunker/moltbunker/internal/security"
+)
+
+// KeyProvider supplies the 32-byte AES-256 master key used to encrypt snapshot
+// data at rest. It replaces the implicit raw-file-or-silent-ephemeral behavior
+// of the old initEncryption() helper: every backend is explicit and named, and
+// NONE of them silently generates an ephemeral key that is lost on restart. A
+// provider that cannot produce a stable key returns a hard error so the daemon
+// fails closed rather than writing unrecoverable snapshots.
+//
+// Backends:
+//   - FileKeyProvider:    32 raw bytes at a 0600 file under DataDir (default).
+//   - KeyringKeyProvider: OS keychain via github.com/99designs/keyring
+//     (darwin Keychain, linux SecretService/kwallet). Headless servers without
+//     a keyring daemon should use the "file" or "env" backend instead.
+//   - EnvKeyProvider:     hex-encoded 32 bytes from MOLTBUNKER_SNAPSHOT_KEY,
+//     for container/CI environments with no keyring and no writable DataDir.
+type KeyProvider interface {
+	// MasterKey returns the 32-byte master key, or an error. Implementations
+	// must NEVER return a randomly generated key that is not persisted — a key
+	// the caller cannot reproduce on the next start silently destroys every
+	// snapshot. MasterKey is called on each encrypt/decrypt; implementations
+	// that talk to an external store should cache after the first call.
+	MasterKey() ([]byte, error)
+}
+
+const masterKeySize = 32
+
+// snapshotKeyEnvVar is the environment variable read by EnvKeyProvider.
+const snapshotKeyEnvVar = "MOLTBUNKER_SNAPSHOT_KEY"
+
+// keyringService is the service/collection name used for the OS keyring entry.
+const keyringService = "moltbunker-snapshot"
+
+// keyringItemKey is the item key (label) for the snapshot master key entry.
+const keyringItemKey = "snapshot-master-key"
+
+// --- File backend ---
+
+// FileKeyProvider reads (or, on first use, generates and persists) a 32-byte
+// master key at a fixed path with 0600 permissions. This mirrors
+// state.LoadOrCreateStateKey and daemon.LoadOrCreateProviderKey: the key
+// survives restarts, so snapshots remain decryptable. It is the safe default.
+type FileKeyProvider struct {
+	path string
+	mu   sync.Mutex
+	key  []byte
+}
+
+// NewFileKeyProvider returns a file-backed provider for the given key path. The
+// path is expected to be DataDir-scoped (never request input). The key is not
+// read or generated until the first MasterKey call.
+func NewFileKeyProvider(path string) (*FileKeyProvider, error) {
+	if path == "" {
+		return nil, fmt.Errorf("snapshot file key provider: empty key path")
+	}
+	return &FileKeyProvider{path: path}, nil
+}
+
+// MasterKey loads the key from disk, generating and persisting a fresh one if
+// the file does not yet exist. A file with the wrong size is a hard error
+// (never silently regenerated — that would orphan existing snapshots).
+func (p *FileKeyProvider) MasterKey() ([]byte, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.key != nil {
+		return cloneKey(p.key), nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(p.path), 0700); err != nil {
+		return nil, fmt.Errorf("create snapshot key dir: %w", err)
+	}
+
+	// #nosec G304 -- path is DataDir-scoped config, not request input.
+	if data, err := os.ReadFile(p.path); err == nil {
+		if len(data) != masterKeySize {
+			return nil, fmt.Errorf("snapshot key file %s has invalid size %d (expected %d)", p.path, len(data), masterKeySize)
+		}
+		p.key = cloneKey(data)
+		logging.Debug("loaded snapshot master key from file", logging.Component("snapshot"))
+		return cloneKey(p.key), nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read snapshot key file: %w", err)
+	}
+
+	key, err := security.GenerateKey(masterKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("generate snapshot key: %w", err)
+	}
+	if err := os.WriteFile(p.path, key, 0600); err != nil {
+		return nil, fmt.Errorf("persist snapshot key: %w", err)
+	}
+	p.key = cloneKey(key)
+	logging.Info("generated new snapshot master key", "path", p.path, logging.Component("snapshot"))
+	return cloneKey(p.key), nil
+}
+
+// --- Keyring backend ---
+
+// keyringOpener is overridable in tests so the interface contract can be
+// exercised against an in-memory keyring without an OS keychain prompt.
+var keyringOpener = func(cfg keyring.Config) (keyring.Keyring, error) {
+	return keyring.Open(cfg)
+}
+
+// KeyringKeyProvider stores the 32-byte master key in the OS keychain. On a
+// fully headless Linux server with no SecretService/kwallet daemon, keyring.Open
+// may fall back to an encrypted file backend that prompts for a password, which
+// is unsuitable for an unattended daemon — use the "file" or "env" backend
+// there instead. The key is fetched once and cached in memory.
+type KeyringKeyProvider struct {
+	service string
+	itemKey string
+	fileDir string // FileBackend fallback dir (DataDir-scoped)
+
+	mu  sync.Mutex
+	key []byte
+}
+
+// NewKeyringKeyProvider returns an OS-keyring-backed provider. fileDir is used
+// only as the FileBackend fallback location (DataDir-scoped); it never holds a
+// plaintext key (the FileBackend is itself encrypted by the keyring library).
+func NewKeyringKeyProvider(service, itemKey, fileDir string) *KeyringKeyProvider {
+	if service == "" {
+		service = keyringService
+	}
+	if itemKey == "" {
+		itemKey = keyringItemKey
+	}
+	return &KeyringKeyProvider{service: service, itemKey: itemKey, fileDir: fileDir}
+}
+
+func (p *KeyringKeyProvider) open() (keyring.Keyring, error) {
+	return keyringOpener(keyring.Config{
+		ServiceName:                    p.service,
+		KeychainName:                   p.service,
+		KeychainTrustApplication:       true,
+		KeychainAccessibleWhenUnlocked: true,
+		LibSecretCollectionName:        p.service,
+		FileDir:                        p.fileDir,
+		// FilePasswordFunc is only consulted for the encrypted FileBackend
+		// fallback; a real headless deployment should use the "file"/"env"
+		// snapshot backend rather than rely on this.
+		FilePasswordFunc: func(string) (string, error) {
+			return "", fmt.Errorf("keyring file backend requires interactive password; use the \"file\" or \"env\" snapshot key backend on headless hosts")
+		},
+	})
+}
+
+// MasterKey fetches the key from the OS keyring, generating and storing a fresh
+// one on first use. A failure to open the keyring is a hard error (no silent
+// ephemeral fallback).
+func (p *KeyringKeyProvider) MasterKey() ([]byte, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.key != nil {
+		return cloneKey(p.key), nil
+	}
+
+	ring, err := p.open()
+	if err != nil {
+		return nil, fmt.Errorf("open OS keyring (use \"file\" or \"env\" backend on headless hosts): %w", err)
+	}
+
+	item, err := ring.Get(p.itemKey)
+	if err == nil {
+		if len(item.Data) != masterKeySize {
+			return nil, fmt.Errorf("keyring snapshot key has invalid size %d (expected %d)", len(item.Data), masterKeySize)
+		}
+		p.key = cloneKey(item.Data)
+		logging.Debug("loaded snapshot master key from OS keyring", logging.Component("snapshot"))
+		return cloneKey(p.key), nil
+	}
+	if err != keyring.ErrKeyNotFound {
+		return nil, fmt.Errorf("read snapshot key from keyring: %w", err)
+	}
+
+	// Not present yet: generate and store.
+	key, gerr := security.GenerateKey(masterKeySize)
+	if gerr != nil {
+		return nil, fmt.Errorf("generate snapshot key: %w", gerr)
+	}
+	if serr := ring.Set(keyring.Item{
+		Key:         p.itemKey,
+		Data:        key,
+		Label:       p.itemKey,
+		Description: "moltbunker snapshot master key (AES-256)",
+	}); serr != nil {
+		return nil, fmt.Errorf("store snapshot key in keyring: %w", serr)
+	}
+	p.key = cloneKey(key)
+	logging.Info("generated new snapshot master key in OS keyring", logging.Component("snapshot"))
+	return cloneKey(p.key), nil
+}
+
+// --- Env backend ---
+
+// EnvKeyProvider reads the master key from MOLTBUNKER_SNAPSHOT_KEY as a
+// hex-encoded 32-byte value. It never touches disk. Intended for container/CI
+// environments. A missing or malformed variable is a hard error.
+type EnvKeyProvider struct {
+	envVar string
+}
+
+// NewEnvKeyProvider returns an env-backed provider reading the default env var.
+func NewEnvKeyProvider() *EnvKeyProvider {
+	return &EnvKeyProvider{envVar: snapshotKeyEnvVar}
+}
+
+// MasterKey decodes the hex value from the environment. The decoded value must
+// be exactly 32 bytes.
+func (p *EnvKeyProvider) MasterKey() ([]byte, error) {
+	raw := os.Getenv(p.envVar)
+	if raw == "" {
+		return nil, fmt.Errorf("snapshot env key provider: %s is not set", p.envVar)
+	}
+	key, err := hex.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot env key provider: %s is not valid hex: %w", p.envVar, err)
+	}
+	if len(key) != masterKeySize {
+		return nil, fmt.Errorf("snapshot env key provider: %s decodes to %d bytes (expected %d)", p.envVar, len(key), masterKeySize)
+	}
+	return key, nil
+}
+
+// --- Factory ---
+
+// NewKeyProviderFromConfig builds the KeyProvider selected by the snapshot
+// config. Backend selection:
+//   - "file" (default): FileKeyProvider at cfg.EncryptionKeyPath, or
+//     dataDir/snapshots/.snapshot_key when the path is empty.
+//   - "keyring":         KeyringKeyProvider (OS keychain).
+//   - "env":             EnvKeyProvider (MOLTBUNKER_SNAPSHOT_KEY).
+//
+// For back-compat, an empty KeyProviderBackend defaults to "file" using the
+// legacy EncryptionKeyPath / StoragePath-derived path so existing deployments
+// keep decrypting their snapshots with the same key.
+func NewKeyProviderFromConfig(cfg *SnapshotConfig, dataDir string) (KeyProvider, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("snapshot key provider: nil config")
+	}
+
+	backend := cfg.KeyProviderBackend
+	if backend == "" {
+		backend = "file"
+	}
+
+	switch backend {
+	case "file":
+		path := cfg.EncryptionKeyPath
+		if path == "" {
+			base := cfg.StoragePath
+			if base == "" && dataDir != "" {
+				base = filepath.Join(dataDir, "snapshots")
+			}
+			if base == "" {
+				return nil, fmt.Errorf("snapshot file key provider: no key path and no storage path/data dir to derive one")
+			}
+			path = filepath.Join(base, ".snapshot_key")
+		}
+		return NewFileKeyProvider(path)
+	case "keyring":
+		service := cfg.KeyringServiceName
+		if service == "" {
+			service = keyringService
+		}
+		fileDir := cfg.StoragePath
+		if fileDir == "" && dataDir != "" {
+			fileDir = filepath.Join(dataDir, "snapshots")
+		}
+		return NewKeyringKeyProvider(service, keyringItemKey, fileDir), nil
+	case "env":
+		return NewEnvKeyProvider(), nil
+	default:
+		return nil, fmt.Errorf("snapshot key provider: unknown backend %q (want \"file\", \"keyring\", or \"env\")", backend)
+	}
+}
+
+// cloneKey returns a defensive copy so the cached key slice is never aliased
+// into callers (which could retain or mutate the live secret).
+func cloneKey(k []byte) []byte {
+	out := make([]byte, len(k))
+	copy(out, k)
+	return out
+}

--- a/internal/snapshot/keyprovider_keyring_test.go
+++ b/internal/snapshot/keyprovider_keyring_test.go
@@ -1,0 +1,38 @@
+//go:build keyring_integration
+
+// Package snapshot keyring integration test.
+//
+// This test talks to the real OS keyring (darwin Keychain, linux
+// SecretService/kwallet) and is therefore excluded from the default
+// `go test ./...` run. Run it explicitly with:
+//
+//	go test -tags keyring_integration ./internal/snapshot/...
+//
+// It may prompt for keychain access on first run.
+package snapshot
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestKeyringKeyProvider_RoundTrip(t *testing.T) {
+	p := NewKeyringKeyProvider("moltbunker-snapshot-test", "snapshot-master-key-test", t.TempDir())
+
+	k1, err := p.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey (generate): %v", err)
+	}
+	if len(k1) != masterKeySize {
+		t.Fatalf("key size = %d, want %d", len(k1), masterKeySize)
+	}
+
+	p2 := NewKeyringKeyProvider("moltbunker-snapshot-test", "snapshot-master-key-test", t.TempDir())
+	k2, err := p2.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey (reload): %v", err)
+	}
+	if !bytes.Equal(k1, k2) {
+		t.Error("reloaded keyring key differs from stored key")
+	}
+}

--- a/internal/snapshot/keyprovider_test.go
+++ b/internal/snapshot/keyprovider_test.go
@@ -1,0 +1,237 @@
+package snapshot
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/99designs/keyring"
+)
+
+func TestFileKeyProvider_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".snapshot_key")
+
+	p, err := NewFileKeyProvider(path)
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+
+	k1, err := p.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey (generate): %v", err)
+	}
+	if len(k1) != masterKeySize {
+		t.Fatalf("key size = %d, want %d", len(k1), masterKeySize)
+	}
+
+	// A fresh provider at the same path must load the SAME key (no orphaning).
+	p2, err := NewFileKeyProvider(path)
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider 2: %v", err)
+	}
+	k2, err := p2.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey (reload): %v", err)
+	}
+	if !bytes.Equal(k1, k2) {
+		t.Error("reloaded key differs from persisted key")
+	}
+
+	// Cached call returns the same key.
+	k3, err := p.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey (cached): %v", err)
+	}
+	if !bytes.Equal(k1, k3) {
+		t.Error("cached key differs")
+	}
+
+	// Returned slice must be a copy, not the cached backing array.
+	k1[0] ^= 0xFF
+	k4, _ := p.MasterKey()
+	if bytes.Equal(k1, k4) {
+		t.Error("MasterKey returned an aliased slice; mutation leaked into cache")
+	}
+}
+
+func TestFileKeyProvider_InvalidSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".snapshot_key")
+	if err := os.WriteFile(path, []byte("too short"), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	p, err := NewFileKeyProvider(path)
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+	if _, err := p.MasterKey(); err == nil {
+		t.Fatal("expected error for wrong-size key file, got nil")
+	}
+}
+
+func TestFileKeyProvider_EmptyPath(t *testing.T) {
+	if _, err := NewFileKeyProvider(""); err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestEnvKeyProvider_Missing(t *testing.T) {
+	t.Setenv(snapshotKeyEnvVar, "")
+	p := NewEnvKeyProvider()
+	if _, err := p.MasterKey(); err == nil {
+		t.Fatal("expected error when env var is unset")
+	}
+}
+
+func TestEnvKeyProvider_WrongLength(t *testing.T) {
+	t.Setenv(snapshotKeyEnvVar, "abcd") // valid hex, but only 2 bytes
+	p := NewEnvKeyProvider()
+	if _, err := p.MasterKey(); err == nil {
+		t.Fatal("expected error for wrong-length key")
+	}
+}
+
+func TestEnvKeyProvider_InvalidHex(t *testing.T) {
+	t.Setenv(snapshotKeyEnvVar, "not-hex-zzzz")
+	p := NewEnvKeyProvider()
+	if _, err := p.MasterKey(); err == nil {
+		t.Fatal("expected error for invalid hex")
+	}
+}
+
+func TestEnvKeyProvider_Valid(t *testing.T) {
+	want := make([]byte, masterKeySize)
+	for i := range want {
+		want[i] = byte(i)
+	}
+	t.Setenv(snapshotKeyEnvVar, hex.EncodeToString(want))
+
+	p := NewEnvKeyProvider()
+	got, err := p.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("key mismatch: got %x want %x", got, want)
+	}
+}
+
+func TestNewKeyProviderFromConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("default is file", func(t *testing.T) {
+		kp, err := NewKeyProviderFromConfig(&SnapshotConfig{StoragePath: dir}, dir)
+		if err != nil {
+			t.Fatalf("factory: %v", err)
+		}
+		if _, ok := kp.(*FileKeyProvider); !ok {
+			t.Errorf("default backend = %T, want *FileKeyProvider", kp)
+		}
+	})
+
+	t.Run("explicit env", func(t *testing.T) {
+		kp, err := NewKeyProviderFromConfig(&SnapshotConfig{KeyProviderBackend: "env"}, dir)
+		if err != nil {
+			t.Fatalf("factory: %v", err)
+		}
+		if _, ok := kp.(*EnvKeyProvider); !ok {
+			t.Errorf("backend = %T, want *EnvKeyProvider", kp)
+		}
+	})
+
+	t.Run("explicit keyring", func(t *testing.T) {
+		kp, err := NewKeyProviderFromConfig(&SnapshotConfig{KeyProviderBackend: "keyring", StoragePath: dir}, dir)
+		if err != nil {
+			t.Fatalf("factory: %v", err)
+		}
+		if _, ok := kp.(*KeyringKeyProvider); !ok {
+			t.Errorf("backend = %T, want *KeyringKeyProvider", kp)
+		}
+	})
+
+	t.Run("unknown backend errors", func(t *testing.T) {
+		if _, err := NewKeyProviderFromConfig(&SnapshotConfig{KeyProviderBackend: "bogus"}, dir); err == nil {
+			t.Fatal("expected error for unknown backend")
+		}
+	})
+
+	t.Run("nil config errors", func(t *testing.T) {
+		if _, err := NewKeyProviderFromConfig(nil, dir); err == nil {
+			t.Fatal("expected error for nil config")
+		}
+	})
+}
+
+// TestKeyringKeyProvider_MockBackend exercises the KeyringKeyProvider contract
+// against an in-memory keyring (no OS keychain prompt) by overriding the opener.
+func TestKeyringKeyProvider_MockBackend(t *testing.T) {
+	orig := keyringOpener
+	t.Cleanup(func() { keyringOpener = orig })
+
+	ring := newMemKeyring()
+	keyringOpener = func(_ keyring.Config) (keyring.Keyring, error) {
+		return ring, nil
+	}
+
+	p := NewKeyringKeyProvider("", "", t.TempDir())
+	k1, err := p.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey (generate): %v", err)
+	}
+	if len(k1) != masterKeySize {
+		t.Fatalf("key size = %d, want %d", len(k1), masterKeySize)
+	}
+
+	// A second provider must reload the same key from the (shared) keyring.
+	p2 := NewKeyringKeyProvider("", "", t.TempDir())
+	k2, err := p2.MasterKey()
+	if err != nil {
+		t.Fatalf("MasterKey (reload): %v", err)
+	}
+	if !bytes.Equal(k1, k2) {
+		t.Error("reloaded keyring key differs from stored key")
+	}
+}
+
+// memKeyring is a minimal in-memory keyring.Keyring for tests.
+type memKeyring struct {
+	items map[string]keyring.Item
+}
+
+func newMemKeyring() *memKeyring {
+	return &memKeyring{items: make(map[string]keyring.Item)}
+}
+
+func (m *memKeyring) Get(key string) (keyring.Item, error) {
+	it, ok := m.items[key]
+	if !ok {
+		return keyring.Item{}, keyring.ErrKeyNotFound
+	}
+	return it, nil
+}
+
+func (m *memKeyring) GetMetadata(string) (keyring.Metadata, error) {
+	return keyring.Metadata{}, keyring.ErrMetadataNotSupported
+}
+
+func (m *memKeyring) Set(item keyring.Item) error {
+	m.items[item.Key] = item
+	return nil
+}
+
+func (m *memKeyring) Remove(key string) error {
+	delete(m.items, key)
+	return nil
+}
+
+func (m *memKeyring) Keys() ([]string, error) {
+	out := make([]string, 0, len(m.items))
+	for k := range m.items {
+		out = append(out, k)
+	}
+	return out, nil
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -66,8 +66,18 @@ type SnapshotConfig struct {
 	CompressionLevel int    `yaml:"compression_level"`  // 0-9, 0 = none
 
 	// Encryption settings
-	EncryptionEnabled bool   `yaml:"encryption_enabled"` // Enable encryption at rest
-	EncryptionKeyPath string `yaml:"encryption_key_path"` // Path to master encryption key
+	EncryptionEnabled bool   `yaml:"encryption_enabled"`  // Enable encryption at rest
+	EncryptionKeyPath string `yaml:"encryption_key_path"` // Deprecated: path to master key (file backend). Kept for back-compat; prefer KeyProviderBackend.
+
+	// KeyProviderBackend selects how the master key is sourced: "file" (default,
+	// 0600 file under DataDir), "keyring" (OS keychain), or "env"
+	// (MOLTBUNKER_SNAPSHOT_KEY hex). Empty defaults to "file" using
+	// EncryptionKeyPath for back-compat. There is NO ephemeral backend: a key
+	// the daemon cannot reproduce on restart would orphan every snapshot.
+	KeyProviderBackend string `yaml:"key_provider_backend"`
+	// KeyringServiceName overrides the OS-keyring service/collection name when
+	// KeyProviderBackend is "keyring". Empty uses the built-in default.
+	KeyringServiceName string `yaml:"keyring_service_name"`
 
 	// Retention
 	RetentionDays int `yaml:"retention_days"` // Days to keep snapshots
@@ -87,16 +97,24 @@ func DefaultSnapshotConfig() *SnapshotConfig {
 
 // Manager handles snapshot creation and lifecycle
 type Manager struct {
-	config        *SnapshotConfig
-	mu            sync.RWMutex
-	snapshots     map[string][]*Snapshot // containerID -> snapshots
-	totalSize     int64
-	encryptionKey []byte                          // Master encryption key (32 bytes for AES-256)
-	blockHashes   map[string]map[int64]string     // containerID -> offset -> hash (for incremental)
+	config      *SnapshotConfig
+	mu          sync.RWMutex
+	snapshots   map[string][]*Snapshot // containerID -> snapshots
+	totalSize   int64
+	keyProvider KeyProvider                 // sources the AES-256 master key (nil when encryption disabled)
+	blockHashes map[string]map[int64]string // containerID -> offset -> hash (for incremental)
 }
 
-// NewManager creates a new snapshot manager
-func NewManager(config *SnapshotConfig) (*Manager, error) {
+// NewManager creates a new snapshot manager.
+//
+// When EncryptionEnabled is true a KeyProvider MUST be supplied as the optional
+// second argument; passing none (or a nil provider) is a hard error rather than
+// the old silent-ephemeral fallback, so a misconfigured daemon fails closed
+// instead of writing snapshots that cannot be recovered after restart. The
+// provider is verified at construction (MasterKey is called once) so an
+// unreadable keyring/file fails startup rather than the first snapshot. When
+// EncryptionEnabled is false the provider argument is ignored.
+func NewManager(config *SnapshotConfig, keyProvider ...KeyProvider) (*Manager, error) {
 	if config == nil {
 		config = DefaultSnapshotConfig()
 	}
@@ -114,11 +132,21 @@ func NewManager(config *SnapshotConfig) (*Manager, error) {
 		blockHashes: make(map[string]map[int64]string),
 	}
 
-	// Initialize encryption if enabled
+	// Initialize encryption if enabled. The key provider is required and must
+	// produce a usable key now — no silent ephemeral fallback.
 	if config.EncryptionEnabled {
-		if err := m.initEncryption(); err != nil {
-			return nil, fmt.Errorf("failed to initialize encryption: %w", err)
+		var kp KeyProvider
+		if len(keyProvider) > 0 {
+			kp = keyProvider[0]
 		}
+		if kp == nil {
+			return nil, fmt.Errorf("snapshot encryption enabled but no key provider supplied (refusing to use an ephemeral key)")
+		}
+		// Fail closed if the key cannot be sourced.
+		if _, err := kp.MasterKey(); err != nil {
+			return nil, fmt.Errorf("snapshot key provider failed: %w", err)
+		}
+		m.keyProvider = kp
 	}
 
 	// Load existing snapshots
@@ -129,53 +157,6 @@ func NewManager(config *SnapshotConfig) (*Manager, error) {
 	}
 
 	return m, nil
-}
-
-// initEncryption initializes or loads the encryption key
-func (m *Manager) initEncryption() error {
-	keyPath := m.config.EncryptionKeyPath
-	if keyPath == "" && m.config.StoragePath != "" {
-		keyPath = filepath.Join(m.config.StoragePath, ".snapshot_key")
-	}
-
-	if keyPath == "" {
-		// Generate ephemeral key if no path specified
-		key, err := security.GenerateKey(32)
-		if err != nil {
-			return fmt.Errorf("failed to generate encryption key: %w", err)
-		}
-		m.encryptionKey = key
-		logging.Warn("using ephemeral encryption key - snapshots will not be recoverable after restart",
-			logging.Component("snapshot"))
-		return nil
-	}
-
-	// Try to load existing key
-	// #nosec G304 -- keyPath is from config (EncryptionKeyPath or StoragePath-derived), not request input
-	if data, err := os.ReadFile(keyPath); err == nil && len(data) == 32 {
-		m.encryptionKey = data
-		logging.Debug("loaded existing encryption key",
-			logging.Component("snapshot"))
-		return nil
-	}
-
-	// Generate new key
-	key, err := security.GenerateKey(32)
-	if err != nil {
-		return fmt.Errorf("failed to generate encryption key: %w", err)
-	}
-
-	// Save key with restrictive permissions
-	if err := os.WriteFile(keyPath, key, 0600); err != nil {
-		return fmt.Errorf("failed to save encryption key: %w", err)
-	}
-
-	m.encryptionKey = key
-	logging.Info("generated new encryption key",
-		"path", keyPath,
-		logging.Component("snapshot"))
-
-	return nil
 }
 
 // compressData compresses data using gzip
@@ -218,22 +199,28 @@ func (m *Manager) decompressData(data []byte) ([]byte, error) {
 	return decompressed, nil
 }
 
-// encryptData encrypts data using AES-256-GCM
+// encryptData encrypts data using AES-256-GCM with the provider's master key.
 func (m *Manager) encryptData(data []byte) ([]byte, error) {
-	if !m.config.EncryptionEnabled || m.encryptionKey == nil {
+	if !m.config.EncryptionEnabled || m.keyProvider == nil {
 		return data, nil
 	}
-
-	return security.EncryptAES256GCM(m.encryptionKey, data)
+	key, err := m.keyProvider.MasterKey()
+	if err != nil {
+		return nil, fmt.Errorf("snapshot master key: %w", err)
+	}
+	return security.EncryptAES256GCM(key, data)
 }
 
-// decryptData decrypts data using AES-256-GCM
+// decryptData decrypts data using AES-256-GCM with the provider's master key.
 func (m *Manager) decryptData(data []byte) ([]byte, error) {
-	if !m.config.EncryptionEnabled || m.encryptionKey == nil {
+	if !m.config.EncryptionEnabled || m.keyProvider == nil {
 		return data, nil
 	}
-
-	return security.DecryptAES256GCM(m.encryptionKey, data)
+	key, err := m.keyProvider.MasterKey()
+	if err != nil {
+		return nil, fmt.Errorf("snapshot master key: %w", err)
+	}
+	return security.DecryptAES256GCM(key, data)
 }
 
 // computeBlockHashes computes hashes for each block of data
@@ -457,7 +444,7 @@ func (m *Manager) CreateSnapshot(containerID string, data []byte, snapshotType S
 	// Encrypt data
 	encrypted := false
 	keyID := ""
-	if m.config.EncryptionEnabled && m.encryptionKey != nil {
+	if m.config.EncryptionEnabled && m.keyProvider != nil {
 		encryptedData, err := m.encryptData(dataToStore)
 		if err != nil {
 			return nil, fmt.Errorf("encryption failed: %w", err)
@@ -1064,22 +1051,39 @@ func readInt32(r io.Reader) (int32, error) {
 	return int32(buf[0])<<24 | int32(buf[1])<<16 | int32(buf[2])<<8 | int32(buf[3]), nil
 }
 
-// RotateEncryptionKey rotates the encryption key and re-encrypts all snapshots
-func (m *Manager) RotateEncryptionKey() error {
+// RotateEncryptionKey re-encrypts all snapshots from the current master key to
+// the key produced by newProvider, then swaps the manager's provider over.
+//
+// The caller owns the new key's persistence: newProvider must itself persist
+// the new key (FileKeyProvider/KeyringKeyProvider do this on first MasterKey),
+// so callers can rotate to a new keyring entry or a new file. Atomicity caveat:
+// snapshots are re-encrypted one file at a time and the provider swap happens
+// last, so a crash mid-rotation leaves some files on the old key and some on
+// the new key; the new provider's key must remain available to recover. This is
+// the same (non-atomic) guarantee as the previous implementation.
+func (m *Manager) RotateEncryptionKey(newProvider KeyProvider) error {
 	if !m.config.EncryptionEnabled {
 		return fmt.Errorf("encryption not enabled")
+	}
+	if newProvider == nil {
+		return fmt.Errorf("rotate snapshot key: nil key provider")
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Generate new key
-	newKey, err := security.GenerateKey(32)
-	if err != nil {
-		return fmt.Errorf("failed to generate new key: %w", err)
+	if m.keyProvider == nil {
+		return fmt.Errorf("rotate snapshot key: no current key provider")
 	}
 
-	oldKey := m.encryptionKey
+	oldKey, err := m.keyProvider.MasterKey()
+	if err != nil {
+		return fmt.Errorf("rotate snapshot key: read current key: %w", err)
+	}
+	newKey, err := newProvider.MasterKey()
+	if err != nil {
+		return fmt.Errorf("rotate snapshot key: read new key: %w", err)
+	}
 
 	// Re-encrypt all snapshots
 	for _, snaps := range m.snapshots {
@@ -1129,17 +1133,9 @@ func (m *Manager) RotateEncryptionKey() error {
 		}
 	}
 
-	// Save new key
-	m.encryptionKey = newKey
-	keyPath := m.config.EncryptionKeyPath
-	if keyPath == "" && m.config.StoragePath != "" {
-		keyPath = filepath.Join(m.config.StoragePath, ".snapshot_key")
-	}
-	if keyPath != "" {
-		if err := os.WriteFile(keyPath, newKey, 0600); err != nil {
-			return fmt.Errorf("failed to save new key: %w", err)
-		}
-	}
+	// Swap provider last so reads keep using the old key until every file is
+	// converted.
+	m.keyProvider = newProvider
 
 	logging.Info("encryption key rotated",
 		logging.Component("snapshot"))

--- a/internal/snapshot/snapshot_encryption_test.go
+++ b/internal/snapshot/snapshot_encryption_test.go
@@ -1,0 +1,141 @@
+package snapshot
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// failingKeyProvider always errors, used to assert fail-closed behavior.
+type failingKeyProvider struct{}
+
+func (failingKeyProvider) MasterKey() ([]byte, error) {
+	return nil, fmt.Errorf("simulated key provider failure")
+}
+
+func TestManager_KeyProviderError(t *testing.T) {
+	// EncryptionEnabled with a failing provider must error rather than silently
+	// going ephemeral.
+	_, err := NewManager(&SnapshotConfig{
+		StoragePath:       t.TempDir(),
+		MaxSnapshots:      5,
+		EncryptionEnabled: true,
+		RetentionDays:     7,
+	}, failingKeyProvider{})
+	if err == nil {
+		t.Fatal("expected NewManager to fail when key provider errors")
+	}
+}
+
+func TestManager_EncryptionRequiresProvider(t *testing.T) {
+	// EncryptionEnabled with NO provider must be a hard error (no ephemeral key).
+	_, err := NewManager(&SnapshotConfig{
+		StoragePath:       t.TempDir(),
+		MaxSnapshots:      5,
+		EncryptionEnabled: true,
+		RetentionDays:     7,
+	})
+	if err == nil {
+		t.Fatal("expected NewManager to fail when encryption enabled but no provider supplied")
+	}
+}
+
+func TestManager_EncryptedRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, ".snapshot_key")
+
+	provider, err := NewFileKeyProvider(keyPath)
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+
+	m, err := NewManager(&SnapshotConfig{
+		StoragePath:       dir,
+		MaxSnapshots:      10,
+		MaxTotalSize:      10 * 1024 * 1024,
+		CompressionLevel:  0,
+		EncryptionEnabled: true,
+		RetentionDays:     7,
+	}, provider)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	plaintext := []byte("sensitive container state that must be encrypted at rest")
+	snap, err := m.CreateSnapshot("c1", plaintext, SnapshotTypeFull, nil)
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if !snap.Encrypted {
+		t.Fatal("snapshot should be marked encrypted")
+	}
+
+	// On-disk blob must NOT contain the plaintext.
+	onDisk, err := os.ReadFile(snap.DataPath)
+	if err != nil {
+		t.Fatalf("read blob: %v", err)
+	}
+	if bytes.Contains(onDisk, plaintext) {
+		t.Fatal("plaintext leaked into encrypted snapshot blob")
+	}
+
+	// Round-trip decrypts correctly.
+	got, err := m.GetSnapshotData(snap.ID)
+	if err != nil {
+		t.Fatalf("GetSnapshotData: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("round-trip mismatch: got %q want %q", got, plaintext)
+	}
+}
+
+func TestManager_RotateEncryptionKey(t *testing.T) {
+	dir := t.TempDir()
+	provider, err := NewFileKeyProvider(filepath.Join(dir, ".snapshot_key"))
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+
+	m, err := NewManager(&SnapshotConfig{
+		StoragePath:       dir,
+		MaxSnapshots:      10,
+		MaxTotalSize:      10 * 1024 * 1024,
+		CompressionLevel:  0,
+		EncryptionEnabled: true,
+		RetentionDays:     7,
+	}, provider)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	plaintext := []byte("rotate me")
+	snap, err := m.CreateSnapshot("c1", plaintext, SnapshotTypeFull, nil)
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	// Rotate to a new file-backed key (different path => different key).
+	newProvider, err := NewFileKeyProvider(filepath.Join(dir, ".snapshot_key.new"))
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider (new): %v", err)
+	}
+	if err := m.RotateEncryptionKey(newProvider); err != nil {
+		t.Fatalf("RotateEncryptionKey: %v", err)
+	}
+
+	// Data is still readable under the new key.
+	got, err := m.GetSnapshotData(snap.ID)
+	if err != nil {
+		t.Fatalf("GetSnapshotData after rotate: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("post-rotation mismatch: got %q want %q", got, plaintext)
+	}
+
+	// Nil provider is rejected.
+	if err := m.RotateEncryptionKey(nil); err == nil {
+		t.Fatal("expected RotateEncryptionKey(nil) to error")
+	}
+}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -65,8 +65,8 @@ func TestNewManager(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewManager() error: %v", err)
 		}
-		if m.encryptionKey != nil {
-			t.Error("expected no encryption key when encryption disabled")
+		if m.keyProvider != nil {
+			t.Error("expected no key provider when encryption disabled")
 		}
 	})
 }

--- a/internal/state/bbolt.go
+++ b/internal/state/bbolt.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
 
+	"github.com/moltbunker/moltbunker/internal/logging"
 	"github.com/moltbunker/moltbunker/internal/security"
 )
 
@@ -25,7 +27,12 @@ import (
 // stolen-disk / leaked-backup / casual filesystem access, not a live host-root
 // attacker who can also read state.key.
 type BboltStore struct {
-	db     *bolt.DB
+	db *bolt.DB
+
+	// keyMu guards encKey so RotateKey can atomically swap the active key while
+	// concurrent put/get/list calls read it. A read lock is held for the brief
+	// encode/decode call; RotateKey holds the write lock for the whole sweep.
+	keyMu  sync.RWMutex
 	encKey []byte // nil => encryption disabled (plaintext)
 }
 
@@ -33,7 +40,14 @@ type BboltStore struct {
 // Plaintext state values are JSON or short ASCII (schema version, timestamps),
 // none of which begin with these bytes, so the prefix unambiguously
 // distinguishes encrypted blobs from legacy plaintext during lazy migration.
-var encMagic = []byte{0x4D, 0x42, 0x45, 0x4E, 0x43, 0x31, 0x00} // "MBENC1\x00"
+//
+// encMagic (MBENC1) tags values written before key rotation; encMagic2 (MBENC2)
+// tags values written by the current code (and values re-encrypted by
+// RotateKey). Both decrypt with the active encKey; the version byte lets a
+// partially-rotated database be read safely and makes rotation progress visible
+// in the raw bytes. New writes always use MBENC2.
+var encMagic = []byte{0x4D, 0x42, 0x45, 0x4E, 0x43, 0x31, 0x00}  // "MBENC1\x00"
+var encMagic2 = []byte{0x4D, 0x42, 0x45, 0x4E, 0x43, 0x32, 0x00} // "MBENC2\x00"
 
 // allBuckets is the list of buckets created on database open.
 var allBuckets = []string{
@@ -92,50 +106,202 @@ func (s *BboltStore) Close() error {
 	return s.db.Close()
 }
 
+// RotateKeyMetrics summarizes a RotateKey sweep for logging.
+type RotateKeyMetrics struct {
+	Buckets       int // buckets visited
+	ValuesRotated int // values decrypted-with-old / re-encrypted-with-new
+	ValuesSkipped int // plaintext/unencrypted values left untouched
+}
+
+// GetEncKey returns a copy of the current at-rest encryption key (nil if
+// encryption is disabled). Exposed so callers (e.g. cmd/daemon) can drive a
+// rotation flow without reaching into the unexported field.
+func (s *BboltStore) GetEncKey() []byte {
+	s.keyMu.RLock()
+	defer s.keyMu.RUnlock()
+	if s.encKey == nil {
+		return nil
+	}
+	out := make([]byte, len(s.encKey))
+	copy(out, s.encKey)
+	return out
+}
+
+// RotateKey re-encrypts every value in every bucket from the current key to
+// newKey, tagging rewritten values with the MBENC2 magic, then atomically swaps
+// the active key. It is concurrency-safe: the write lock is held for the whole
+// sweep, so concurrent put/get/list calls block until rotation completes (this
+// can pause client requests for a large database — iteration is per-bucket via
+// db.Batch to coalesce fsyncs and keep individual stalls bounded).
+//
+// Rotation is idempotent for the no-key-change case: passing the current key
+// simply re-tags any lingering MBENC1 values to MBENC2. Encryption must be
+// enabled (a non-nil current key); rotating a plaintext store is an error.
+func (s *BboltStore) RotateKey(ctx context.Context, newKey []byte) (RotateKeyMetrics, error) {
+	var m RotateKeyMetrics
+
+	if len(newKey) != 32 {
+		return m, fmt.Errorf("rotate state key: new key must be 32 bytes, got %d", len(newKey))
+	}
+
+	s.keyMu.Lock()
+	defer s.keyMu.Unlock()
+
+	if s.encKey == nil {
+		return m, fmt.Errorf("rotate state key: encryption is disabled (no current key)")
+	}
+	oldKey := s.encKey
+
+	for _, bucket := range allBuckets {
+		if err := ctx.Err(); err != nil {
+			return m, fmt.Errorf("rotate state key: cancelled: %w", err)
+		}
+		m.Buckets++
+
+		// Collect keys+rewritten values in a read pass to keep the write batch
+		// small and avoid mutating while iterating.
+		type kv struct {
+			key []byte
+			val []byte
+		}
+		var rewrites []kv
+
+		err := s.db.View(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(bucket))
+			if b == nil {
+				return nil // bucket may not exist on older schemas
+			}
+			return b.ForEach(func(k, v []byte) error {
+				// Only rewrite values that are actually encrypted; plaintext /
+				// unencrypted values are left as-is (they predate encryption).
+				if _, ok := encPrefixLen(v); !ok {
+					m.ValuesSkipped++
+					return nil
+				}
+				plain, derr := decodeWithKey(oldKey, v)
+				if derr != nil {
+					return fmt.Errorf("decrypt %s/%s: %w", bucket, string(k), derr)
+				}
+				reenc, eerr := encodeWithKey(newKey, plain)
+				if eerr != nil {
+					return fmt.Errorf("re-encrypt %s/%s: %w", bucket, string(k), eerr)
+				}
+				kc := make([]byte, len(k))
+				copy(kc, k)
+				rewrites = append(rewrites, kv{key: kc, val: reenc})
+				return nil
+			})
+		})
+		if err != nil {
+			return m, fmt.Errorf("rotate state key: read bucket %s: %w", bucket, err)
+		}
+
+		if len(rewrites) == 0 {
+			continue
+		}
+
+		// Write the re-encrypted values back. db.Batch coalesces concurrent
+		// batches into fewer fsyncs.
+		berr := s.db.Batch(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(bucket))
+			if b == nil {
+				return fmt.Errorf("bucket %s disappeared during rotation", bucket)
+			}
+			for _, r := range rewrites {
+				if perr := b.Put(r.key, r.val); perr != nil {
+					return perr
+				}
+			}
+			return nil
+		})
+		if berr != nil {
+			return m, fmt.Errorf("rotate state key: write bucket %s: %w", bucket, berr)
+		}
+		m.ValuesRotated += len(rewrites)
+	}
+
+	// Swap the active key last: until now every read used oldKey, and the just-
+	// written MBENC2 values are readable with newKey, so the switch is safe.
+	swapped := make([]byte, len(newKey))
+	copy(swapped, newKey)
+	s.encKey = swapped
+
+	logging.Info("state at-rest key rotated",
+		"buckets", m.Buckets,
+		"values_rotated", m.ValuesRotated,
+		"values_skipped", m.ValuesSkipped,
+		logging.Component("state"))
+
+	return m, nil
+}
+
 // --- encryption helpers ---
 
-// encode returns the bytes to store on disk for a value. With encryption enabled
-// it produces encMagic || AES-256-GCM(data); otherwise data is returned as-is.
-func (s *BboltStore) encode(data []byte) ([]byte, error) {
-	if s.encKey == nil {
+// encodeWithKey produces the on-disk bytes for a value with the given key. With
+// a non-nil key it produces encMagic2 || AES-256-GCM(data); otherwise data is
+// returned as-is. New writes always use the MBENC2 prefix. It is lock-free: the
+// caller holds keyMu so the key cannot be swapped mid-write.
+func encodeWithKey(key, data []byte) ([]byte, error) {
+	if key == nil {
 		return data, nil
 	}
-	ct, err := security.EncryptAES256GCM(s.encKey, data)
+	ct, err := security.EncryptAES256GCM(key, data)
 	if err != nil {
 		return nil, fmt.Errorf("encrypt state value: %w", err)
 	}
-	out := make([]byte, 0, len(encMagic)+len(ct))
-	out = append(out, encMagic...)
+	out := make([]byte, 0, len(encMagic2)+len(ct))
+	out = append(out, encMagic2...)
 	out = append(out, ct...)
 	return out, nil
 }
 
-// decode reverses encode for a value read from disk. A value carrying encMagic
-// is decrypted (and a decrypt failure is a hard error — ciphertext is never
-// returned). A value without the magic prefix is returned verbatim: this is the
-// back-compat / lazy-migration path (legacy plaintext, or values written while
-// encryption was disabled). With encryption disabled, values are returned as-is.
-func (s *BboltStore) decode(stored []byte) ([]byte, error) {
+// decodeWithKey reverses encodeWithKey for a value read from disk. A value
+// carrying an encrypted prefix (MBENC1 or MBENC2) is decrypted (a decrypt
+// failure is a hard error — ciphertext is never returned). A value without a
+// magic prefix is returned verbatim: the back-compat / lazy-migration path
+// (legacy plaintext, or values written while encryption was disabled). With a
+// nil key, values are returned as-is. Lock-free: the caller holds keyMu.
+func decodeWithKey(key, stored []byte) ([]byte, error) {
 	if stored == nil {
 		return nil, nil
 	}
-	if s.encKey == nil {
+	if key == nil {
 		return stored, nil
 	}
-	if !bytes.HasPrefix(stored, encMagic) {
-		return stored, nil
+	if prefix, ok := encPrefixLen(stored); ok {
+		pt, err := security.DecryptAES256GCM(key, stored[prefix:])
+		if err != nil {
+			return nil, fmt.Errorf("decrypt state value: %w", err)
+		}
+		return pt, nil
 	}
-	pt, err := security.DecryptAES256GCM(s.encKey, stored[len(encMagic):])
-	if err != nil {
-		return nil, fmt.Errorf("decrypt state value: %w", err)
+	return stored, nil
+}
+
+// encPrefixLen reports the length of the recognized encrypted magic prefix
+// (MBENC1 or MBENC2) on stored, or (0, false) if none is present.
+func encPrefixLen(stored []byte) (int, bool) {
+	switch {
+	case bytes.HasPrefix(stored, encMagic2):
+		return len(encMagic2), true
+	case bytes.HasPrefix(stored, encMagic):
+		return len(encMagic), true
+	default:
+		return 0, false
 	}
-	return pt, nil
 }
 
 // --- internal helpers ---
 
+// put encrypts and stores a value. The keyMu read lock is held for the WHOLE
+// operation (encode + bbolt write) so RotateKey's exclusive lock fully
+// serializes against it: a value can never be written with the old key after
+// the rotation read pass but before the key swap.
 func (s *BboltStore) put(bucket, key string, data []byte) error {
-	stored, err := s.encode(data)
+	s.keyMu.RLock()
+	defer s.keyMu.RUnlock()
+
+	stored, err := encodeWithKey(s.encKey, data)
 	if err != nil {
 		return err
 	}
@@ -148,7 +314,12 @@ func (s *BboltStore) put(bucket, key string, data []byte) error {
 	})
 }
 
+// get reads and decrypts a value. The keyMu read lock is held for the whole
+// operation so the active key matches the on-disk value (see put).
 func (s *BboltStore) get(bucket, key string) ([]byte, error) {
+	s.keyMu.RLock()
+	defer s.keyMu.RUnlock()
+
 	var stored []byte
 	err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucket))
@@ -165,10 +336,19 @@ func (s *BboltStore) get(bucket, key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.decode(stored)
+	return decodeWithKey(s.encKey, stored)
 }
 
+// del removes a value. It holds keyMu.RLock for the whole operation — like
+// put/get/list — even though delete itself touches no key material. This
+// serializes deletes against RotateKey's exclusive lock: without it, a Delete
+// landing between RotateKey's read pass and its batch write-back could be
+// silently undone (the batch re-Puts the re-encrypted, still-valid value,
+// resurrecting the deleted key). Taking the read lock closes that window.
 func (s *BboltStore) del(bucket, key string) error {
+	s.keyMu.RLock()
+	defer s.keyMu.RUnlock()
+
 	return s.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucket))
 		if b == nil {
@@ -179,6 +359,9 @@ func (s *BboltStore) del(bucket, key string) error {
 }
 
 func (s *BboltStore) list(bucket string) (map[string][]byte, error) {
+	s.keyMu.RLock()
+	defer s.keyMu.RUnlock()
+
 	result := make(map[string][]byte)
 	err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucket))
@@ -188,7 +371,7 @@ func (s *BboltStore) list(bucket string) (map[string][]byte, error) {
 		return b.ForEach(func(k, v []byte) error {
 			cp := make([]byte, len(v))
 			copy(cp, v)
-			plain, derr := s.decode(cp)
+			plain, derr := decodeWithKey(s.encKey, cp)
 			if derr != nil {
 				return fmt.Errorf("decode value for key %q: %w", string(k), derr)
 			}

--- a/internal/state/bbolt_encryption_test.go
+++ b/internal/state/bbolt_encryption_test.go
@@ -92,8 +92,10 @@ func TestRawValueIsEncrypted(t *testing.T) {
 	if bytes.Contains(raw, []byte("do-not-leak")) {
 		t.Fatal("plaintext token leaked into raw on-disk value")
 	}
-	if !bytes.HasPrefix(raw, encMagic) {
-		t.Fatalf("raw value missing magic prefix: %x", raw)
+	// New writes carry the current-version magic (MBENC2). MBENC1 is still
+	// accepted on read for back-compat / partially-rotated databases.
+	if !bytes.HasPrefix(raw, encMagic2) {
+		t.Fatalf("raw value missing MBENC2 magic prefix: %x", raw)
 	}
 }
 

--- a/internal/state/bbolt_rotation_test.go
+++ b/internal/state/bbolt_rotation_test.go
@@ -1,0 +1,216 @@
+package state
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/moltbunker/moltbunker/internal/security"
+)
+
+func TestBboltStore_RotateKey(t *testing.T) {
+	ctx := context.Background()
+	oldKey := newKey(t)
+	s, path := openEncrypted(t, oldKey)
+
+	// Write 10 values across several buckets.
+	want := map[string][]byte{}
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("dep-%d", i)
+		v := []byte(fmt.Sprintf(`{"id":%q,"secret":"s-%d"}`, id, i))
+		if err := s.PutDeployment(ctx, id, v); err != nil {
+			t.Fatalf("PutDeployment: %v", err)
+		}
+		want[id] = v
+	}
+	if err := s.PutPeer(ctx, "peer-1", []byte("peer-data")); err != nil {
+		t.Fatalf("PutPeer: %v", err)
+	}
+
+	// Rotate to a new key.
+	newKeyBytes := newKey(t)
+	m, err := s.RotateKey(ctx, newKeyBytes)
+	if err != nil {
+		t.Fatalf("RotateKey: %v", err)
+	}
+	if m.ValuesRotated < 11 {
+		t.Errorf("ValuesRotated = %d, want >= 11", m.ValuesRotated)
+	}
+
+	// All values readable under the new key (same store, swapped key).
+	for id, v := range want {
+		got, err := s.GetDeployment(ctx, id)
+		if err != nil {
+			t.Fatalf("GetDeployment %s: %v", id, err)
+		}
+		if !bytes.Equal(got, v) {
+			t.Errorf("%s mismatch after rotate: got %q want %q", id, got, v)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// A store opened with the OLD key must fail to decrypt the rotated values.
+	// bbolt takes an exclusive file lock, so each reopen must be closed before
+	// the next.
+	old, err := NewBboltStore(path, oldKey)
+	if err != nil {
+		t.Fatalf("reopen with old key: %v", err)
+	}
+	if _, err := old.GetDeployment(ctx, "dep-0"); err == nil {
+		_ = old.Close()
+		t.Fatal("old key should NOT decrypt rotated values")
+	}
+	if err := old.Close(); err != nil {
+		t.Fatalf("close old: %v", err)
+	}
+
+	// A store opened with the NEW key reads them fine.
+	fresh, err := NewBboltStore(path, newKeyBytes)
+	if err != nil {
+		t.Fatalf("reopen with new key: %v", err)
+	}
+	defer fresh.Close()
+	got, err := fresh.GetDeployment(ctx, "dep-3")
+	if err != nil {
+		t.Fatalf("fresh GetDeployment: %v", err)
+	}
+	if !bytes.Equal(got, want["dep-3"]) {
+		t.Errorf("fresh read mismatch: got %q want %q", got, want["dep-3"])
+	}
+}
+
+// TestBboltStore_RotateMagicVersion writes a value with the legacy MBENC1 magic
+// directly, then verifies RotateKey migrates it to MBENC2.
+func TestBboltStore_RotateMagicVersion(t *testing.T) {
+	ctx := context.Background()
+	key := newKey(t)
+	s, path := openEncrypted(t, key)
+
+	// Manually construct an MBENC1-tagged value and write it raw into bbolt.
+	plain := []byte(`{"id":"legacy","v":1}`)
+	ct, err := security.EncryptAES256GCM(key, plain)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	mbenc1 := append(append([]byte(nil), encMagic...), ct...)
+	err = s.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte(BucketDeployments)).Put([]byte("legacy"), mbenc1)
+	})
+	if err != nil {
+		t.Fatalf("raw put MBENC1: %v", err)
+	}
+
+	// Readable before rotation (decode accepts MBENC1).
+	got, err := s.GetDeployment(ctx, "legacy")
+	if err != nil {
+		t.Fatalf("GetDeployment pre-rotate: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("pre-rotate mismatch: got %q want %q", got, plain)
+	}
+
+	// Rotate to the SAME key (idempotent re-tag).
+	if _, err := s.RotateKey(ctx, key); err != nil {
+		t.Fatalf("RotateKey: %v", err)
+	}
+
+	// The on-disk value must now carry MBENC2.
+	var raw []byte
+	err = s.db.View(func(tx *bolt.Tx) error {
+		raw = append([]byte(nil), tx.Bucket([]byte(BucketDeployments)).Get([]byte("legacy"))...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("View: %v", err)
+	}
+	if !bytes.HasPrefix(raw, encMagic2) {
+		t.Fatalf("value not migrated to MBENC2: %x", raw[:8])
+	}
+
+	got, err = s.GetDeployment(ctx, "legacy")
+	if err != nil {
+		t.Fatalf("GetDeployment post-rotate: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("post-rotate mismatch: got %q want %q", got, plain)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	_ = path
+}
+
+// TestBboltStore_RotateConcurrent runs parallel puts alongside a RotateKey call
+// and asserts no panic / no data loss / consistent reads afterward.
+func TestBboltStore_RotateConcurrent(t *testing.T) {
+	ctx := context.Background()
+	oldKey := newKey(t)
+	s, _ := openEncrypted(t, oldKey)
+	defer s.Close()
+
+	// Seed some values so rotation has work to do.
+	for i := 0; i < 20; i++ {
+		if err := s.PutDeployment(ctx, fmt.Sprintf("seed-%d", i), []byte(fmt.Sprintf("v%d", i))); err != nil {
+			t.Fatalf("seed put: %v", err)
+		}
+	}
+
+	newKeyBytes := newKey(t)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 64)
+
+	// 50 concurrent writers.
+	for g := 0; g < 50; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 5; i++ {
+				id := fmt.Sprintf("c-%d-%d", g, i)
+				if err := s.PutDeployment(ctx, id, []byte(id)); err != nil {
+					errCh <- err
+					return
+				}
+				if _, err := s.GetDeployment(ctx, id); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}(g)
+	}
+
+	// Rotate mid-flight.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, err := s.RotateKey(ctx, newKeyBytes); err != nil {
+			errCh <- err
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent op failed: %v", err)
+	}
+
+	// After rotation, every concurrent value is readable and consistent.
+	for g := 0; g < 50; g++ {
+		for i := 0; i < 5; i++ {
+			id := fmt.Sprintf("c-%d-%d", g, i)
+			got, err := s.GetDeployment(ctx, id)
+			if err != nil {
+				t.Fatalf("post GetDeployment %s: %v", id, err)
+			}
+			if string(got) != id {
+				t.Errorf("%s = %q, want %q", id, got, id)
+			}
+		}
+	}
+}

--- a/internal/storage/encryption.go
+++ b/internal/storage/encryption.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -11,73 +12,160 @@ import (
 	"github.com/moltbunker/moltbunker/internal/security"
 )
 
-// ObjectEncryptor handles per-object encryption using AES-256-GCM.
+// Object encryption uses envelope encryption: each object gets a fresh random
+// 32-byte Data Encryption Key (DEK) that encrypts the content with AES-256-GCM.
+// The DEK itself is then sealed to the owner's X25519 public key using the
+// project's ECIES primitive (security.SealToX25519) — the SAME key ladder used
+// for exec-key delivery (SEC-10) and R5 image encryption. This replaces the old
+// DeriveOwnerKey scheme, which derived an AES key deterministically from the
+// (public) owner address string — meaning anyone who knew the address could
+// recompute the DEK-wrapping key. The sealed DEK is stored as a JSON-encoded
+// security.X25519Envelope in ObjectInfo.EncryptedDEK.
 //
-// Each object gets a random 32-byte Data Encryption Key (DEK).
-// The DEK encrypts the plaintext content. The DEK itself is then
-// encrypted with the owner's key (in Phase 2, via X25519 ECDH —
-// for now we use HKDF key derivation from the owner address).
-type ObjectEncryptor struct{}
+// Back-compat: objects written by the old scheme carry a raw AES-GCM-wrapped DEK
+// (not a JSON envelope). Those are detected on read (json.Unmarshal into an
+// X25519Envelope fails, or the EphemeralPub field is absent) and decrypted via
+// legacyDeriveOwnerKey. New writes always use the X25519 envelope.
 
-// NewObjectEncryptor creates a new object encryptor.
-func NewObjectEncryptor() *ObjectEncryptor {
-	return &ObjectEncryptor{}
+// OwnerKeyEncryptor performs envelope encryption sealing the DEK to an owner's
+// X25519 public key.
+type OwnerKeyEncryptor struct{}
+
+// NewOwnerKeyEncryptor creates a new X25519 envelope encryptor.
+func NewOwnerKeyEncryptor() *OwnerKeyEncryptor { return &OwnerKeyEncryptor{} }
+
+// X25519EncryptionResult is the result of sealing an object to an owner key.
+type X25519EncryptionResult struct {
+	// Ciphertext is the AES-256-GCM-encrypted content (nonce prepended).
+	Ciphertext []byte
+	// SealedDEK is the per-object DEK sealed to the owner's X25519 public key.
+	SealedDEK *security.X25519Envelope
 }
 
-// EncryptionResult contains the encrypted blob and key material.
-type EncryptionResult struct {
-	Ciphertext   []byte // AES-256-GCM encrypted content (nonce prepended)
-	EncryptedDEK []byte // DEK encrypted with owner key
-}
+// Encrypt generates a random DEK, encrypts the plaintext with it, then seals the
+// DEK to the owner's 32-byte X25519 public key.
+func (e *OwnerKeyEncryptor) Encrypt(plaintext, ownerPub []byte) (*X25519EncryptionResult, error) {
+	if len(ownerPub) != security.X25519KeySize {
+		return nil, fmt.Errorf("owner public key must be %d bytes, got %d", security.X25519KeySize, len(ownerPub))
+	}
 
-// Encrypt encrypts content with a random DEK, then wraps the DEK
-// with the provided owner key.
-func (e *ObjectEncryptor) Encrypt(plaintext []byte, ownerKey []byte) (*EncryptionResult, error) {
-	// Generate random DEK
 	dek := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
 		return nil, fmt.Errorf("generate DEK: %w", err)
 	}
 
-	// Encrypt content with DEK
 	ciphertext, err := security.EncryptAES256GCM(dek, plaintext)
 	if err != nil {
 		return nil, fmt.Errorf("encrypt content: %w", err)
 	}
 
-	// Encrypt DEK with owner key
-	encryptedDEK, err := security.EncryptAES256GCM(ownerKey, dek)
+	sealed, err := security.SealToX25519(ownerPub, dek)
 	if err != nil {
-		return nil, fmt.Errorf("encrypt DEK: %w", err)
+		return nil, fmt.Errorf("seal DEK: %w", err)
 	}
 
-	return &EncryptionResult{
-		Ciphertext:   ciphertext,
-		EncryptedDEK: encryptedDEK,
-	}, nil
+	return &X25519EncryptionResult{Ciphertext: ciphertext, SealedDEK: sealed}, nil
 }
 
-// Decrypt decrypts the DEK with the owner key, then decrypts the content.
-func (e *ObjectEncryptor) Decrypt(ciphertext, encryptedDEK, ownerKey []byte) ([]byte, error) {
-	// Decrypt DEK
-	dek, err := security.DecryptAES256GCM(ownerKey, encryptedDEK)
-	if err != nil {
-		return nil, fmt.Errorf("decrypt DEK: %w", err)
+// Decrypt opens the sealed DEK with the owner's X25519 private key, then decrypts
+// the content.
+func (e *OwnerKeyEncryptor) Decrypt(ciphertext []byte, sealedDEK *security.X25519Envelope, ownerPriv []byte) ([]byte, error) {
+	if sealedDEK == nil {
+		return nil, fmt.Errorf("nil sealed DEK")
 	}
-
-	// Decrypt content
+	dek, err := security.OpenFromX25519(ownerPriv, sealedDEK)
+	if err != nil {
+		return nil, fmt.Errorf("open DEK: %w", err)
+	}
 	plaintext, err := security.DecryptAES256GCM(dek, ciphertext)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt content: %w", err)
 	}
-
 	return plaintext, nil
 }
 
-// DeriveOwnerKey derives a 32-byte encryption key from an owner identifier
-// using HKDF with SHA-256. This is a placeholder — in production, X25519
-// ECDH with the owner's public key provides forward secrecy.
-func DeriveOwnerKey(owner string) ([]byte, error) {
+// MarshalSealedDEK serializes an X25519 envelope for storage in
+// ObjectInfo.EncryptedDEK.
+func MarshalSealedDEK(env *security.X25519Envelope) ([]byte, error) {
+	if env == nil {
+		return nil, fmt.Errorf("nil envelope")
+	}
+	return json.Marshal(env)
+}
+
+// looksLikeX25519Envelope reports whether the stored EncryptedDEK is a
+// JSON-encoded X25519 envelope (new scheme) rather than a raw AES-GCM-wrapped
+// DEK (legacy scheme). It checks both that the bytes parse as JSON and that the
+// envelope's required EphemeralPub field is present.
+func looksLikeX25519Envelope(encryptedDEK []byte) (*security.X25519Envelope, bool) {
+	if len(encryptedDEK) == 0 {
+		return nil, false
+	}
+	var env security.X25519Envelope
+	if err := json.Unmarshal(encryptedDEK, &env); err != nil {
+		return nil, false
+	}
+	if len(env.EphemeralPub) != security.X25519KeySize {
+		return nil, false
+	}
+	return &env, true
+}
+
+// --- Back-compat (legacy) path ---
+
+// ObjectEncryptor is the legacy envelope encryptor that wraps the DEK with a
+// raw 32-byte symmetric key (the AES-GCM-wrapped-DEK scheme). It is retained for
+// reading objects written before the X25519 migration. New code should use
+// OwnerKeyEncryptor.
+type ObjectEncryptor struct{}
+
+// NewObjectEncryptor creates a new legacy object encryptor.
+func NewObjectEncryptor() *ObjectEncryptor { return &ObjectEncryptor{} }
+
+// EncryptionResult contains the legacy encrypted blob and key material.
+type EncryptionResult struct {
+	Ciphertext   []byte // AES-256-GCM encrypted content (nonce prepended)
+	EncryptedDEK []byte // DEK encrypted with the (symmetric) owner key
+}
+
+// Encrypt encrypts content with a random DEK, then wraps the DEK with the
+// provided symmetric owner key (legacy scheme).
+func (e *ObjectEncryptor) Encrypt(plaintext, ownerKey []byte) (*EncryptionResult, error) {
+	dek := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+		return nil, fmt.Errorf("generate DEK: %w", err)
+	}
+	ciphertext, err := security.EncryptAES256GCM(dek, plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt content: %w", err)
+	}
+	encryptedDEK, err := security.EncryptAES256GCM(ownerKey, dek)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt DEK: %w", err)
+	}
+	return &EncryptionResult{Ciphertext: ciphertext, EncryptedDEK: encryptedDEK}, nil
+}
+
+// Decrypt decrypts the DEK with the symmetric owner key, then decrypts content
+// (legacy scheme).
+func (e *ObjectEncryptor) Decrypt(ciphertext, encryptedDEK, ownerKey []byte) ([]byte, error) {
+	dek, err := security.DecryptAES256GCM(ownerKey, encryptedDEK)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt DEK: %w", err)
+	}
+	plaintext, err := security.DecryptAES256GCM(dek, ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt content: %w", err)
+	}
+	return plaintext, nil
+}
+
+// legacyDeriveOwnerKey derives a 32-byte symmetric key from an owner identifier
+// using HKDF-SHA256. This is the OLD scheme: the owner address is public, so the
+// derived key is computable by any observer — it is NOT a secret. It is retained
+// only to read objects written before the X25519 migration. Do not use for new
+// writes.
+func legacyDeriveOwnerKey(owner string) ([]byte, error) {
 	hkdfReader := hkdf.New(sha256.New, []byte(owner), []byte("moltbunker-storage-v1"), []byte("object-encryption"))
 	key := make([]byte, 32)
 	if _, err := io.ReadFull(hkdfReader, key); err != nil {

--- a/internal/storage/encryption_test.go
+++ b/internal/storage/encryption_test.go
@@ -3,99 +3,174 @@ package storage
 import (
 	"bytes"
 	"testing"
+
+	"github.com/moltbunker/moltbunker/internal/security"
 )
+
+// --- New X25519 envelope path ---
+
+func TestOwnerKeyEncryptor_RoundTrip(t *testing.T) {
+	pub, priv, err := security.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+
+	enc := NewOwnerKeyEncryptor()
+	plaintext := []byte("hello, X25519-sealed storage!")
+
+	res, err := enc.Encrypt(plaintext, pub)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if bytes.Equal(res.Ciphertext, plaintext) {
+		t.Error("ciphertext should not equal plaintext")
+	}
+	if res.SealedDEK == nil || len(res.SealedDEK.EphemeralPub) != security.X25519KeySize {
+		t.Fatal("sealed DEK envelope is malformed")
+	}
+
+	got, err := enc.Decrypt(res.Ciphertext, res.SealedDEK, priv)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("decrypted = %q, want %q", got, plaintext)
+	}
+}
+
+func TestOwnerKeyEncryptor_WrongKey(t *testing.T) {
+	pub, _, err := security.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	_, wrongPriv, err := security.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+
+	enc := NewOwnerKeyEncryptor()
+	res, err := enc.Encrypt([]byte("secret"), pub)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if _, err := enc.Decrypt(res.Ciphertext, res.SealedDEK, wrongPriv); err == nil {
+		t.Fatal("decrypting with wrong private key should fail")
+	}
+}
+
+func TestOwnerKeyEncryptor_DifferentDEKs(t *testing.T) {
+	pub, priv, _ := security.GenerateX25519KeyPair()
+	enc := NewOwnerKeyEncryptor()
+	plaintext := []byte("same content")
+
+	r1, _ := enc.Encrypt(plaintext, pub)
+	r2, _ := enc.Encrypt(plaintext, pub)
+
+	if bytes.Equal(r1.Ciphertext, r2.Ciphertext) {
+		t.Error("two encryptions of the same plaintext should differ (random DEK)")
+	}
+	d1, _ := enc.Decrypt(r1.Ciphertext, r1.SealedDEK, priv)
+	d2, _ := enc.Decrypt(r2.Ciphertext, r2.SealedDEK, priv)
+	if !bytes.Equal(d1, d2) {
+		t.Error("both should decrypt to the same plaintext")
+	}
+}
+
+func TestOwnerKeyEncryptor_InvalidPubKey(t *testing.T) {
+	enc := NewOwnerKeyEncryptor()
+	if _, err := enc.Encrypt([]byte("x"), []byte("too short")); err == nil {
+		t.Fatal("expected error for invalid public key size")
+	}
+}
+
+func TestMarshalSealedDEK_RoundTrip(t *testing.T) {
+	pub, priv, _ := security.GenerateX25519KeyPair()
+	enc := NewOwnerKeyEncryptor()
+	res, err := enc.Encrypt([]byte("payload"), pub)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	blob, err := MarshalSealedDEK(res.SealedDEK)
+	if err != nil {
+		t.Fatalf("MarshalSealedDEK: %v", err)
+	}
+	env, ok := looksLikeX25519Envelope(blob)
+	if !ok {
+		t.Fatal("serialized envelope should be recognized as X25519 envelope")
+	}
+	got, err := enc.Decrypt(res.Ciphertext, env, priv)
+	if err != nil {
+		t.Fatalf("Decrypt after round-trip: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestLooksLikeX25519Envelope_LegacyBlob(t *testing.T) {
+	// A legacy raw AES-GCM-wrapped DEK is NOT a JSON envelope.
+	legacyKey, _ := legacyDeriveOwnerKey("0xOwner")
+	legacy := NewObjectEncryptor()
+	res, err := legacy.Encrypt([]byte("data"), legacyKey)
+	if err != nil {
+		t.Fatalf("legacy Encrypt: %v", err)
+	}
+	if _, ok := looksLikeX25519Envelope(res.EncryptedDEK); ok {
+		t.Error("legacy wrapped DEK should NOT be detected as an X25519 envelope")
+	}
+}
+
+// --- Legacy AES-GCM-wrapped-DEK path (back-compat) ---
 
 func TestObjectEncryptor_RoundTrip(t *testing.T) {
 	enc := NewObjectEncryptor()
-
-	ownerKey, err := DeriveOwnerKey("0xAc1D8d6e25E54c05986E8bFa9b759063D5e69592")
+	ownerKey, err := legacyDeriveOwnerKey("0xAc1D8d6e25E54c05986E8bFa9b759063D5e69592")
 	if err != nil {
-		t.Fatalf("DeriveOwnerKey: %v", err)
+		t.Fatalf("legacyDeriveOwnerKey: %v", err)
 	}
-
 	plaintext := []byte("hello, encrypted storage!")
 
 	result, err := enc.Encrypt(plaintext, ownerKey)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
-
-	// Ciphertext should be different from plaintext
 	if bytes.Equal(result.Ciphertext, plaintext) {
 		t.Error("ciphertext should not equal plaintext")
 	}
-
-	// Decrypt
 	decrypted, err := enc.Decrypt(result.Ciphertext, result.EncryptedDEK, ownerKey)
 	if err != nil {
 		t.Fatalf("Decrypt: %v", err)
 	}
-
 	if !bytes.Equal(decrypted, plaintext) {
-		t.Errorf("decrypted = %q, want %q", string(decrypted), string(plaintext))
-	}
-}
-
-func TestObjectEncryptor_DifferentDEKs(t *testing.T) {
-	enc := NewObjectEncryptor()
-
-	ownerKey, err := DeriveOwnerKey("0xAc1D8d6e25E54c05986E8bFa9b759063D5e69592")
-	if err != nil {
-		t.Fatalf("DeriveOwnerKey: %v", err)
-	}
-
-	plaintext := []byte("same content")
-
-	r1, err := enc.Encrypt(plaintext, ownerKey)
-	if err != nil {
-		t.Fatalf("Encrypt 1: %v", err)
-	}
-
-	r2, err := enc.Encrypt(plaintext, ownerKey)
-	if err != nil {
-		t.Fatalf("Encrypt 2: %v", err)
-	}
-
-	// Each encryption should use a different random DEK, producing different ciphertext
-	if bytes.Equal(r1.Ciphertext, r2.Ciphertext) {
-		t.Error("two encryptions of the same plaintext should produce different ciphertext")
-	}
-
-	// But both should decrypt to the same plaintext
-	d1, _ := enc.Decrypt(r1.Ciphertext, r1.EncryptedDEK, ownerKey)
-	d2, _ := enc.Decrypt(r2.Ciphertext, r2.EncryptedDEK, ownerKey)
-	if !bytes.Equal(d1, d2) {
-		t.Error("both should decrypt to the same plaintext")
+		t.Errorf("decrypted = %q, want %q", decrypted, plaintext)
 	}
 }
 
 func TestObjectEncryptor_WrongKey(t *testing.T) {
 	enc := NewObjectEncryptor()
-
-	ownerKey, _ := DeriveOwnerKey("0xCorrectOwner")
-	wrongKey, _ := DeriveOwnerKey("0xWrongOwner")
+	ownerKey, _ := legacyDeriveOwnerKey("0xCorrectOwner")
+	wrongKey, _ := legacyDeriveOwnerKey("0xWrongOwner")
 
 	plaintext := []byte("secret data")
 	result, err := enc.Encrypt(plaintext, ownerKey)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
-
-	_, err = enc.Decrypt(result.Ciphertext, result.EncryptedDEK, wrongKey)
-	if err == nil {
+	if _, err := enc.Decrypt(result.Ciphertext, result.EncryptedDEK, wrongKey); err == nil {
 		t.Fatal("decrypting with wrong key should fail")
 	}
 }
 
 func TestObjectEncryptor_EmptyContent(t *testing.T) {
 	enc := NewObjectEncryptor()
-	ownerKey, _ := DeriveOwnerKey("0xOwner")
+	ownerKey, _ := legacyDeriveOwnerKey("0xOwner")
 
 	result, err := enc.Encrypt([]byte{}, ownerKey)
 	if err != nil {
 		t.Fatalf("Encrypt empty: %v", err)
 	}
-
 	decrypted, err := enc.Decrypt(result.Ciphertext, result.EncryptedDEK, ownerKey)
 	if err != nil {
 		t.Fatalf("Decrypt empty: %v", err)
@@ -107,50 +182,35 @@ func TestObjectEncryptor_EmptyContent(t *testing.T) {
 
 func TestObjectEncryptor_LargeContent(t *testing.T) {
 	enc := NewObjectEncryptor()
-	ownerKey, _ := DeriveOwnerKey("0xOwner")
+	ownerKey, _ := legacyDeriveOwnerKey("0xOwner")
 
-	// 1MB of data
 	plaintext := make([]byte, 1024*1024)
 	for i := range plaintext {
 		plaintext[i] = byte(i % 256)
 	}
-
 	result, err := enc.Encrypt(plaintext, ownerKey)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
-
 	decrypted, err := enc.Decrypt(result.Ciphertext, result.EncryptedDEK, ownerKey)
 	if err != nil {
 		t.Fatalf("Decrypt: %v", err)
 	}
-
 	if !bytes.Equal(decrypted, plaintext) {
 		t.Error("large content round-trip failed")
 	}
 }
 
-func TestDeriveOwnerKey_Deterministic(t *testing.T) {
-	k1, err := DeriveOwnerKey("0xSameOwner")
+func TestLegacyDeriveOwnerKey_Deterministic(t *testing.T) {
+	k1, err := legacyDeriveOwnerKey("0xSameOwner")
 	if err != nil {
-		t.Fatalf("DeriveOwnerKey 1: %v", err)
+		t.Fatalf("legacyDeriveOwnerKey 1: %v", err)
 	}
-
-	k2, err := DeriveOwnerKey("0xSameOwner")
+	k2, err := legacyDeriveOwnerKey("0xSameOwner")
 	if err != nil {
-		t.Fatalf("DeriveOwnerKey 2: %v", err)
+		t.Fatalf("legacyDeriveOwnerKey 2: %v", err)
 	}
-
 	if !bytes.Equal(k1, k2) {
 		t.Error("same owner should produce same key")
-	}
-}
-
-func TestDeriveOwnerKey_DifferentOwners(t *testing.T) {
-	k1, _ := DeriveOwnerKey("0xOwnerA")
-	k2, _ := DeriveOwnerKey("0xOwnerB")
-
-	if bytes.Equal(k1, k2) {
-		t.Error("different owners should produce different keys")
 	}
 }

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5" // #nosec G501 -- non-security use: S3-compatible ETag (content identifier), not auth/integrity
 	"encoding/hex"
@@ -31,12 +32,15 @@ type MeteringHook interface {
 
 // StorageEngine is the main orchestrator for object storage operations.
 // Phase 1: local blob storage with bbolt metadata.
-// Phase 2 adds encryption and IPFS distribution.
+// Phase 2 adds encryption (X25519 envelope, opt-in via keyStore) and IPFS
+// distribution.
 type StorageEngine struct {
-	dataDir  string
-	metadata *MetadataStore
-	config   EngineConfig
-	meter    MeteringHook // optional usage metering hook (nil = no metering)
+	dataDir   string
+	metadata  *MetadataStore
+	config    EngineConfig
+	meter     MeteringHook  // optional usage metering hook (nil = no metering)
+	keyStore  OwnerKeyStore // optional X25519 owner key store (nil = at-rest encryption disabled)
+	encryptor *OwnerKeyEncryptor
 }
 
 // SetMeteringHook installs an optional metering hook. Pass nil to disable.
@@ -45,18 +49,62 @@ func (e *StorageEngine) SetMeteringHook(h MeteringHook) {
 	e.meter = h
 }
 
+// WithOwnerKeyStore enables at-rest object encryption. When set, PutObject
+// encrypts the blob with a per-object DEK sealed to the owner's X25519 key and
+// GetObject transparently decrypts. Pass nil (or never call) to keep plaintext
+// blobs (the default, legacy behavior). Returns the engine for chaining.
+func (e *StorageEngine) WithOwnerKeyStore(ks OwnerKeyStore) *StorageEngine {
+	e.keyStore = ks
+	if ks != nil && e.encryptor == nil {
+		e.encryptor = NewOwnerKeyEncryptor()
+	}
+	return e
+}
+
 // EngineConfig configures the storage engine.
 type EngineConfig struct {
 	MaxBuckets    int   // Max buckets per wallet
 	MaxObjectSize int64 // Max single object size in bytes
+
+	// EncryptedMaxInMemoryBytes caps the size of an object that the at-rest
+	// encryption path will accept. The current envelope scheme is NOT streaming:
+	// PutObject reads the whole plaintext blob into memory to seal it, and
+	// GetObject/decryptBlob reads the whole ciphertext into memory to open it.
+	// With MaxObjectSize at 5GB, an unconstrained encrypted Put/Get would hold
+	// multiple GB resident (plaintext + ciphertext copies) — an OOM/DoS vector
+	// that the plaintext io.Copy path avoids. We therefore reject encrypted
+	// objects larger than this ceiling with a clear error.
+	//
+	// Zero falls back to defaultEncryptedMaxInMemoryBytes (256MB). It is only
+	// consulted when at-rest encryption is enabled (keyStore != nil); the
+	// plaintext path streams and is unaffected. A full chunked/framed streaming
+	// AEAD that removes this ceiling is tracked as a follow-up (see
+	// daemon-todo.md).
+	EncryptedMaxInMemoryBytes int64
 }
+
+// defaultEncryptedMaxInMemoryBytes is the default in-memory ceiling for the
+// (non-streaming) encrypted object path. 256MB is large enough for typical
+// config/state/object payloads while bounding per-request memory well below the
+// 5GB plaintext MaxObjectSize.
+const defaultEncryptedMaxInMemoryBytes = 256 * 1024 * 1024 // 256MB
 
 // DefaultEngineConfig returns sensible defaults.
 func DefaultEngineConfig() EngineConfig {
 	return EngineConfig{
-		MaxBuckets:    100,
-		MaxObjectSize: 5 * 1024 * 1024 * 1024, // 5GB
+		MaxBuckets:                100,
+		MaxObjectSize:             5 * 1024 * 1024 * 1024, // 5GB
+		EncryptedMaxInMemoryBytes: defaultEncryptedMaxInMemoryBytes,
 	}
+}
+
+// encryptedMaxInMemoryBytes returns the effective in-memory ceiling for the
+// encrypted path, applying the default when the config value is unset (<= 0).
+func (e *StorageEngine) encryptedMaxInMemoryBytes() int64 {
+	if e.config.EncryptedMaxInMemoryBytes > 0 {
+		return e.config.EncryptedMaxInMemoryBytes
+	}
+	return defaultEncryptedMaxInMemoryBytes
 }
 
 // NewStorageEngine creates a new storage engine.
@@ -239,13 +287,58 @@ func (e *StorageEngine) PutObject(ctx context.Context, input *PutObjectInput) (*
 		return nil, fmt.Errorf("object too large: %d bytes exceeds max %d", n, e.config.MaxObjectSize)
 	}
 
+	etag := hex.EncodeToString(hasher.Sum(nil))
+
+	// At-rest encryption (opt-in via keyStore): seal the blob to the owner's
+	// X25519 key. ETag and Size are kept over the PLAINTEXT (S3 semantics); only
+	// the on-disk bytes are ciphertext. We read the freshly-written temp file
+	// back, encrypt, and overwrite it before the atomic rename.
+	var sealedDEKBytes []byte
+	if e.keyStore != nil && e.encryptor != nil {
+		// In-memory ceiling: the envelope scheme buffers the whole blob (read
+		// back + encrypt produces a second copy). Reject oversized objects rather
+		// than risk OOM. n is the plaintext size already on disk in tempPath.
+		if max := e.encryptedMaxInMemoryBytes(); n > max {
+			_ = os.Remove(tempPath)
+			return nil, fmt.Errorf("encrypted object too large: %d bytes exceeds in-memory encryption limit of %d bytes (at-rest encryption buffers the whole object; use a smaller object or disable storage encryption)", n, max)
+		}
+		ownerPub, keyErr := e.keyStore.PublicKeyForOwner(input.Owner)
+		if keyErr != nil {
+			_ = os.Remove(tempPath)
+			return nil, fmt.Errorf("resolve owner key: %w", keyErr)
+		}
+		// #nosec G304 -- tempPath is a CreateTemp file in the blob dir we just wrote.
+		plain, readErr := os.ReadFile(tempPath)
+		if readErr != nil {
+			_ = os.Remove(tempPath)
+			return nil, fmt.Errorf("read blob for encryption: %w", readErr)
+		}
+		res, encErr := e.encryptor.Encrypt(plain, ownerPub)
+		if encErr != nil {
+			_ = os.Remove(tempPath)
+			return nil, fmt.Errorf("encrypt blob: %w", encErr)
+		}
+		sealedDEKBytes, encErr = MarshalSealedDEK(res.SealedDEK)
+		if encErr != nil {
+			_ = os.Remove(tempPath)
+			return nil, fmt.Errorf("marshal sealed DEK: %w", encErr)
+		}
+		// #nosec G703 G304 -- tempPath is the os.CreateTemp file we created in
+		// filepath.Dir(blobPath); blobPath is validated by blobPath() (Clean +
+		// prefix check rejects traversal). We are overwriting our own temp file
+		// in place before the atomic rename, not following request input.
+		if writeErr := os.WriteFile(tempPath, res.Ciphertext, 0600); writeErr != nil {
+			_ = os.Remove(tempPath)
+			return nil, fmt.Errorf("write encrypted blob: %w", writeErr)
+		}
+	}
+
 	// Atomic rename
 	if err := os.Rename(tempPath, blobPath); err != nil {
 		_ = os.Remove(tempPath)
 		return nil, fmt.Errorf("rename blob: %w", err)
 	}
 
-	etag := hex.EncodeToString(hasher.Sum(nil))
 	now := time.Now().UTC()
 
 	contentType := input.ContentType
@@ -254,14 +347,15 @@ func (e *StorageEngine) PutObject(ctx context.Context, input *PutObjectInput) (*
 	}
 
 	obj := &ObjectInfo{
-		Bucket:      input.Bucket,
-		Key:         input.Key,
-		Size:        n,
-		ContentType: contentType,
-		ETag:        etag,
-		Owner:       input.Owner,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		Bucket:       input.Bucket,
+		Key:          input.Key,
+		Size:         n,
+		ContentType:  contentType,
+		ETag:         etag,
+		Owner:        input.Owner,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		EncryptedDEK: sealedDEKBytes,
 	}
 
 	if err := e.metadata.PutObject(ctx, obj); err != nil {
@@ -315,11 +409,72 @@ func (e *StorageEngine) GetObject(ctx context.Context, bucket, key, owner string
 		return nil, fmt.Errorf("open blob: %w", err)
 	}
 
+	// At-rest decryption: if the object carries a sealed DEK, decrypt the blob
+	// in memory and return the plaintext. Both the new X25519-envelope scheme and
+	// the legacy AES-GCM-wrapped-DEK scheme are supported (back-compat read path).
+	if len(obj.EncryptedDEK) > 0 {
+		// In-memory ceiling: decryptBlob reads the entire ciphertext into memory.
+		// obj.Size is the plaintext size (S3 semantics); the ciphertext is at most
+		// that plus a small GCM/nonce overhead, so guarding on Size bounds resident
+		// memory. Reject rather than risk OOM on a large encrypted object.
+		if max := e.encryptedMaxInMemoryBytes(); obj.Size > max {
+			_ = f.Close()
+			return nil, fmt.Errorf("encrypted object too large to read: %d bytes exceeds in-memory decryption limit of %d bytes (at-rest decryption buffers the whole object)", obj.Size, max)
+		}
+		plain, decErr := e.decryptBlob(f, obj)
+		_ = f.Close()
+		if decErr != nil {
+			return nil, decErr
+		}
+		return &GetObjectOutput{
+			Body:        io.NopCloser(bytes.NewReader(plain)),
+			Info:        *obj,
+			ContentType: obj.ContentType,
+		}, nil
+	}
+
 	return &GetObjectOutput{
 		Body:        f,
 		Info:        *obj,
 		ContentType: obj.ContentType,
 	}, nil
+}
+
+// decryptBlob reads the (encrypted) blob from r and returns the plaintext. It
+// supports both the X25519-envelope scheme (new) and the legacy HKDF-derived
+// symmetric scheme, distinguished by whether EncryptedDEK is a JSON envelope.
+func (e *StorageEngine) decryptBlob(r io.Reader, obj *ObjectInfo) ([]byte, error) {
+	ciphertext, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read encrypted blob: %w", err)
+	}
+
+	// New scheme: JSON-encoded X25519 envelope sealed to the owner key.
+	if env, ok := looksLikeX25519Envelope(obj.EncryptedDEK); ok {
+		if e.keyStore == nil || e.encryptor == nil {
+			return nil, fmt.Errorf("object is encrypted but no owner key store is configured")
+		}
+		ownerPriv, keyErr := e.keyStore.PrivateKeyForOwner(obj.Owner)
+		if keyErr != nil {
+			return nil, fmt.Errorf("resolve owner private key: %w", keyErr)
+		}
+		plain, decErr := e.encryptor.Decrypt(ciphertext, env, ownerPriv)
+		if decErr != nil {
+			return nil, fmt.Errorf("decrypt object: %w", decErr)
+		}
+		return plain, nil
+	}
+
+	// Legacy scheme: DEK wrapped with the HKDF-derived symmetric owner key.
+	ownerKey, keyErr := legacyDeriveOwnerKey(obj.Owner)
+	if keyErr != nil {
+		return nil, fmt.Errorf("derive legacy owner key: %w", keyErr)
+	}
+	plain, decErr := NewObjectEncryptor().Decrypt(ciphertext, obj.EncryptedDEK, ownerKey)
+	if decErr != nil {
+		return nil, fmt.Errorf("decrypt legacy object: %w", decErr)
+	}
+	return plain, nil
 }
 
 // HeadObject returns object metadata without the body. The caller must own the bucket.

--- a/internal/storage/engine_encryption_test.go
+++ b/internal/storage/engine_encryption_test.go
@@ -1,0 +1,328 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moltbunker/moltbunker/internal/security"
+	"github.com/moltbunker/moltbunker/internal/state"
+)
+
+// fakeProviderResolver is a self-recipient key resolver backed by an in-memory
+// X25519 keypair.
+type fakeProviderResolver struct {
+	pub  []byte
+	priv []byte
+}
+
+func newFakeResolver(t *testing.T) *fakeProviderResolver {
+	t.Helper()
+	pub, priv, err := security.GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("GenerateX25519KeyPair: %v", err)
+	}
+	return &fakeProviderResolver{pub: pub, priv: priv}
+}
+
+func (f *fakeProviderResolver) PublicKey() []byte  { return append([]byte(nil), f.pub...) }
+func (f *fakeProviderResolver) PrivateKey() []byte { return append([]byte(nil), f.priv...) }
+
+func newEncryptedEngine(t *testing.T) (*StorageEngine, *fakeProviderResolver) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := state.NewBboltStore(filepath.Join(dir, "state.db"), nil)
+	if err != nil {
+		t.Fatalf("NewBboltStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	eng, err := NewStorageEngine(dir, store, DefaultEngineConfig())
+	if err != nil {
+		t.Fatalf("NewStorageEngine: %v", err)
+	}
+
+	resolver := newFakeResolver(t)
+	ks, err := NewProviderKeyStore(resolver)
+	if err != nil {
+		t.Fatalf("NewProviderKeyStore: %v", err)
+	}
+	eng.WithOwnerKeyStore(ks)
+	return eng, resolver
+}
+
+func TestStorageEngine_EncryptedPutGet(t *testing.T) {
+	eng, _ := newEncryptedEngine(t)
+	ctx := context.Background()
+	owner := "0xAc1D8d6e25E54c05986E8bFa9b759063D5e69592"
+
+	if _, err := eng.CreateBucket(ctx, "my-bucket", owner); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	plaintext := []byte("top secret object contents at rest")
+	obj, err := eng.PutObject(ctx, &PutObjectInput{
+		Bucket: "my-bucket",
+		Key:    "secret.txt",
+		Body:   bytes.NewReader(plaintext),
+		Owner:  owner,
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+	if len(obj.EncryptedDEK) == 0 {
+		t.Fatal("expected object to carry a sealed DEK")
+	}
+	if obj.Size != int64(len(plaintext)) {
+		t.Errorf("Size = %d, want %d (plaintext size)", obj.Size, len(plaintext))
+	}
+
+	// On-disk blob must be ciphertext.
+	blobPath, _ := eng.blobPath("my-bucket", "secret.txt")
+	// #nosec G304 -- test-controlled path
+	onDisk, err := os.ReadFile(blobPath)
+	if err != nil {
+		t.Fatalf("read blob: %v", err)
+	}
+	if bytes.Contains(onDisk, plaintext) {
+		t.Fatal("plaintext leaked into encrypted blob on disk")
+	}
+
+	// GetObject returns decrypted plaintext.
+	out, err := eng.GetObject(ctx, "my-bucket", "secret.txt", owner)
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	defer out.Body.Close()
+	got, err := io.ReadAll(out.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("round-trip mismatch: got %q want %q", got, plaintext)
+	}
+}
+
+// TestStorageEngine_LegacyReadthrough writes an object whose blob is encrypted
+// with the legacy HKDF-derived symmetric key and a raw AES-GCM-wrapped DEK, then
+// verifies GetObject transparently decrypts it via the back-compat path.
+func TestStorageEngine_LegacyReadthrough(t *testing.T) {
+	eng, _ := newEncryptedEngine(t)
+	ctx := context.Background()
+	owner := "0xLegacyOwner"
+
+	if _, err := eng.CreateBucket(ctx, "legacy-bucket", owner); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	plaintext := []byte("legacy object written by the old scheme")
+
+	// Manually produce a legacy-encrypted blob + wrapped DEK.
+	legacyKey, err := legacyDeriveOwnerKey(owner)
+	if err != nil {
+		t.Fatalf("legacyDeriveOwnerKey: %v", err)
+	}
+	res, err := NewObjectEncryptor().Encrypt(plaintext, legacyKey)
+	if err != nil {
+		t.Fatalf("legacy Encrypt: %v", err)
+	}
+
+	// Write the ciphertext blob directly.
+	blobPath, _ := eng.blobPath("legacy-bucket", "old.txt")
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(blobPath, res.Ciphertext, 0600); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+
+	// Persist metadata with the legacy (non-JSON) wrapped DEK.
+	if err := eng.metadata.PutObject(ctx, &ObjectInfo{
+		Bucket:       "legacy-bucket",
+		Key:          "old.txt",
+		Size:         int64(len(plaintext)),
+		Owner:        owner,
+		EncryptedDEK: res.EncryptedDEK,
+	}); err != nil {
+		t.Fatalf("PutObject metadata: %v", err)
+	}
+
+	out, err := eng.GetObject(ctx, "legacy-bucket", "old.txt", owner)
+	if err != nil {
+		t.Fatalf("GetObject (legacy): %v", err)
+	}
+	defer out.Body.Close()
+	got, err := io.ReadAll(out.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("legacy read-through mismatch: got %q want %q", got, plaintext)
+	}
+}
+
+func TestStorageEngine_PlaintextWhenNoKeyStore(t *testing.T) {
+	dir := t.TempDir()
+	store, err := state.NewBboltStore(filepath.Join(dir, "state.db"), nil)
+	if err != nil {
+		t.Fatalf("NewBboltStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	eng, err := NewStorageEngine(dir, store, DefaultEngineConfig())
+	if err != nil {
+		t.Fatalf("NewStorageEngine: %v", err)
+	}
+
+	ctx := context.Background()
+	owner := "0xOwner"
+	if _, err := eng.CreateBucket(ctx, "plain-bucket", owner); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	plaintext := []byte("not encrypted")
+	obj, err := eng.PutObject(ctx, &PutObjectInput{
+		Bucket: "plain-bucket",
+		Key:    "p.txt",
+		Body:   bytes.NewReader(plaintext),
+		Owner:  owner,
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+	if len(obj.EncryptedDEK) != 0 {
+		t.Error("object should not carry a sealed DEK when encryption disabled")
+	}
+
+	blobPath, _ := eng.blobPath("plain-bucket", "p.txt")
+	// #nosec G304 -- test-controlled path
+	onDisk, _ := os.ReadFile(blobPath)
+	if !bytes.Equal(onDisk, plaintext) {
+		t.Error("blob should be stored as plaintext when encryption disabled")
+	}
+}
+
+// TestStorageEngine_EncryptedInMemoryCeiling verifies that the encrypted path
+// rejects objects larger than EncryptedMaxInMemoryBytes on both Put and Get,
+// while the plaintext path is unaffected by the ceiling.
+func TestStorageEngine_EncryptedInMemoryCeiling(t *testing.T) {
+	dir := t.TempDir()
+	store, err := state.NewBboltStore(filepath.Join(dir, "state.db"), nil)
+	if err != nil {
+		t.Fatalf("NewBboltStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Small ceiling so the test stays fast and uses no real memory pressure.
+	cfg := DefaultEngineConfig()
+	cfg.EncryptedMaxInMemoryBytes = 1024 // 1KB
+	eng, err := NewStorageEngine(dir, store, cfg)
+	if err != nil {
+		t.Fatalf("NewStorageEngine: %v", err)
+	}
+	resolver := newFakeResolver(t)
+	ks, err := NewProviderKeyStore(resolver)
+	if err != nil {
+		t.Fatalf("NewProviderKeyStore: %v", err)
+	}
+	eng.WithOwnerKeyStore(ks)
+
+	ctx := context.Background()
+	owner := "0xAc1D8d6e25E54c05986E8bFa9b759063D5e69592"
+	if _, err := eng.CreateBucket(ctx, "ceil-bucket", owner); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	// Over-ceiling Put must be rejected.
+	big := bytes.Repeat([]byte("A"), 2048) // 2KB > 1KB ceiling
+	if _, err := eng.PutObject(ctx, &PutObjectInput{
+		Bucket: "ceil-bucket", Key: "big.bin", Body: bytes.NewReader(big), Owner: owner,
+	}); err == nil {
+		t.Fatal("expected oversized encrypted PutObject to be rejected")
+	}
+
+	// The temp blob must not be left behind as a committed object.
+	if _, err := eng.GetObject(ctx, "ceil-bucket", "big.bin", owner); err == nil {
+		t.Fatal("oversized object should not have been stored")
+	}
+
+	// Under-ceiling Put/Get round-trips fine.
+	small := []byte("small enough")
+	if _, err := eng.PutObject(ctx, &PutObjectInput{
+		Bucket: "ceil-bucket", Key: "small.txt", Body: bytes.NewReader(small), Owner: owner,
+	}); err != nil {
+		t.Fatalf("small PutObject: %v", err)
+	}
+	out, err := eng.GetObject(ctx, "ceil-bucket", "small.txt", owner)
+	if err != nil {
+		t.Fatalf("small GetObject: %v", err)
+	}
+	defer out.Body.Close()
+	got, _ := io.ReadAll(out.Body)
+	if !bytes.Equal(got, small) {
+		t.Errorf("round-trip mismatch: got %q want %q", got, small)
+	}
+
+	// GetObject ceiling: simulate a stored object whose recorded plaintext Size
+	// exceeds the ceiling and confirm Get rejects it before buffering.
+	if err := eng.metadata.PutObject(ctx, &ObjectInfo{
+		Bucket: "ceil-bucket", Key: "oversize-meta", Size: 4096, Owner: owner,
+		EncryptedDEK: []byte(`{"ephemeral_pub":"AAAA"}`), // non-empty so the decrypt path is taken
+	}); err != nil {
+		t.Fatalf("PutObject metadata: %v", err)
+	}
+	// Write a dummy blob so os.Open succeeds and the Size guard is what trips.
+	blobPath, _ := eng.blobPath("ceil-bucket", "oversize-meta")
+	if err := os.WriteFile(blobPath, []byte("dummy"), 0600); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+	if _, err := eng.GetObject(ctx, "ceil-bucket", "oversize-meta", owner); err == nil {
+		t.Fatal("expected oversized encrypted GetObject to be rejected by the Size guard")
+	}
+}
+
+// TestStorageEngine_PlaintextIgnoresCeiling verifies the in-memory ceiling does
+// not constrain the plaintext (streaming) path.
+func TestStorageEngine_PlaintextIgnoresCeiling(t *testing.T) {
+	dir := t.TempDir()
+	store, err := state.NewBboltStore(filepath.Join(dir, "state.db"), nil)
+	if err != nil {
+		t.Fatalf("NewBboltStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	cfg := DefaultEngineConfig()
+	cfg.EncryptedMaxInMemoryBytes = 1024 // 1KB ceiling, but encryption disabled
+	eng, err := NewStorageEngine(dir, store, cfg)
+	if err != nil {
+		t.Fatalf("NewStorageEngine: %v", err)
+	}
+	ctx := context.Background()
+	owner := "0xOwner"
+	if _, err := eng.CreateBucket(ctx, "plain-ceil", owner); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	big := bytes.Repeat([]byte("B"), 4096) // 4KB > ceiling, but plaintext path streams
+	if _, err := eng.PutObject(ctx, &PutObjectInput{
+		Bucket: "plain-ceil", Key: "big.bin", Body: bytes.NewReader(big), Owner: owner,
+	}); err != nil {
+		t.Fatalf("plaintext PutObject should ignore encrypted ceiling: %v", err)
+	}
+}
+
+func TestNewProviderKeyStore_NilResolver(t *testing.T) {
+	if _, err := NewProviderKeyStore(nil); err == nil {
+		t.Fatal("expected error for nil resolver")
+	}
+}
+
+func TestWalletKeyStore_Stubbed(t *testing.T) {
+	ks := NewWalletKeyStore()
+	if _, err := ks.PublicKeyForOwner("0x1"); err != ErrOwnerKeyNotImplemented {
+		t.Errorf("PublicKeyForOwner err = %v, want ErrOwnerKeyNotImplemented", err)
+	}
+	if _, err := ks.PrivateKeyForOwner("0x1"); err != ErrOwnerKeyNotImplemented {
+		t.Errorf("PrivateKeyForOwner err = %v, want ErrOwnerKeyNotImplemented", err)
+	}
+}

--- a/internal/storage/keyprovider.go
+++ b/internal/storage/keyprovider.go
@@ -1,0 +1,96 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/moltbunker/moltbunker/internal/security"
+)
+
+// ErrOwnerKeyNotImplemented is returned by stubbed key stores that do not yet
+// support per-wallet key resolution.
+var ErrOwnerKeyNotImplemented = errors.New("storage: per-owner X25519 key resolution not implemented")
+
+// OwnerKeyStore resolves the X25519 keypair used to wrap an object's per-object
+// DEK. The public key is used to seal (encrypt) the DEK on PutObject; the
+// private key is used to open (decrypt) it on GetObject. Both are 32 bytes.
+//
+// Two models are supported:
+//   - ProviderKeyStore (single-node / self-recipient): every owner's objects are
+//     sealed to the provider's own stable X25519 key. This matches the R5 image
+//     encryption recipient model — a provider's data is readable only by that
+//     same provider's daemon.
+//   - WalletKeyStore (multi-tenant, future): maps a wallet address to a per-owner
+//     keypair from a keyring entry. Stubbed with ErrOwnerKeyNotImplemented so the
+//     interface is stable for the follow-up.
+type OwnerKeyStore interface {
+	// PublicKeyForOwner returns the 32-byte X25519 public key the object's DEK
+	// is sealed to.
+	PublicKeyForOwner(ownerAddr string) ([]byte, error)
+	// PrivateKeyForOwner returns the 32-byte X25519 private key used to open the
+	// sealed DEK. Daemon-internal use only; never serialized or logged.
+	PrivateKeyForOwner(ownerAddr string) ([]byte, error)
+}
+
+// ProviderKeyResolver is the minimal interface ProviderKeyStore needs from the
+// daemon's provider key manager. Defined here (rather than importing the daemon
+// package) to avoid an import cycle: the concrete *daemon.ProviderKeyManager is
+// wired in cmd/daemon/main.go and satisfies this structurally.
+type ProviderKeyResolver interface {
+	// PublicKey returns a copy of the 32-byte X25519 public key.
+	PublicKey() []byte
+	// PrivateKey returns a copy of the 32-byte X25519 private key.
+	PrivateKey() []byte
+}
+
+// ProviderKeyStore implements OwnerKeyStore using the daemon's own stable
+// X25519 keypair for every owner (self-recipient model).
+type ProviderKeyStore struct {
+	resolver ProviderKeyResolver
+}
+
+// NewProviderKeyStore builds a self-recipient key store backed by the provider's
+// X25519 keypair.
+func NewProviderKeyStore(resolver ProviderKeyResolver) (*ProviderKeyStore, error) {
+	if resolver == nil {
+		return nil, fmt.Errorf("storage: nil provider key resolver")
+	}
+	if len(resolver.PublicKey()) != security.X25519KeySize {
+		return nil, fmt.Errorf("storage: provider public key has invalid size")
+	}
+	return &ProviderKeyStore{resolver: resolver}, nil
+}
+
+// PublicKeyForOwner returns the provider's own public key for any owner.
+func (s *ProviderKeyStore) PublicKeyForOwner(_ string) ([]byte, error) {
+	pub := s.resolver.PublicKey()
+	if len(pub) != security.X25519KeySize {
+		return nil, fmt.Errorf("storage: provider public key has invalid size %d", len(pub))
+	}
+	return pub, nil
+}
+
+// PrivateKeyForOwner returns the provider's own private key for any owner.
+func (s *ProviderKeyStore) PrivateKeyForOwner(_ string) ([]byte, error) {
+	priv := s.resolver.PrivateKey()
+	if len(priv) != security.X25519KeySize {
+		return nil, fmt.Errorf("storage: provider private key has invalid size %d", len(priv))
+	}
+	return priv, nil
+}
+
+// WalletKeyStore is a placeholder for per-wallet key resolution (multi-tenant).
+// It returns ErrOwnerKeyNotImplemented until per-wallet key distribution is
+// designed; it exists so the OwnerKeyStore interface is stable for callers.
+type WalletKeyStore struct{}
+
+// NewWalletKeyStore returns the stubbed per-wallet key store.
+func NewWalletKeyStore() *WalletKeyStore { return &WalletKeyStore{} }
+
+func (s *WalletKeyStore) PublicKeyForOwner(string) ([]byte, error) {
+	return nil, ErrOwnerKeyNotImplemented
+}
+
+func (s *WalletKeyStore) PrivateKeyForOwner(string) ([]byte, error) {
+	return nil, ErrOwnerKeyNotImplemented
+}


### PR DESCRIPTION
## KEY-01 — Snapshot + storage key management hardening

- **Snapshot master key** behind a pluggable `KeyProvider` (file + OS-keyring); never ephemeral-silent-loss — fails/warns loudly.
- **Storage DEK** now wrapped via real **X25519 ECDH** per-owner (reusing the existing ECIES used by exec + R5) instead of HKDF-from-owner-address; back-compat read path retained.
- **R8 bbolt key-rotation:** versioned magic (`MBENC2`) + `RotateKey`. Encrypted-object path bounded by an in-memory-size guard (DoS); a full chunked/streaming AEAD is noted as follow-up.

Verification: build + vet + linux cross-build + gosec(0) + snapshot/storage/state tests green. Secret-scan clean.

> **Stacked PR — base `RUN-01`.** Merge order: PAY-01 → RUN-01 → **KEY-01**.
