### PR TITLE
ABIGEN-01 Generate Go contract bindings and retire hand-typed delegation ABI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,8 @@ research/
 TODO.local.md
 
 # Deploy scripts and keys (contain private keys)
-scripts/
+scripts/*
+!scripts/gen-bindings.sh
 secrets/
 
 # Deployment config (local/generated, do not commit)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
        test-containerd-linux test-integration test-localnet test-fuzz test-contracts test-all test-production \
        test-production-verbose clean install lint vet coverage doctor setup setup-linux \
        dev localnet localnet-stop localnet-status localnet-logs localnet-clean \
-       docker docker-dev docker-up docker-down release release-snapshot tidy check help
+       docker docker-dev docker-up docker-down release release-snapshot tidy check help \
+       gen-bindings bindings-check
 
 # ─── Configuration ────────────────────────────────────────────────────────────
 
@@ -128,6 +129,25 @@ tidy:
 check: tidy vet lint test
 	@echo "All checks passed"
 
+# ─── Contract Bindings (codegen) ────────────────────────────────────────────────
+# The generated Go bindings in internal/payment/bindings/ are COMMITTED, so a
+# normal `make build` needs only the Go toolchain. Run gen-bindings only when the
+# Solidity contracts change; it requires forge, jq, and abigen on PATH.
+
+gen-bindings:
+	@command -v jq >/dev/null 2>&1 || { echo "error: 'jq' not on PATH (macOS: brew install jq)"; exit 1; }
+	@command -v abigen >/dev/null 2>&1 || { echo "error: 'abigen' not on PATH (go install github.com/ethereum/go-ethereum/cmd/abigen@latest)"; exit 1; }
+	@command -v forge >/dev/null 2>&1 || [ -x "$(FOUNDRY_BIN)/forge" ] || { echo "error: 'forge' not on PATH (https://getfoundry.sh)"; exit 1; }
+	@echo "Generating contract bindings (forge build -> abigen -> internal/payment/bindings/)..."
+	@PATH="$(FOUNDRY_BIN):$$PATH" go generate ./internal/payment/...
+	@echo "Bindings generated. Review the diff before committing."
+
+bindings-check: gen-bindings
+	@echo "Checking committed bindings match a fresh generation..."
+	@git diff --exit-code -- internal/payment/bindings/ \
+		|| { echo "error: committed bindings differ from generated output; run 'make gen-bindings' and commit."; exit 1; }
+	@echo "Bindings are up to date."
+
 # ─── Localnet ─────────────────────────────────────────────────────────────────
 
 localnet: build
@@ -237,6 +257,10 @@ help:
 	@echo "  vet                  Run go vet"
 	@echo "  tidy                 go mod tidy + verify"
 	@echo "  check                tidy + vet + lint + test (pre-commit)"
+	@echo ""
+	@echo "Generate:"
+	@echo "  gen-bindings         Regenerate Go contract bindings (needs forge, jq, abigen)"
+	@echo "  bindings-check       Verify committed bindings match a fresh generation (drift)"
 	@echo ""
 	@echo "Localnet:"
 	@echo "  localnet             Build and start local network (Anvil + contracts + daemon + API)"

--- a/internal/payment/bindings/bunkerdelegation.go
+++ b/internal/payment/bindings/bunkerdelegation.go
@@ -1,0 +1,3342 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BunkerDelegationDelegationInfo is an auto generated low-level Go binding around an user-defined struct.
+type BunkerDelegationDelegationInfo struct {
+	Provider    common.Address
+	Amount      *big.Int
+	DelegatedAt *big.Int
+	Active      bool
+}
+
+// BunkerDelegationProviderDelegationConfig is an auto generated low-level Go binding around an user-defined struct.
+type BunkerDelegationProviderDelegationConfig struct {
+	RewardCutBps         uint16
+	PendingRewardCutBps  uint16
+	RewardCutEffectiveAt *big.Int
+	FeeShareBps          uint16
+	TotalDelegated       *big.Int
+	AcceptingDelegations bool
+}
+
+// BunkerDelegationUnbondingRequest is an auto generated low-level Go binding around an user-defined struct.
+type BunkerDelegationUnbondingRequest struct {
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Completed  bool
+}
+
+// BunkerDelegationMetaData contains all meta data concerning the BunkerDelegation contract.
+var BunkerDelegationMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_stakingContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_initialOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BPS_DENOMINATOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_UNBONDING_QUEUE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"completeUndelegate\",\"inputs\":[{\"name\":\"requestIndex\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"delegate\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"delegations\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"delegatedAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"active\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizeRewardCut\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getDelegation\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structBunkerDelegation.DelegationInfo\",\"components\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"delegatedAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"active\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderConfig\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"config\",\"type\":\"tuple\",\"internalType\":\"structBunkerDelegation.ProviderDelegationConfig\",\"components\":[{\"name\":\"rewardCutBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"pendingRewardCutBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"rewardCutEffectiveAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"feeShareBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"totalDelegated\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"acceptingDelegations\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getTotalDelegatedTo\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"total\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getUnbondingQueueLength\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"count\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getUnbondingRequest\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"request\",\"type\":\"tuple\",\"internalType\":\"structBunkerDelegation.UnbondingRequest\",\"components\":[{\"name\":\"amount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"unlockTime\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"completed\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"maxRewardCutBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"providerConfigs\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"rewardCutBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"pendingRewardCutBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"rewardCutEffectiveAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"feeShareBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"totalDelegated\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"acceptingDelegations\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestUndelegate\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setDelegationConfig\",\"inputs\":[{\"name\":\"rewardCutBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"feeShareBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMaxRewardCutBps\",\"inputs\":[{\"name\":\"newMax\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setStakingContract\",\"inputs\":[{\"name\":\"_stakingContract\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setUnbondingPeriod\",\"inputs\":[{\"name\":\"newPeriod\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"stakingContract\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"toggleAcceptDelegations\",\"inputs\":[{\"name\":\"accepting\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"token\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalDelegated\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unbondingPeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unbondingQueues\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"amount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"unlockTime\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"completed\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Delegated\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DelegationAcceptanceToggled\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"accepting\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DelegationWithdrawn\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MaxRewardCutUpdated\",\"inputs\":[{\"name\":\"newMax\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderConfigUpdated\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"rewardCutBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"},{\"name\":\"feeShareBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardCutFinalized\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"rewardCutBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardCutIncreaseScheduled\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newRewardCutBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"},{\"name\":\"effectiveAt\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakingContractUpdated\",\"inputs\":[{\"name\":\"oldStaking\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newStaking\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"UnbondingPeriodUpdated\",\"inputs\":[{\"name\":\"newPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"UndelegateCompleted\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"UndelegateRequested\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"unlockTime\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AlreadyDelegated\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InsufficientDelegation\",\"inputs\":[{\"name\":\"requested\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"available\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidRewardCutCap\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidUnbondingIndex\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"queueLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidUnbondingPeriod\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoPendingRewardCut\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotDelegated\",\"inputs\":[{\"name\":\"delegator\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProviderNotAccepting\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProviderNotActive\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RewardCutTimelockActive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RewardCutTooHigh\",\"inputs\":[{\"name\":\"requested\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"maximum\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"TooManyUnbondingRequests\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnbondingAlreadyCompleted\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UnbondingNotReady\",\"inputs\":[{\"name\":\"unlockTime\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"currentTime\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// BunkerDelegationABI is the input ABI used to generate the binding from.
+// Deprecated: Use BunkerDelegationMetaData.ABI instead.
+var BunkerDelegationABI = BunkerDelegationMetaData.ABI
+
+// BunkerDelegation is an auto generated Go binding around an Ethereum contract.
+type BunkerDelegation struct {
+	BunkerDelegationCaller     // Read-only binding to the contract
+	BunkerDelegationTransactor // Write-only binding to the contract
+	BunkerDelegationFilterer   // Log filterer for contract events
+}
+
+// BunkerDelegationCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BunkerDelegationCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerDelegationTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BunkerDelegationTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerDelegationFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BunkerDelegationFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerDelegationSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BunkerDelegationSession struct {
+	Contract     *BunkerDelegation // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BunkerDelegationCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BunkerDelegationCallerSession struct {
+	Contract *BunkerDelegationCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// BunkerDelegationTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BunkerDelegationTransactorSession struct {
+	Contract     *BunkerDelegationTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// BunkerDelegationRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BunkerDelegationRaw struct {
+	Contract *BunkerDelegation // Generic contract binding to access the raw methods on
+}
+
+// BunkerDelegationCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BunkerDelegationCallerRaw struct {
+	Contract *BunkerDelegationCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BunkerDelegationTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BunkerDelegationTransactorRaw struct {
+	Contract *BunkerDelegationTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBunkerDelegation creates a new instance of BunkerDelegation, bound to a specific deployed contract.
+func NewBunkerDelegation(address common.Address, backend bind.ContractBackend) (*BunkerDelegation, error) {
+	contract, err := bindBunkerDelegation(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegation{BunkerDelegationCaller: BunkerDelegationCaller{contract: contract}, BunkerDelegationTransactor: BunkerDelegationTransactor{contract: contract}, BunkerDelegationFilterer: BunkerDelegationFilterer{contract: contract}}, nil
+}
+
+// NewBunkerDelegationCaller creates a new read-only instance of BunkerDelegation, bound to a specific deployed contract.
+func NewBunkerDelegationCaller(address common.Address, caller bind.ContractCaller) (*BunkerDelegationCaller, error) {
+	contract, err := bindBunkerDelegation(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationCaller{contract: contract}, nil
+}
+
+// NewBunkerDelegationTransactor creates a new write-only instance of BunkerDelegation, bound to a specific deployed contract.
+func NewBunkerDelegationTransactor(address common.Address, transactor bind.ContractTransactor) (*BunkerDelegationTransactor, error) {
+	contract, err := bindBunkerDelegation(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationTransactor{contract: contract}, nil
+}
+
+// NewBunkerDelegationFilterer creates a new log filterer instance of BunkerDelegation, bound to a specific deployed contract.
+func NewBunkerDelegationFilterer(address common.Address, filterer bind.ContractFilterer) (*BunkerDelegationFilterer, error) {
+	contract, err := bindBunkerDelegation(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationFilterer{contract: contract}, nil
+}
+
+// bindBunkerDelegation binds a generic wrapper to an already deployed contract.
+func bindBunkerDelegation(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BunkerDelegationMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerDelegation *BunkerDelegationRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerDelegation.Contract.BunkerDelegationCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerDelegation *BunkerDelegationRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.BunkerDelegationTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerDelegation *BunkerDelegationRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.BunkerDelegationTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerDelegation *BunkerDelegationCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerDelegation.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerDelegation *BunkerDelegationTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerDelegation *BunkerDelegationTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.contract.Transact(opts, method, params...)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCaller) BPSDENOMINATOR(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "BPS_DENOMINATOR")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerDelegation.Contract.BPSDENOMINATOR(&_BunkerDelegation.CallOpts)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCallerSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerDelegation.Contract.BPSDENOMINATOR(&_BunkerDelegation.CallOpts)
+}
+
+// MAXUNBONDINGQUEUE is a free data retrieval call binding the contract method 0x5a14a6ef.
+//
+// Solidity: function MAX_UNBONDING_QUEUE() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCaller) MAXUNBONDINGQUEUE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "MAX_UNBONDING_QUEUE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXUNBONDINGQUEUE is a free data retrieval call binding the contract method 0x5a14a6ef.
+//
+// Solidity: function MAX_UNBONDING_QUEUE() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationSession) MAXUNBONDINGQUEUE() (*big.Int, error) {
+	return _BunkerDelegation.Contract.MAXUNBONDINGQUEUE(&_BunkerDelegation.CallOpts)
+}
+
+// MAXUNBONDINGQUEUE is a free data retrieval call binding the contract method 0x5a14a6ef.
+//
+// Solidity: function MAX_UNBONDING_QUEUE() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCallerSession) MAXUNBONDINGQUEUE() (*big.Int, error) {
+	return _BunkerDelegation.Contract.MAXUNBONDINGQUEUE(&_BunkerDelegation.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerDelegation *BunkerDelegationCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerDelegation *BunkerDelegationSession) VERSION() (string, error) {
+	return _BunkerDelegation.Contract.VERSION(&_BunkerDelegation.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerDelegation *BunkerDelegationCallerSession) VERSION() (string, error) {
+	return _BunkerDelegation.Contract.VERSION(&_BunkerDelegation.CallOpts)
+}
+
+// Delegations is a free data retrieval call binding the contract method 0xbffe3486.
+//
+// Solidity: function delegations(address ) view returns(address provider, uint128 amount, uint48 delegatedAt, bool active)
+func (_BunkerDelegation *BunkerDelegationCaller) Delegations(opts *bind.CallOpts, arg0 common.Address) (struct {
+	Provider    common.Address
+	Amount      *big.Int
+	DelegatedAt *big.Int
+	Active      bool
+}, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "delegations", arg0)
+
+	outstruct := new(struct {
+		Provider    common.Address
+		Amount      *big.Int
+		DelegatedAt *big.Int
+		Active      bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Provider = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.Amount = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.DelegatedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.Active = *abi.ConvertType(out[3], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// Delegations is a free data retrieval call binding the contract method 0xbffe3486.
+//
+// Solidity: function delegations(address ) view returns(address provider, uint128 amount, uint48 delegatedAt, bool active)
+func (_BunkerDelegation *BunkerDelegationSession) Delegations(arg0 common.Address) (struct {
+	Provider    common.Address
+	Amount      *big.Int
+	DelegatedAt *big.Int
+	Active      bool
+}, error) {
+	return _BunkerDelegation.Contract.Delegations(&_BunkerDelegation.CallOpts, arg0)
+}
+
+// Delegations is a free data retrieval call binding the contract method 0xbffe3486.
+//
+// Solidity: function delegations(address ) view returns(address provider, uint128 amount, uint48 delegatedAt, bool active)
+func (_BunkerDelegation *BunkerDelegationCallerSession) Delegations(arg0 common.Address) (struct {
+	Provider    common.Address
+	Amount      *big.Int
+	DelegatedAt *big.Int
+	Active      bool
+}, error) {
+	return _BunkerDelegation.Contract.Delegations(&_BunkerDelegation.CallOpts, arg0)
+}
+
+// GetDelegation is a free data retrieval call binding the contract method 0x2b293768.
+//
+// Solidity: function getDelegation(address delegator) view returns((address,uint128,uint48,bool) info)
+func (_BunkerDelegation *BunkerDelegationCaller) GetDelegation(opts *bind.CallOpts, delegator common.Address) (BunkerDelegationDelegationInfo, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "getDelegation", delegator)
+
+	if err != nil {
+		return *new(BunkerDelegationDelegationInfo), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerDelegationDelegationInfo)).(*BunkerDelegationDelegationInfo)
+
+	return out0, err
+
+}
+
+// GetDelegation is a free data retrieval call binding the contract method 0x2b293768.
+//
+// Solidity: function getDelegation(address delegator) view returns((address,uint128,uint48,bool) info)
+func (_BunkerDelegation *BunkerDelegationSession) GetDelegation(delegator common.Address) (BunkerDelegationDelegationInfo, error) {
+	return _BunkerDelegation.Contract.GetDelegation(&_BunkerDelegation.CallOpts, delegator)
+}
+
+// GetDelegation is a free data retrieval call binding the contract method 0x2b293768.
+//
+// Solidity: function getDelegation(address delegator) view returns((address,uint128,uint48,bool) info)
+func (_BunkerDelegation *BunkerDelegationCallerSession) GetDelegation(delegator common.Address) (BunkerDelegationDelegationInfo, error) {
+	return _BunkerDelegation.Contract.GetDelegation(&_BunkerDelegation.CallOpts, delegator)
+}
+
+// GetProviderConfig is a free data retrieval call binding the contract method 0x0edcd564.
+//
+// Solidity: function getProviderConfig(address provider) view returns((uint16,uint16,uint48,uint16,uint128,bool) config)
+func (_BunkerDelegation *BunkerDelegationCaller) GetProviderConfig(opts *bind.CallOpts, provider common.Address) (BunkerDelegationProviderDelegationConfig, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "getProviderConfig", provider)
+
+	if err != nil {
+		return *new(BunkerDelegationProviderDelegationConfig), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerDelegationProviderDelegationConfig)).(*BunkerDelegationProviderDelegationConfig)
+
+	return out0, err
+
+}
+
+// GetProviderConfig is a free data retrieval call binding the contract method 0x0edcd564.
+//
+// Solidity: function getProviderConfig(address provider) view returns((uint16,uint16,uint48,uint16,uint128,bool) config)
+func (_BunkerDelegation *BunkerDelegationSession) GetProviderConfig(provider common.Address) (BunkerDelegationProviderDelegationConfig, error) {
+	return _BunkerDelegation.Contract.GetProviderConfig(&_BunkerDelegation.CallOpts, provider)
+}
+
+// GetProviderConfig is a free data retrieval call binding the contract method 0x0edcd564.
+//
+// Solidity: function getProviderConfig(address provider) view returns((uint16,uint16,uint48,uint16,uint128,bool) config)
+func (_BunkerDelegation *BunkerDelegationCallerSession) GetProviderConfig(provider common.Address) (BunkerDelegationProviderDelegationConfig, error) {
+	return _BunkerDelegation.Contract.GetProviderConfig(&_BunkerDelegation.CallOpts, provider)
+}
+
+// GetTotalDelegatedTo is a free data retrieval call binding the contract method 0xd2032d71.
+//
+// Solidity: function getTotalDelegatedTo(address provider) view returns(uint256 total)
+func (_BunkerDelegation *BunkerDelegationCaller) GetTotalDelegatedTo(opts *bind.CallOpts, provider common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "getTotalDelegatedTo", provider)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetTotalDelegatedTo is a free data retrieval call binding the contract method 0xd2032d71.
+//
+// Solidity: function getTotalDelegatedTo(address provider) view returns(uint256 total)
+func (_BunkerDelegation *BunkerDelegationSession) GetTotalDelegatedTo(provider common.Address) (*big.Int, error) {
+	return _BunkerDelegation.Contract.GetTotalDelegatedTo(&_BunkerDelegation.CallOpts, provider)
+}
+
+// GetTotalDelegatedTo is a free data retrieval call binding the contract method 0xd2032d71.
+//
+// Solidity: function getTotalDelegatedTo(address provider) view returns(uint256 total)
+func (_BunkerDelegation *BunkerDelegationCallerSession) GetTotalDelegatedTo(provider common.Address) (*big.Int, error) {
+	return _BunkerDelegation.Contract.GetTotalDelegatedTo(&_BunkerDelegation.CallOpts, provider)
+}
+
+// GetUnbondingQueueLength is a free data retrieval call binding the contract method 0xdcb67d53.
+//
+// Solidity: function getUnbondingQueueLength(address delegator) view returns(uint256 count)
+func (_BunkerDelegation *BunkerDelegationCaller) GetUnbondingQueueLength(opts *bind.CallOpts, delegator common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "getUnbondingQueueLength", delegator)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetUnbondingQueueLength is a free data retrieval call binding the contract method 0xdcb67d53.
+//
+// Solidity: function getUnbondingQueueLength(address delegator) view returns(uint256 count)
+func (_BunkerDelegation *BunkerDelegationSession) GetUnbondingQueueLength(delegator common.Address) (*big.Int, error) {
+	return _BunkerDelegation.Contract.GetUnbondingQueueLength(&_BunkerDelegation.CallOpts, delegator)
+}
+
+// GetUnbondingQueueLength is a free data retrieval call binding the contract method 0xdcb67d53.
+//
+// Solidity: function getUnbondingQueueLength(address delegator) view returns(uint256 count)
+func (_BunkerDelegation *BunkerDelegationCallerSession) GetUnbondingQueueLength(delegator common.Address) (*big.Int, error) {
+	return _BunkerDelegation.Contract.GetUnbondingQueueLength(&_BunkerDelegation.CallOpts, delegator)
+}
+
+// GetUnbondingRequest is a free data retrieval call binding the contract method 0x9e79b122.
+//
+// Solidity: function getUnbondingRequest(address delegator, uint256 index) view returns((uint128,uint48,bool) request)
+func (_BunkerDelegation *BunkerDelegationCaller) GetUnbondingRequest(opts *bind.CallOpts, delegator common.Address, index *big.Int) (BunkerDelegationUnbondingRequest, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "getUnbondingRequest", delegator, index)
+
+	if err != nil {
+		return *new(BunkerDelegationUnbondingRequest), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerDelegationUnbondingRequest)).(*BunkerDelegationUnbondingRequest)
+
+	return out0, err
+
+}
+
+// GetUnbondingRequest is a free data retrieval call binding the contract method 0x9e79b122.
+//
+// Solidity: function getUnbondingRequest(address delegator, uint256 index) view returns((uint128,uint48,bool) request)
+func (_BunkerDelegation *BunkerDelegationSession) GetUnbondingRequest(delegator common.Address, index *big.Int) (BunkerDelegationUnbondingRequest, error) {
+	return _BunkerDelegation.Contract.GetUnbondingRequest(&_BunkerDelegation.CallOpts, delegator, index)
+}
+
+// GetUnbondingRequest is a free data retrieval call binding the contract method 0x9e79b122.
+//
+// Solidity: function getUnbondingRequest(address delegator, uint256 index) view returns((uint128,uint48,bool) request)
+func (_BunkerDelegation *BunkerDelegationCallerSession) GetUnbondingRequest(delegator common.Address, index *big.Int) (BunkerDelegationUnbondingRequest, error) {
+	return _BunkerDelegation.Contract.GetUnbondingRequest(&_BunkerDelegation.CallOpts, delegator, index)
+}
+
+// MaxRewardCutBps is a free data retrieval call binding the contract method 0xbfb38478.
+//
+// Solidity: function maxRewardCutBps() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCaller) MaxRewardCutBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "maxRewardCutBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MaxRewardCutBps is a free data retrieval call binding the contract method 0xbfb38478.
+//
+// Solidity: function maxRewardCutBps() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationSession) MaxRewardCutBps() (*big.Int, error) {
+	return _BunkerDelegation.Contract.MaxRewardCutBps(&_BunkerDelegation.CallOpts)
+}
+
+// MaxRewardCutBps is a free data retrieval call binding the contract method 0xbfb38478.
+//
+// Solidity: function maxRewardCutBps() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCallerSession) MaxRewardCutBps() (*big.Int, error) {
+	return _BunkerDelegation.Contract.MaxRewardCutBps(&_BunkerDelegation.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerDelegation *BunkerDelegationCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerDelegation *BunkerDelegationSession) Owner() (common.Address, error) {
+	return _BunkerDelegation.Contract.Owner(&_BunkerDelegation.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerDelegation *BunkerDelegationCallerSession) Owner() (common.Address, error) {
+	return _BunkerDelegation.Contract.Owner(&_BunkerDelegation.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerDelegation *BunkerDelegationCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerDelegation *BunkerDelegationSession) Paused() (bool, error) {
+	return _BunkerDelegation.Contract.Paused(&_BunkerDelegation.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerDelegation *BunkerDelegationCallerSession) Paused() (bool, error) {
+	return _BunkerDelegation.Contract.Paused(&_BunkerDelegation.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerDelegation *BunkerDelegationCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerDelegation *BunkerDelegationSession) PendingOwner() (common.Address, error) {
+	return _BunkerDelegation.Contract.PendingOwner(&_BunkerDelegation.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerDelegation *BunkerDelegationCallerSession) PendingOwner() (common.Address, error) {
+	return _BunkerDelegation.Contract.PendingOwner(&_BunkerDelegation.CallOpts)
+}
+
+// ProviderConfigs is a free data retrieval call binding the contract method 0x96d509f2.
+//
+// Solidity: function providerConfigs(address ) view returns(uint16 rewardCutBps, uint16 pendingRewardCutBps, uint48 rewardCutEffectiveAt, uint16 feeShareBps, uint128 totalDelegated, bool acceptingDelegations)
+func (_BunkerDelegation *BunkerDelegationCaller) ProviderConfigs(opts *bind.CallOpts, arg0 common.Address) (struct {
+	RewardCutBps         uint16
+	PendingRewardCutBps  uint16
+	RewardCutEffectiveAt *big.Int
+	FeeShareBps          uint16
+	TotalDelegated       *big.Int
+	AcceptingDelegations bool
+}, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "providerConfigs", arg0)
+
+	outstruct := new(struct {
+		RewardCutBps         uint16
+		PendingRewardCutBps  uint16
+		RewardCutEffectiveAt *big.Int
+		FeeShareBps          uint16
+		TotalDelegated       *big.Int
+		AcceptingDelegations bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RewardCutBps = *abi.ConvertType(out[0], new(uint16)).(*uint16)
+	outstruct.PendingRewardCutBps = *abi.ConvertType(out[1], new(uint16)).(*uint16)
+	outstruct.RewardCutEffectiveAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.FeeShareBps = *abi.ConvertType(out[3], new(uint16)).(*uint16)
+	outstruct.TotalDelegated = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+	outstruct.AcceptingDelegations = *abi.ConvertType(out[5], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// ProviderConfigs is a free data retrieval call binding the contract method 0x96d509f2.
+//
+// Solidity: function providerConfigs(address ) view returns(uint16 rewardCutBps, uint16 pendingRewardCutBps, uint48 rewardCutEffectiveAt, uint16 feeShareBps, uint128 totalDelegated, bool acceptingDelegations)
+func (_BunkerDelegation *BunkerDelegationSession) ProviderConfigs(arg0 common.Address) (struct {
+	RewardCutBps         uint16
+	PendingRewardCutBps  uint16
+	RewardCutEffectiveAt *big.Int
+	FeeShareBps          uint16
+	TotalDelegated       *big.Int
+	AcceptingDelegations bool
+}, error) {
+	return _BunkerDelegation.Contract.ProviderConfigs(&_BunkerDelegation.CallOpts, arg0)
+}
+
+// ProviderConfigs is a free data retrieval call binding the contract method 0x96d509f2.
+//
+// Solidity: function providerConfigs(address ) view returns(uint16 rewardCutBps, uint16 pendingRewardCutBps, uint48 rewardCutEffectiveAt, uint16 feeShareBps, uint128 totalDelegated, bool acceptingDelegations)
+func (_BunkerDelegation *BunkerDelegationCallerSession) ProviderConfigs(arg0 common.Address) (struct {
+	RewardCutBps         uint16
+	PendingRewardCutBps  uint16
+	RewardCutEffectiveAt *big.Int
+	FeeShareBps          uint16
+	TotalDelegated       *big.Int
+	AcceptingDelegations bool
+}, error) {
+	return _BunkerDelegation.Contract.ProviderConfigs(&_BunkerDelegation.CallOpts, arg0)
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerDelegation *BunkerDelegationCaller) StakingContract(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "stakingContract")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerDelegation *BunkerDelegationSession) StakingContract() (common.Address, error) {
+	return _BunkerDelegation.Contract.StakingContract(&_BunkerDelegation.CallOpts)
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerDelegation *BunkerDelegationCallerSession) StakingContract() (common.Address, error) {
+	return _BunkerDelegation.Contract.StakingContract(&_BunkerDelegation.CallOpts)
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerDelegation *BunkerDelegationCaller) Token(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "token")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerDelegation *BunkerDelegationSession) Token() (common.Address, error) {
+	return _BunkerDelegation.Contract.Token(&_BunkerDelegation.CallOpts)
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerDelegation *BunkerDelegationCallerSession) Token() (common.Address, error) {
+	return _BunkerDelegation.Contract.Token(&_BunkerDelegation.CallOpts)
+}
+
+// TotalDelegated is a free data retrieval call binding the contract method 0x80d04de8.
+//
+// Solidity: function totalDelegated() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCaller) TotalDelegated(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "totalDelegated")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalDelegated is a free data retrieval call binding the contract method 0x80d04de8.
+//
+// Solidity: function totalDelegated() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationSession) TotalDelegated() (*big.Int, error) {
+	return _BunkerDelegation.Contract.TotalDelegated(&_BunkerDelegation.CallOpts)
+}
+
+// TotalDelegated is a free data retrieval call binding the contract method 0x80d04de8.
+//
+// Solidity: function totalDelegated() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCallerSession) TotalDelegated() (*big.Int, error) {
+	return _BunkerDelegation.Contract.TotalDelegated(&_BunkerDelegation.CallOpts)
+}
+
+// UnbondingPeriod is a free data retrieval call binding the contract method 0x6cf6d675.
+//
+// Solidity: function unbondingPeriod() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCaller) UnbondingPeriod(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "unbondingPeriod")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// UnbondingPeriod is a free data retrieval call binding the contract method 0x6cf6d675.
+//
+// Solidity: function unbondingPeriod() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationSession) UnbondingPeriod() (*big.Int, error) {
+	return _BunkerDelegation.Contract.UnbondingPeriod(&_BunkerDelegation.CallOpts)
+}
+
+// UnbondingPeriod is a free data retrieval call binding the contract method 0x6cf6d675.
+//
+// Solidity: function unbondingPeriod() view returns(uint256)
+func (_BunkerDelegation *BunkerDelegationCallerSession) UnbondingPeriod() (*big.Int, error) {
+	return _BunkerDelegation.Contract.UnbondingPeriod(&_BunkerDelegation.CallOpts)
+}
+
+// UnbondingQueues is a free data retrieval call binding the contract method 0x28a78f43.
+//
+// Solidity: function unbondingQueues(address , uint256 ) view returns(uint128 amount, uint48 unlockTime, bool completed)
+func (_BunkerDelegation *BunkerDelegationCaller) UnbondingQueues(opts *bind.CallOpts, arg0 common.Address, arg1 *big.Int) (struct {
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Completed  bool
+}, error) {
+	var out []interface{}
+	err := _BunkerDelegation.contract.Call(opts, &out, "unbondingQueues", arg0, arg1)
+
+	outstruct := new(struct {
+		Amount     *big.Int
+		UnlockTime *big.Int
+		Completed  bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Amount = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.UnlockTime = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.Completed = *abi.ConvertType(out[2], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// UnbondingQueues is a free data retrieval call binding the contract method 0x28a78f43.
+//
+// Solidity: function unbondingQueues(address , uint256 ) view returns(uint128 amount, uint48 unlockTime, bool completed)
+func (_BunkerDelegation *BunkerDelegationSession) UnbondingQueues(arg0 common.Address, arg1 *big.Int) (struct {
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Completed  bool
+}, error) {
+	return _BunkerDelegation.Contract.UnbondingQueues(&_BunkerDelegation.CallOpts, arg0, arg1)
+}
+
+// UnbondingQueues is a free data retrieval call binding the contract method 0x28a78f43.
+//
+// Solidity: function unbondingQueues(address , uint256 ) view returns(uint128 amount, uint48 unlockTime, bool completed)
+func (_BunkerDelegation *BunkerDelegationCallerSession) UnbondingQueues(arg0 common.Address, arg1 *big.Int) (struct {
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Completed  bool
+}, error) {
+	return _BunkerDelegation.Contract.UnbondingQueues(&_BunkerDelegation.CallOpts, arg0, arg1)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerDelegation *BunkerDelegationSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.AcceptOwnership(&_BunkerDelegation.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.AcceptOwnership(&_BunkerDelegation.TransactOpts)
+}
+
+// CompleteUndelegate is a paid mutator transaction binding the contract method 0xdfb22ad1.
+//
+// Solidity: function completeUndelegate(uint256 requestIndex) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) CompleteUndelegate(opts *bind.TransactOpts, requestIndex *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "completeUndelegate", requestIndex)
+}
+
+// CompleteUndelegate is a paid mutator transaction binding the contract method 0xdfb22ad1.
+//
+// Solidity: function completeUndelegate(uint256 requestIndex) returns()
+func (_BunkerDelegation *BunkerDelegationSession) CompleteUndelegate(requestIndex *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.CompleteUndelegate(&_BunkerDelegation.TransactOpts, requestIndex)
+}
+
+// CompleteUndelegate is a paid mutator transaction binding the contract method 0xdfb22ad1.
+//
+// Solidity: function completeUndelegate(uint256 requestIndex) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) CompleteUndelegate(requestIndex *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.CompleteUndelegate(&_BunkerDelegation.TransactOpts, requestIndex)
+}
+
+// Delegate is a paid mutator transaction binding the contract method 0x026e402b.
+//
+// Solidity: function delegate(address provider, uint256 amount) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) Delegate(opts *bind.TransactOpts, provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "delegate", provider, amount)
+}
+
+// Delegate is a paid mutator transaction binding the contract method 0x026e402b.
+//
+// Solidity: function delegate(address provider, uint256 amount) returns()
+func (_BunkerDelegation *BunkerDelegationSession) Delegate(provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.Delegate(&_BunkerDelegation.TransactOpts, provider, amount)
+}
+
+// Delegate is a paid mutator transaction binding the contract method 0x026e402b.
+//
+// Solidity: function delegate(address provider, uint256 amount) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) Delegate(provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.Delegate(&_BunkerDelegation.TransactOpts, provider, amount)
+}
+
+// FinalizeRewardCut is a paid mutator transaction binding the contract method 0x6063f05c.
+//
+// Solidity: function finalizeRewardCut() returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) FinalizeRewardCut(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "finalizeRewardCut")
+}
+
+// FinalizeRewardCut is a paid mutator transaction binding the contract method 0x6063f05c.
+//
+// Solidity: function finalizeRewardCut() returns()
+func (_BunkerDelegation *BunkerDelegationSession) FinalizeRewardCut() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.FinalizeRewardCut(&_BunkerDelegation.TransactOpts)
+}
+
+// FinalizeRewardCut is a paid mutator transaction binding the contract method 0x6063f05c.
+//
+// Solidity: function finalizeRewardCut() returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) FinalizeRewardCut() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.FinalizeRewardCut(&_BunkerDelegation.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerDelegation *BunkerDelegationSession) Pause() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.Pause(&_BunkerDelegation.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) Pause() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.Pause(&_BunkerDelegation.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerDelegation *BunkerDelegationSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.RenounceOwnership(&_BunkerDelegation.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.RenounceOwnership(&_BunkerDelegation.TransactOpts)
+}
+
+// RequestUndelegate is a paid mutator transaction binding the contract method 0xf86bc80c.
+//
+// Solidity: function requestUndelegate(uint256 amount) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) RequestUndelegate(opts *bind.TransactOpts, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "requestUndelegate", amount)
+}
+
+// RequestUndelegate is a paid mutator transaction binding the contract method 0xf86bc80c.
+//
+// Solidity: function requestUndelegate(uint256 amount) returns()
+func (_BunkerDelegation *BunkerDelegationSession) RequestUndelegate(amount *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.RequestUndelegate(&_BunkerDelegation.TransactOpts, amount)
+}
+
+// RequestUndelegate is a paid mutator transaction binding the contract method 0xf86bc80c.
+//
+// Solidity: function requestUndelegate(uint256 amount) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) RequestUndelegate(amount *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.RequestUndelegate(&_BunkerDelegation.TransactOpts, amount)
+}
+
+// SetDelegationConfig is a paid mutator transaction binding the contract method 0x9047b71f.
+//
+// Solidity: function setDelegationConfig(uint16 rewardCutBps, uint16 feeShareBps) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) SetDelegationConfig(opts *bind.TransactOpts, rewardCutBps uint16, feeShareBps uint16) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "setDelegationConfig", rewardCutBps, feeShareBps)
+}
+
+// SetDelegationConfig is a paid mutator transaction binding the contract method 0x9047b71f.
+//
+// Solidity: function setDelegationConfig(uint16 rewardCutBps, uint16 feeShareBps) returns()
+func (_BunkerDelegation *BunkerDelegationSession) SetDelegationConfig(rewardCutBps uint16, feeShareBps uint16) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.SetDelegationConfig(&_BunkerDelegation.TransactOpts, rewardCutBps, feeShareBps)
+}
+
+// SetDelegationConfig is a paid mutator transaction binding the contract method 0x9047b71f.
+//
+// Solidity: function setDelegationConfig(uint16 rewardCutBps, uint16 feeShareBps) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) SetDelegationConfig(rewardCutBps uint16, feeShareBps uint16) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.SetDelegationConfig(&_BunkerDelegation.TransactOpts, rewardCutBps, feeShareBps)
+}
+
+// SetMaxRewardCutBps is a paid mutator transaction binding the contract method 0x6f91a0dd.
+//
+// Solidity: function setMaxRewardCutBps(uint16 newMax) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) SetMaxRewardCutBps(opts *bind.TransactOpts, newMax uint16) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "setMaxRewardCutBps", newMax)
+}
+
+// SetMaxRewardCutBps is a paid mutator transaction binding the contract method 0x6f91a0dd.
+//
+// Solidity: function setMaxRewardCutBps(uint16 newMax) returns()
+func (_BunkerDelegation *BunkerDelegationSession) SetMaxRewardCutBps(newMax uint16) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.SetMaxRewardCutBps(&_BunkerDelegation.TransactOpts, newMax)
+}
+
+// SetMaxRewardCutBps is a paid mutator transaction binding the contract method 0x6f91a0dd.
+//
+// Solidity: function setMaxRewardCutBps(uint16 newMax) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) SetMaxRewardCutBps(newMax uint16) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.SetMaxRewardCutBps(&_BunkerDelegation.TransactOpts, newMax)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address _stakingContract) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) SetStakingContract(opts *bind.TransactOpts, _stakingContract common.Address) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "setStakingContract", _stakingContract)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address _stakingContract) returns()
+func (_BunkerDelegation *BunkerDelegationSession) SetStakingContract(_stakingContract common.Address) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.SetStakingContract(&_BunkerDelegation.TransactOpts, _stakingContract)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address _stakingContract) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) SetStakingContract(_stakingContract common.Address) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.SetStakingContract(&_BunkerDelegation.TransactOpts, _stakingContract)
+}
+
+// SetUnbondingPeriod is a paid mutator transaction binding the contract method 0x114eaf55.
+//
+// Solidity: function setUnbondingPeriod(uint256 newPeriod) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) SetUnbondingPeriod(opts *bind.TransactOpts, newPeriod *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "setUnbondingPeriod", newPeriod)
+}
+
+// SetUnbondingPeriod is a paid mutator transaction binding the contract method 0x114eaf55.
+//
+// Solidity: function setUnbondingPeriod(uint256 newPeriod) returns()
+func (_BunkerDelegation *BunkerDelegationSession) SetUnbondingPeriod(newPeriod *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.SetUnbondingPeriod(&_BunkerDelegation.TransactOpts, newPeriod)
+}
+
+// SetUnbondingPeriod is a paid mutator transaction binding the contract method 0x114eaf55.
+//
+// Solidity: function setUnbondingPeriod(uint256 newPeriod) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) SetUnbondingPeriod(newPeriod *big.Int) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.SetUnbondingPeriod(&_BunkerDelegation.TransactOpts, newPeriod)
+}
+
+// ToggleAcceptDelegations is a paid mutator transaction binding the contract method 0xf86d6829.
+//
+// Solidity: function toggleAcceptDelegations(bool accepting) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) ToggleAcceptDelegations(opts *bind.TransactOpts, accepting bool) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "toggleAcceptDelegations", accepting)
+}
+
+// ToggleAcceptDelegations is a paid mutator transaction binding the contract method 0xf86d6829.
+//
+// Solidity: function toggleAcceptDelegations(bool accepting) returns()
+func (_BunkerDelegation *BunkerDelegationSession) ToggleAcceptDelegations(accepting bool) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.ToggleAcceptDelegations(&_BunkerDelegation.TransactOpts, accepting)
+}
+
+// ToggleAcceptDelegations is a paid mutator transaction binding the contract method 0xf86d6829.
+//
+// Solidity: function toggleAcceptDelegations(bool accepting) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) ToggleAcceptDelegations(accepting bool) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.ToggleAcceptDelegations(&_BunkerDelegation.TransactOpts, accepting)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerDelegation *BunkerDelegationSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.TransferOwnership(&_BunkerDelegation.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.TransferOwnership(&_BunkerDelegation.TransactOpts, newOwner)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerDelegation *BunkerDelegationTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerDelegation.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerDelegation *BunkerDelegationSession) Unpause() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.Unpause(&_BunkerDelegation.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerDelegation *BunkerDelegationTransactorSession) Unpause() (*types.Transaction, error) {
+	return _BunkerDelegation.Contract.Unpause(&_BunkerDelegation.TransactOpts)
+}
+
+// BunkerDelegationDelegatedIterator is returned from FilterDelegated and is used to iterate over the raw logs and unpacked data for Delegated events raised by the BunkerDelegation contract.
+type BunkerDelegationDelegatedIterator struct {
+	Event *BunkerDelegationDelegated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationDelegatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationDelegated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationDelegated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationDelegatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationDelegatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationDelegated represents a Delegated event raised by the BunkerDelegation contract.
+type BunkerDelegationDelegated struct {
+	Delegator common.Address
+	Provider  common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterDelegated is a free log retrieval operation binding the contract event 0xe5541a6b6103d4fa7e021ed54fad39c66f27a76bd13d374cf6240ae6bd0bb72b.
+//
+// Solidity: event Delegated(address indexed delegator, address indexed provider, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterDelegated(opts *bind.FilterOpts, delegator []common.Address, provider []common.Address) (*BunkerDelegationDelegatedIterator, error) {
+
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "Delegated", delegatorRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationDelegatedIterator{contract: _BunkerDelegation.contract, event: "Delegated", logs: logs, sub: sub}, nil
+}
+
+// WatchDelegated is a free log subscription operation binding the contract event 0xe5541a6b6103d4fa7e021ed54fad39c66f27a76bd13d374cf6240ae6bd0bb72b.
+//
+// Solidity: event Delegated(address indexed delegator, address indexed provider, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchDelegated(opts *bind.WatchOpts, sink chan<- *BunkerDelegationDelegated, delegator []common.Address, provider []common.Address) (event.Subscription, error) {
+
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "Delegated", delegatorRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationDelegated)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "Delegated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDelegated is a log parse operation binding the contract event 0xe5541a6b6103d4fa7e021ed54fad39c66f27a76bd13d374cf6240ae6bd0bb72b.
+//
+// Solidity: event Delegated(address indexed delegator, address indexed provider, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseDelegated(log types.Log) (*BunkerDelegationDelegated, error) {
+	event := new(BunkerDelegationDelegated)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "Delegated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationDelegationAcceptanceToggledIterator is returned from FilterDelegationAcceptanceToggled and is used to iterate over the raw logs and unpacked data for DelegationAcceptanceToggled events raised by the BunkerDelegation contract.
+type BunkerDelegationDelegationAcceptanceToggledIterator struct {
+	Event *BunkerDelegationDelegationAcceptanceToggled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationDelegationAcceptanceToggledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationDelegationAcceptanceToggled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationDelegationAcceptanceToggled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationDelegationAcceptanceToggledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationDelegationAcceptanceToggledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationDelegationAcceptanceToggled represents a DelegationAcceptanceToggled event raised by the BunkerDelegation contract.
+type BunkerDelegationDelegationAcceptanceToggled struct {
+	Provider  common.Address
+	Accepting bool
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterDelegationAcceptanceToggled is a free log retrieval operation binding the contract event 0x6b98bc340f3988300f115b17fe5da378d561c6317fcc3fbfda4033e77f2699ef.
+//
+// Solidity: event DelegationAcceptanceToggled(address indexed provider, bool accepting)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterDelegationAcceptanceToggled(opts *bind.FilterOpts, provider []common.Address) (*BunkerDelegationDelegationAcceptanceToggledIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "DelegationAcceptanceToggled", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationDelegationAcceptanceToggledIterator{contract: _BunkerDelegation.contract, event: "DelegationAcceptanceToggled", logs: logs, sub: sub}, nil
+}
+
+// WatchDelegationAcceptanceToggled is a free log subscription operation binding the contract event 0x6b98bc340f3988300f115b17fe5da378d561c6317fcc3fbfda4033e77f2699ef.
+//
+// Solidity: event DelegationAcceptanceToggled(address indexed provider, bool accepting)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchDelegationAcceptanceToggled(opts *bind.WatchOpts, sink chan<- *BunkerDelegationDelegationAcceptanceToggled, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "DelegationAcceptanceToggled", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationDelegationAcceptanceToggled)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "DelegationAcceptanceToggled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDelegationAcceptanceToggled is a log parse operation binding the contract event 0x6b98bc340f3988300f115b17fe5da378d561c6317fcc3fbfda4033e77f2699ef.
+//
+// Solidity: event DelegationAcceptanceToggled(address indexed provider, bool accepting)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseDelegationAcceptanceToggled(log types.Log) (*BunkerDelegationDelegationAcceptanceToggled, error) {
+	event := new(BunkerDelegationDelegationAcceptanceToggled)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "DelegationAcceptanceToggled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationDelegationWithdrawnIterator is returned from FilterDelegationWithdrawn and is used to iterate over the raw logs and unpacked data for DelegationWithdrawn events raised by the BunkerDelegation contract.
+type BunkerDelegationDelegationWithdrawnIterator struct {
+	Event *BunkerDelegationDelegationWithdrawn // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationDelegationWithdrawnIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationDelegationWithdrawn)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationDelegationWithdrawn)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationDelegationWithdrawnIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationDelegationWithdrawnIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationDelegationWithdrawn represents a DelegationWithdrawn event raised by the BunkerDelegation contract.
+type BunkerDelegationDelegationWithdrawn struct {
+	Delegator common.Address
+	Provider  common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterDelegationWithdrawn is a free log retrieval operation binding the contract event 0xaa0001b0e2e76b9a1b925257fefa58b756aebc52d2d7c8a85ea5beacc77a2100.
+//
+// Solidity: event DelegationWithdrawn(address indexed delegator, address indexed provider, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterDelegationWithdrawn(opts *bind.FilterOpts, delegator []common.Address, provider []common.Address) (*BunkerDelegationDelegationWithdrawnIterator, error) {
+
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "DelegationWithdrawn", delegatorRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationDelegationWithdrawnIterator{contract: _BunkerDelegation.contract, event: "DelegationWithdrawn", logs: logs, sub: sub}, nil
+}
+
+// WatchDelegationWithdrawn is a free log subscription operation binding the contract event 0xaa0001b0e2e76b9a1b925257fefa58b756aebc52d2d7c8a85ea5beacc77a2100.
+//
+// Solidity: event DelegationWithdrawn(address indexed delegator, address indexed provider, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchDelegationWithdrawn(opts *bind.WatchOpts, sink chan<- *BunkerDelegationDelegationWithdrawn, delegator []common.Address, provider []common.Address) (event.Subscription, error) {
+
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "DelegationWithdrawn", delegatorRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationDelegationWithdrawn)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "DelegationWithdrawn", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDelegationWithdrawn is a log parse operation binding the contract event 0xaa0001b0e2e76b9a1b925257fefa58b756aebc52d2d7c8a85ea5beacc77a2100.
+//
+// Solidity: event DelegationWithdrawn(address indexed delegator, address indexed provider, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseDelegationWithdrawn(log types.Log) (*BunkerDelegationDelegationWithdrawn, error) {
+	event := new(BunkerDelegationDelegationWithdrawn)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "DelegationWithdrawn", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationMaxRewardCutUpdatedIterator is returned from FilterMaxRewardCutUpdated and is used to iterate over the raw logs and unpacked data for MaxRewardCutUpdated events raised by the BunkerDelegation contract.
+type BunkerDelegationMaxRewardCutUpdatedIterator struct {
+	Event *BunkerDelegationMaxRewardCutUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationMaxRewardCutUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationMaxRewardCutUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationMaxRewardCutUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationMaxRewardCutUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationMaxRewardCutUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationMaxRewardCutUpdated represents a MaxRewardCutUpdated event raised by the BunkerDelegation contract.
+type BunkerDelegationMaxRewardCutUpdated struct {
+	NewMax uint16
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterMaxRewardCutUpdated is a free log retrieval operation binding the contract event 0xfe2dd0e7c42a6b3aaeb9c8487d1fa6c72bebea32edce7b0d34d2b86b4b90844a.
+//
+// Solidity: event MaxRewardCutUpdated(uint16 newMax)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterMaxRewardCutUpdated(opts *bind.FilterOpts) (*BunkerDelegationMaxRewardCutUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "MaxRewardCutUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationMaxRewardCutUpdatedIterator{contract: _BunkerDelegation.contract, event: "MaxRewardCutUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMaxRewardCutUpdated is a free log subscription operation binding the contract event 0xfe2dd0e7c42a6b3aaeb9c8487d1fa6c72bebea32edce7b0d34d2b86b4b90844a.
+//
+// Solidity: event MaxRewardCutUpdated(uint16 newMax)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchMaxRewardCutUpdated(opts *bind.WatchOpts, sink chan<- *BunkerDelegationMaxRewardCutUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "MaxRewardCutUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationMaxRewardCutUpdated)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "MaxRewardCutUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMaxRewardCutUpdated is a log parse operation binding the contract event 0xfe2dd0e7c42a6b3aaeb9c8487d1fa6c72bebea32edce7b0d34d2b86b4b90844a.
+//
+// Solidity: event MaxRewardCutUpdated(uint16 newMax)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseMaxRewardCutUpdated(log types.Log) (*BunkerDelegationMaxRewardCutUpdated, error) {
+	event := new(BunkerDelegationMaxRewardCutUpdated)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "MaxRewardCutUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the BunkerDelegation contract.
+type BunkerDelegationOwnershipTransferStartedIterator struct {
+	Event *BunkerDelegationOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the BunkerDelegation contract.
+type BunkerDelegationOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerDelegationOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationOwnershipTransferStartedIterator{contract: _BunkerDelegation.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BunkerDelegationOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationOwnershipTransferStarted)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseOwnershipTransferStarted(log types.Log) (*BunkerDelegationOwnershipTransferStarted, error) {
+	event := new(BunkerDelegationOwnershipTransferStarted)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BunkerDelegation contract.
+type BunkerDelegationOwnershipTransferredIterator struct {
+	Event *BunkerDelegationOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationOwnershipTransferred represents a OwnershipTransferred event raised by the BunkerDelegation contract.
+type BunkerDelegationOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerDelegationOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationOwnershipTransferredIterator{contract: _BunkerDelegation.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BunkerDelegationOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationOwnershipTransferred)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseOwnershipTransferred(log types.Log) (*BunkerDelegationOwnershipTransferred, error) {
+	event := new(BunkerDelegationOwnershipTransferred)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the BunkerDelegation contract.
+type BunkerDelegationPausedIterator struct {
+	Event *BunkerDelegationPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationPaused represents a Paused event raised by the BunkerDelegation contract.
+type BunkerDelegationPaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterPaused(opts *bind.FilterOpts) (*BunkerDelegationPausedIterator, error) {
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationPausedIterator{contract: _BunkerDelegation.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *BunkerDelegationPaused) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationPaused)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParsePaused(log types.Log) (*BunkerDelegationPaused, error) {
+	event := new(BunkerDelegationPaused)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationProviderConfigUpdatedIterator is returned from FilterProviderConfigUpdated and is used to iterate over the raw logs and unpacked data for ProviderConfigUpdated events raised by the BunkerDelegation contract.
+type BunkerDelegationProviderConfigUpdatedIterator struct {
+	Event *BunkerDelegationProviderConfigUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationProviderConfigUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationProviderConfigUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationProviderConfigUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationProviderConfigUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationProviderConfigUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationProviderConfigUpdated represents a ProviderConfigUpdated event raised by the BunkerDelegation contract.
+type BunkerDelegationProviderConfigUpdated struct {
+	Provider     common.Address
+	RewardCutBps uint16
+	FeeShareBps  uint16
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderConfigUpdated is a free log retrieval operation binding the contract event 0x06f77c1359530c8fc190310202965155808170209f916f4b0a5efac34342e1d7.
+//
+// Solidity: event ProviderConfigUpdated(address indexed provider, uint16 rewardCutBps, uint16 feeShareBps)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterProviderConfigUpdated(opts *bind.FilterOpts, provider []common.Address) (*BunkerDelegationProviderConfigUpdatedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "ProviderConfigUpdated", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationProviderConfigUpdatedIterator{contract: _BunkerDelegation.contract, event: "ProviderConfigUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderConfigUpdated is a free log subscription operation binding the contract event 0x06f77c1359530c8fc190310202965155808170209f916f4b0a5efac34342e1d7.
+//
+// Solidity: event ProviderConfigUpdated(address indexed provider, uint16 rewardCutBps, uint16 feeShareBps)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchProviderConfigUpdated(opts *bind.WatchOpts, sink chan<- *BunkerDelegationProviderConfigUpdated, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "ProviderConfigUpdated", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationProviderConfigUpdated)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "ProviderConfigUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderConfigUpdated is a log parse operation binding the contract event 0x06f77c1359530c8fc190310202965155808170209f916f4b0a5efac34342e1d7.
+//
+// Solidity: event ProviderConfigUpdated(address indexed provider, uint16 rewardCutBps, uint16 feeShareBps)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseProviderConfigUpdated(log types.Log) (*BunkerDelegationProviderConfigUpdated, error) {
+	event := new(BunkerDelegationProviderConfigUpdated)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "ProviderConfigUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationRewardCutFinalizedIterator is returned from FilterRewardCutFinalized and is used to iterate over the raw logs and unpacked data for RewardCutFinalized events raised by the BunkerDelegation contract.
+type BunkerDelegationRewardCutFinalizedIterator struct {
+	Event *BunkerDelegationRewardCutFinalized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationRewardCutFinalizedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationRewardCutFinalized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationRewardCutFinalized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationRewardCutFinalizedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationRewardCutFinalizedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationRewardCutFinalized represents a RewardCutFinalized event raised by the BunkerDelegation contract.
+type BunkerDelegationRewardCutFinalized struct {
+	Provider     common.Address
+	RewardCutBps uint16
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardCutFinalized is a free log retrieval operation binding the contract event 0xb850bcde10c1aa68133a57670c0c9f790f4a8e2454836924c876c79a01c259f2.
+//
+// Solidity: event RewardCutFinalized(address indexed provider, uint16 rewardCutBps)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterRewardCutFinalized(opts *bind.FilterOpts, provider []common.Address) (*BunkerDelegationRewardCutFinalizedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "RewardCutFinalized", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationRewardCutFinalizedIterator{contract: _BunkerDelegation.contract, event: "RewardCutFinalized", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardCutFinalized is a free log subscription operation binding the contract event 0xb850bcde10c1aa68133a57670c0c9f790f4a8e2454836924c876c79a01c259f2.
+//
+// Solidity: event RewardCutFinalized(address indexed provider, uint16 rewardCutBps)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchRewardCutFinalized(opts *bind.WatchOpts, sink chan<- *BunkerDelegationRewardCutFinalized, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "RewardCutFinalized", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationRewardCutFinalized)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "RewardCutFinalized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardCutFinalized is a log parse operation binding the contract event 0xb850bcde10c1aa68133a57670c0c9f790f4a8e2454836924c876c79a01c259f2.
+//
+// Solidity: event RewardCutFinalized(address indexed provider, uint16 rewardCutBps)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseRewardCutFinalized(log types.Log) (*BunkerDelegationRewardCutFinalized, error) {
+	event := new(BunkerDelegationRewardCutFinalized)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "RewardCutFinalized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationRewardCutIncreaseScheduledIterator is returned from FilterRewardCutIncreaseScheduled and is used to iterate over the raw logs and unpacked data for RewardCutIncreaseScheduled events raised by the BunkerDelegation contract.
+type BunkerDelegationRewardCutIncreaseScheduledIterator struct {
+	Event *BunkerDelegationRewardCutIncreaseScheduled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationRewardCutIncreaseScheduledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationRewardCutIncreaseScheduled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationRewardCutIncreaseScheduled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationRewardCutIncreaseScheduledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationRewardCutIncreaseScheduledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationRewardCutIncreaseScheduled represents a RewardCutIncreaseScheduled event raised by the BunkerDelegation contract.
+type BunkerDelegationRewardCutIncreaseScheduled struct {
+	Provider        common.Address
+	NewRewardCutBps uint16
+	EffectiveAt     *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardCutIncreaseScheduled is a free log retrieval operation binding the contract event 0x13c6fcb618d3034412ea56025117271a589dcb26f773ea346a1d057d2bdf4fde.
+//
+// Solidity: event RewardCutIncreaseScheduled(address indexed provider, uint16 newRewardCutBps, uint48 effectiveAt)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterRewardCutIncreaseScheduled(opts *bind.FilterOpts, provider []common.Address) (*BunkerDelegationRewardCutIncreaseScheduledIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "RewardCutIncreaseScheduled", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationRewardCutIncreaseScheduledIterator{contract: _BunkerDelegation.contract, event: "RewardCutIncreaseScheduled", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardCutIncreaseScheduled is a free log subscription operation binding the contract event 0x13c6fcb618d3034412ea56025117271a589dcb26f773ea346a1d057d2bdf4fde.
+//
+// Solidity: event RewardCutIncreaseScheduled(address indexed provider, uint16 newRewardCutBps, uint48 effectiveAt)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchRewardCutIncreaseScheduled(opts *bind.WatchOpts, sink chan<- *BunkerDelegationRewardCutIncreaseScheduled, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "RewardCutIncreaseScheduled", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationRewardCutIncreaseScheduled)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "RewardCutIncreaseScheduled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardCutIncreaseScheduled is a log parse operation binding the contract event 0x13c6fcb618d3034412ea56025117271a589dcb26f773ea346a1d057d2bdf4fde.
+//
+// Solidity: event RewardCutIncreaseScheduled(address indexed provider, uint16 newRewardCutBps, uint48 effectiveAt)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseRewardCutIncreaseScheduled(log types.Log) (*BunkerDelegationRewardCutIncreaseScheduled, error) {
+	event := new(BunkerDelegationRewardCutIncreaseScheduled)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "RewardCutIncreaseScheduled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationStakingContractUpdatedIterator is returned from FilterStakingContractUpdated and is used to iterate over the raw logs and unpacked data for StakingContractUpdated events raised by the BunkerDelegation contract.
+type BunkerDelegationStakingContractUpdatedIterator struct {
+	Event *BunkerDelegationStakingContractUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationStakingContractUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationStakingContractUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationStakingContractUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationStakingContractUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationStakingContractUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationStakingContractUpdated represents a StakingContractUpdated event raised by the BunkerDelegation contract.
+type BunkerDelegationStakingContractUpdated struct {
+	OldStaking common.Address
+	NewStaking common.Address
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakingContractUpdated is a free log retrieval operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address indexed oldStaking, address indexed newStaking)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterStakingContractUpdated(opts *bind.FilterOpts, oldStaking []common.Address, newStaking []common.Address) (*BunkerDelegationStakingContractUpdatedIterator, error) {
+
+	var oldStakingRule []interface{}
+	for _, oldStakingItem := range oldStaking {
+		oldStakingRule = append(oldStakingRule, oldStakingItem)
+	}
+	var newStakingRule []interface{}
+	for _, newStakingItem := range newStaking {
+		newStakingRule = append(newStakingRule, newStakingItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "StakingContractUpdated", oldStakingRule, newStakingRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationStakingContractUpdatedIterator{contract: _BunkerDelegation.contract, event: "StakingContractUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakingContractUpdated is a free log subscription operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address indexed oldStaking, address indexed newStaking)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchStakingContractUpdated(opts *bind.WatchOpts, sink chan<- *BunkerDelegationStakingContractUpdated, oldStaking []common.Address, newStaking []common.Address) (event.Subscription, error) {
+
+	var oldStakingRule []interface{}
+	for _, oldStakingItem := range oldStaking {
+		oldStakingRule = append(oldStakingRule, oldStakingItem)
+	}
+	var newStakingRule []interface{}
+	for _, newStakingItem := range newStaking {
+		newStakingRule = append(newStakingRule, newStakingItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "StakingContractUpdated", oldStakingRule, newStakingRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationStakingContractUpdated)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "StakingContractUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakingContractUpdated is a log parse operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address indexed oldStaking, address indexed newStaking)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseStakingContractUpdated(log types.Log) (*BunkerDelegationStakingContractUpdated, error) {
+	event := new(BunkerDelegationStakingContractUpdated)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "StakingContractUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationUnbondingPeriodUpdatedIterator is returned from FilterUnbondingPeriodUpdated and is used to iterate over the raw logs and unpacked data for UnbondingPeriodUpdated events raised by the BunkerDelegation contract.
+type BunkerDelegationUnbondingPeriodUpdatedIterator struct {
+	Event *BunkerDelegationUnbondingPeriodUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationUnbondingPeriodUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationUnbondingPeriodUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationUnbondingPeriodUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationUnbondingPeriodUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationUnbondingPeriodUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationUnbondingPeriodUpdated represents a UnbondingPeriodUpdated event raised by the BunkerDelegation contract.
+type BunkerDelegationUnbondingPeriodUpdated struct {
+	NewPeriod *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnbondingPeriodUpdated is a free log retrieval operation binding the contract event 0x38a1644f59872db6fd17fdced395495fcaa3ca7d2825a0704db5a3acbd1dd064.
+//
+// Solidity: event UnbondingPeriodUpdated(uint256 newPeriod)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterUnbondingPeriodUpdated(opts *bind.FilterOpts) (*BunkerDelegationUnbondingPeriodUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "UnbondingPeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationUnbondingPeriodUpdatedIterator{contract: _BunkerDelegation.contract, event: "UnbondingPeriodUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchUnbondingPeriodUpdated is a free log subscription operation binding the contract event 0x38a1644f59872db6fd17fdced395495fcaa3ca7d2825a0704db5a3acbd1dd064.
+//
+// Solidity: event UnbondingPeriodUpdated(uint256 newPeriod)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchUnbondingPeriodUpdated(opts *bind.WatchOpts, sink chan<- *BunkerDelegationUnbondingPeriodUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "UnbondingPeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationUnbondingPeriodUpdated)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "UnbondingPeriodUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnbondingPeriodUpdated is a log parse operation binding the contract event 0x38a1644f59872db6fd17fdced395495fcaa3ca7d2825a0704db5a3acbd1dd064.
+//
+// Solidity: event UnbondingPeriodUpdated(uint256 newPeriod)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseUnbondingPeriodUpdated(log types.Log) (*BunkerDelegationUnbondingPeriodUpdated, error) {
+	event := new(BunkerDelegationUnbondingPeriodUpdated)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "UnbondingPeriodUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationUndelegateCompletedIterator is returned from FilterUndelegateCompleted and is used to iterate over the raw logs and unpacked data for UndelegateCompleted events raised by the BunkerDelegation contract.
+type BunkerDelegationUndelegateCompletedIterator struct {
+	Event *BunkerDelegationUndelegateCompleted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationUndelegateCompletedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationUndelegateCompleted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationUndelegateCompleted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationUndelegateCompletedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationUndelegateCompletedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationUndelegateCompleted represents a UndelegateCompleted event raised by the BunkerDelegation contract.
+type BunkerDelegationUndelegateCompleted struct {
+	Delegator common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterUndelegateCompleted is a free log retrieval operation binding the contract event 0xf3b3534c5f214996f6f38d120ceaa4508da213ebe303320f0ab3f4cf08e13397.
+//
+// Solidity: event UndelegateCompleted(address indexed delegator, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterUndelegateCompleted(opts *bind.FilterOpts, delegator []common.Address) (*BunkerDelegationUndelegateCompletedIterator, error) {
+
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "UndelegateCompleted", delegatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationUndelegateCompletedIterator{contract: _BunkerDelegation.contract, event: "UndelegateCompleted", logs: logs, sub: sub}, nil
+}
+
+// WatchUndelegateCompleted is a free log subscription operation binding the contract event 0xf3b3534c5f214996f6f38d120ceaa4508da213ebe303320f0ab3f4cf08e13397.
+//
+// Solidity: event UndelegateCompleted(address indexed delegator, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchUndelegateCompleted(opts *bind.WatchOpts, sink chan<- *BunkerDelegationUndelegateCompleted, delegator []common.Address) (event.Subscription, error) {
+
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "UndelegateCompleted", delegatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationUndelegateCompleted)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "UndelegateCompleted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUndelegateCompleted is a log parse operation binding the contract event 0xf3b3534c5f214996f6f38d120ceaa4508da213ebe303320f0ab3f4cf08e13397.
+//
+// Solidity: event UndelegateCompleted(address indexed delegator, uint256 amount)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseUndelegateCompleted(log types.Log) (*BunkerDelegationUndelegateCompleted, error) {
+	event := new(BunkerDelegationUndelegateCompleted)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "UndelegateCompleted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationUndelegateRequestedIterator is returned from FilterUndelegateRequested and is used to iterate over the raw logs and unpacked data for UndelegateRequested events raised by the BunkerDelegation contract.
+type BunkerDelegationUndelegateRequestedIterator struct {
+	Event *BunkerDelegationUndelegateRequested // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationUndelegateRequestedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationUndelegateRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationUndelegateRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationUndelegateRequestedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationUndelegateRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationUndelegateRequested represents a UndelegateRequested event raised by the BunkerDelegation contract.
+type BunkerDelegationUndelegateRequested struct {
+	Delegator  common.Address
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterUndelegateRequested is a free log retrieval operation binding the contract event 0xb8f4399de78dca166c5bc08ed55854b9f2c74a607cecd2fd94e9db166d51c425.
+//
+// Solidity: event UndelegateRequested(address indexed delegator, uint256 amount, uint256 unlockTime)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterUndelegateRequested(opts *bind.FilterOpts, delegator []common.Address) (*BunkerDelegationUndelegateRequestedIterator, error) {
+
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "UndelegateRequested", delegatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationUndelegateRequestedIterator{contract: _BunkerDelegation.contract, event: "UndelegateRequested", logs: logs, sub: sub}, nil
+}
+
+// WatchUndelegateRequested is a free log subscription operation binding the contract event 0xb8f4399de78dca166c5bc08ed55854b9f2c74a607cecd2fd94e9db166d51c425.
+//
+// Solidity: event UndelegateRequested(address indexed delegator, uint256 amount, uint256 unlockTime)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchUndelegateRequested(opts *bind.WatchOpts, sink chan<- *BunkerDelegationUndelegateRequested, delegator []common.Address) (event.Subscription, error) {
+
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "UndelegateRequested", delegatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationUndelegateRequested)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "UndelegateRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUndelegateRequested is a log parse operation binding the contract event 0xb8f4399de78dca166c5bc08ed55854b9f2c74a607cecd2fd94e9db166d51c425.
+//
+// Solidity: event UndelegateRequested(address indexed delegator, uint256 amount, uint256 unlockTime)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseUndelegateRequested(log types.Log) (*BunkerDelegationUndelegateRequested, error) {
+	event := new(BunkerDelegationUndelegateRequested)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "UndelegateRequested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerDelegationUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the BunkerDelegation contract.
+type BunkerDelegationUnpausedIterator struct {
+	Event *BunkerDelegationUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerDelegationUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerDelegationUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerDelegationUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerDelegationUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerDelegationUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerDelegationUnpaused represents a Unpaused event raised by the BunkerDelegation contract.
+type BunkerDelegationUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerDelegation *BunkerDelegationFilterer) FilterUnpaused(opts *bind.FilterOpts) (*BunkerDelegationUnpausedIterator, error) {
+
+	logs, sub, err := _BunkerDelegation.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerDelegationUnpausedIterator{contract: _BunkerDelegation.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerDelegation *BunkerDelegationFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *BunkerDelegationUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerDelegation.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerDelegationUnpaused)
+				if err := _BunkerDelegation.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerDelegation *BunkerDelegationFilterer) ParseUnpaused(log types.Log) (*BunkerDelegationUnpaused, error) {
+	event := new(BunkerDelegationUnpaused)
+	if err := _BunkerDelegation.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/payment/bindings/bunkerescrow.go
+++ b/internal/payment/bindings/bunkerescrow.go
@@ -1,0 +1,4271 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BunkerEscrowReservation is an auto generated low-level Go binding around an user-defined struct.
+type BunkerEscrowReservation struct {
+	Requester      common.Address
+	TotalAmount    *big.Int
+	ReleasedAmount *big.Int
+	Duration       *big.Int
+	StartTime      *big.Int
+	Status         uint8
+	Providers      [3]common.Address
+}
+
+// BunkerEscrowMetaData contains all meta data concerning the BunkerEscrow contract.
+var BunkerEscrowMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_treasury\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_initialOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BPS_DENOMINATOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_PROTOCOL_FEE_BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"OPERATOR_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"PROVIDERS_PER_RESERVATION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"calculateProtocolFee\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"fee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"claim\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"createReservation\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"duration\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"feeBurnBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"feeTreasuryBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"finalizeReservation\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getProviders\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address[3]\",\"internalType\":\"address[3]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getReservation\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structBunkerEscrow.Reservation\",\"components\":[{\"name\":\"requester\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"totalAmount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"releasedAmount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"duration\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"startTime\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"status\",\"type\":\"uint8\",\"internalType\":\"enumBunkerEscrow.Status\"},{\"name\":\"providers\",\"type\":\"address[3]\",\"internalType\":\"address[3]\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"increaseDeposit\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"lowBalanceThresholdBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"nextReservationId\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"protocolFeeBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"refund\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"releasePayment\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"settledDuration\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"reservationFeeBps\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"selectProviders\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"providerAddrs\",\"type\":\"address[3]\",\"internalType\":\"address[3]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setFeeSplit\",\"inputs\":[{\"name\":\"burnBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"treasuryBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setLowBalanceThreshold\",\"inputs\":[{\"name\":\"newThresholdBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setProtocolFee\",\"inputs\":[{\"name\":\"newFeeBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setStakingContract\",\"inputs\":[{\"name\":\"_stakingContract\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTreasury\",\"inputs\":[{\"name\":\"newTreasury\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"settleDispute\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"requesterAmount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"providerAmount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"stakingContract\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"token\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalBurned\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalTreasuryFees\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"treasury\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"DepositIncreased\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"requester\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"additionalAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newTotal\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DisputeSettled\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"requesterAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"providerAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"FeeSplitUpdated\",\"inputs\":[{\"name\":\"burnBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"},{\"name\":\"treasuryBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"LowBalance\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"remaining\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"threshold\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PaymentReleased\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"grossAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"netToProviders\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"protocolFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"burnedAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"treasuryAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProtocolFeeUpdated\",\"inputs\":[{\"name\":\"oldFeeBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newFeeBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProvidersSelected\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"provider0\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"provider1\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"provider2\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Refunded\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"requester\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"refundAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReservationCreated\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"requester\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"duration\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReservationFinalized\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakingContractUpdated\",\"inputs\":[{\"name\":\"oldStaking\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newStaking\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TreasuryUpdated\",\"inputs\":[{\"name\":\"oldTreasury\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newTreasury\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AmountOverflow\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"CannotDisableStakingVerification\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DuplicateProvider\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DurationOverflow\",\"inputs\":[{\"name\":\"duration\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidDisputeAmounts\",\"inputs\":[{\"name\":\"requesterAmt\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"providerAmt\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"available\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFeeSplit\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReservation\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidStatus\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"expected\",\"type\":\"uint8\",\"internalType\":\"enumBunkerEscrow.Status\"},{\"name\":\"actual\",\"type\":\"uint8\",\"internalType\":\"enumBunkerEscrow.Status\"}]},{\"type\":\"error\",\"name\":\"NotProvider\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotRequester\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotRequesterOrOperator\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NothingToRelease\",\"inputs\":[{\"name\":\"reservationId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProtocolFeeTooHigh\",\"inputs\":[{\"name\":\"requested\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maximum\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProviderNotStaked\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SettledDurationExceedsTotal\",\"inputs\":[{\"name\":\"settled\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"total\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ThresholdTooHigh\",\"inputs\":[{\"name\":\"requested\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"maximum\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroDuration\",\"inputs\":[]}]",
+}
+
+// BunkerEscrowABI is the input ABI used to generate the binding from.
+// Deprecated: Use BunkerEscrowMetaData.ABI instead.
+var BunkerEscrowABI = BunkerEscrowMetaData.ABI
+
+// BunkerEscrow is an auto generated Go binding around an Ethereum contract.
+type BunkerEscrow struct {
+	BunkerEscrowCaller     // Read-only binding to the contract
+	BunkerEscrowTransactor // Write-only binding to the contract
+	BunkerEscrowFilterer   // Log filterer for contract events
+}
+
+// BunkerEscrowCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BunkerEscrowCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerEscrowTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BunkerEscrowTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerEscrowFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BunkerEscrowFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerEscrowSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BunkerEscrowSession struct {
+	Contract     *BunkerEscrow     // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BunkerEscrowCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BunkerEscrowCallerSession struct {
+	Contract *BunkerEscrowCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts       // Call options to use throughout this session
+}
+
+// BunkerEscrowTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BunkerEscrowTransactorSession struct {
+	Contract     *BunkerEscrowTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// BunkerEscrowRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BunkerEscrowRaw struct {
+	Contract *BunkerEscrow // Generic contract binding to access the raw methods on
+}
+
+// BunkerEscrowCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BunkerEscrowCallerRaw struct {
+	Contract *BunkerEscrowCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BunkerEscrowTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BunkerEscrowTransactorRaw struct {
+	Contract *BunkerEscrowTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBunkerEscrow creates a new instance of BunkerEscrow, bound to a specific deployed contract.
+func NewBunkerEscrow(address common.Address, backend bind.ContractBackend) (*BunkerEscrow, error) {
+	contract, err := bindBunkerEscrow(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrow{BunkerEscrowCaller: BunkerEscrowCaller{contract: contract}, BunkerEscrowTransactor: BunkerEscrowTransactor{contract: contract}, BunkerEscrowFilterer: BunkerEscrowFilterer{contract: contract}}, nil
+}
+
+// NewBunkerEscrowCaller creates a new read-only instance of BunkerEscrow, bound to a specific deployed contract.
+func NewBunkerEscrowCaller(address common.Address, caller bind.ContractCaller) (*BunkerEscrowCaller, error) {
+	contract, err := bindBunkerEscrow(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowCaller{contract: contract}, nil
+}
+
+// NewBunkerEscrowTransactor creates a new write-only instance of BunkerEscrow, bound to a specific deployed contract.
+func NewBunkerEscrowTransactor(address common.Address, transactor bind.ContractTransactor) (*BunkerEscrowTransactor, error) {
+	contract, err := bindBunkerEscrow(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowTransactor{contract: contract}, nil
+}
+
+// NewBunkerEscrowFilterer creates a new log filterer instance of BunkerEscrow, bound to a specific deployed contract.
+func NewBunkerEscrowFilterer(address common.Address, filterer bind.ContractFilterer) (*BunkerEscrowFilterer, error) {
+	contract, err := bindBunkerEscrow(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowFilterer{contract: contract}, nil
+}
+
+// bindBunkerEscrow binds a generic wrapper to an already deployed contract.
+func bindBunkerEscrow(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BunkerEscrowMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerEscrow *BunkerEscrowRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerEscrow.Contract.BunkerEscrowCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerEscrow *BunkerEscrowRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.BunkerEscrowTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerEscrow *BunkerEscrowRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.BunkerEscrowTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerEscrow *BunkerEscrowCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerEscrow.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerEscrow *BunkerEscrowTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerEscrow *BunkerEscrowTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.contract.Transact(opts, method, params...)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) BPSDENOMINATOR(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "BPS_DENOMINATOR")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerEscrow.Contract.BPSDENOMINATOR(&_BunkerEscrow.CallOpts)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerEscrow.Contract.BPSDENOMINATOR(&_BunkerEscrow.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BunkerEscrow.Contract.DEFAULTADMINROLE(&_BunkerEscrow.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BunkerEscrow.Contract.DEFAULTADMINROLE(&_BunkerEscrow.CallOpts)
+}
+
+// MAXPROTOCOLFEEBPS is a free data retrieval call binding the contract method 0x6d947e4b.
+//
+// Solidity: function MAX_PROTOCOL_FEE_BPS() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) MAXPROTOCOLFEEBPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "MAX_PROTOCOL_FEE_BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXPROTOCOLFEEBPS is a free data retrieval call binding the contract method 0x6d947e4b.
+//
+// Solidity: function MAX_PROTOCOL_FEE_BPS() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) MAXPROTOCOLFEEBPS() (*big.Int, error) {
+	return _BunkerEscrow.Contract.MAXPROTOCOLFEEBPS(&_BunkerEscrow.CallOpts)
+}
+
+// MAXPROTOCOLFEEBPS is a free data retrieval call binding the contract method 0x6d947e4b.
+//
+// Solidity: function MAX_PROTOCOL_FEE_BPS() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) MAXPROTOCOLFEEBPS() (*big.Int, error) {
+	return _BunkerEscrow.Contract.MAXPROTOCOLFEEBPS(&_BunkerEscrow.CallOpts)
+}
+
+// OPERATORROLE is a free data retrieval call binding the contract method 0xf5b541a6.
+//
+// Solidity: function OPERATOR_ROLE() view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowCaller) OPERATORROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "OPERATOR_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// OPERATORROLE is a free data retrieval call binding the contract method 0xf5b541a6.
+//
+// Solidity: function OPERATOR_ROLE() view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowSession) OPERATORROLE() ([32]byte, error) {
+	return _BunkerEscrow.Contract.OPERATORROLE(&_BunkerEscrow.CallOpts)
+}
+
+// OPERATORROLE is a free data retrieval call binding the contract method 0xf5b541a6.
+//
+// Solidity: function OPERATOR_ROLE() view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowCallerSession) OPERATORROLE() ([32]byte, error) {
+	return _BunkerEscrow.Contract.OPERATORROLE(&_BunkerEscrow.CallOpts)
+}
+
+// PROVIDERSPERRESERVATION is a free data retrieval call binding the contract method 0x34f9ef48.
+//
+// Solidity: function PROVIDERS_PER_RESERVATION() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) PROVIDERSPERRESERVATION(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "PROVIDERS_PER_RESERVATION")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PROVIDERSPERRESERVATION is a free data retrieval call binding the contract method 0x34f9ef48.
+//
+// Solidity: function PROVIDERS_PER_RESERVATION() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) PROVIDERSPERRESERVATION() (*big.Int, error) {
+	return _BunkerEscrow.Contract.PROVIDERSPERRESERVATION(&_BunkerEscrow.CallOpts)
+}
+
+// PROVIDERSPERRESERVATION is a free data retrieval call binding the contract method 0x34f9ef48.
+//
+// Solidity: function PROVIDERS_PER_RESERVATION() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) PROVIDERSPERRESERVATION() (*big.Int, error) {
+	return _BunkerEscrow.Contract.PROVIDERSPERRESERVATION(&_BunkerEscrow.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerEscrow *BunkerEscrowCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerEscrow *BunkerEscrowSession) VERSION() (string, error) {
+	return _BunkerEscrow.Contract.VERSION(&_BunkerEscrow.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerEscrow *BunkerEscrowCallerSession) VERSION() (string, error) {
+	return _BunkerEscrow.Contract.VERSION(&_BunkerEscrow.CallOpts)
+}
+
+// CalculateProtocolFee is a free data retrieval call binding the contract method 0x9c7c270c.
+//
+// Solidity: function calculateProtocolFee(uint256 amount) view returns(uint256 fee)
+func (_BunkerEscrow *BunkerEscrowCaller) CalculateProtocolFee(opts *bind.CallOpts, amount *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "calculateProtocolFee", amount)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// CalculateProtocolFee is a free data retrieval call binding the contract method 0x9c7c270c.
+//
+// Solidity: function calculateProtocolFee(uint256 amount) view returns(uint256 fee)
+func (_BunkerEscrow *BunkerEscrowSession) CalculateProtocolFee(amount *big.Int) (*big.Int, error) {
+	return _BunkerEscrow.Contract.CalculateProtocolFee(&_BunkerEscrow.CallOpts, amount)
+}
+
+// CalculateProtocolFee is a free data retrieval call binding the contract method 0x9c7c270c.
+//
+// Solidity: function calculateProtocolFee(uint256 amount) view returns(uint256 fee)
+func (_BunkerEscrow *BunkerEscrowCallerSession) CalculateProtocolFee(amount *big.Int) (*big.Int, error) {
+	return _BunkerEscrow.Contract.CalculateProtocolFee(&_BunkerEscrow.CallOpts, amount)
+}
+
+// FeeBurnBps is a free data retrieval call binding the contract method 0x1d5514f7.
+//
+// Solidity: function feeBurnBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) FeeBurnBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "feeBurnBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// FeeBurnBps is a free data retrieval call binding the contract method 0x1d5514f7.
+//
+// Solidity: function feeBurnBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) FeeBurnBps() (*big.Int, error) {
+	return _BunkerEscrow.Contract.FeeBurnBps(&_BunkerEscrow.CallOpts)
+}
+
+// FeeBurnBps is a free data retrieval call binding the contract method 0x1d5514f7.
+//
+// Solidity: function feeBurnBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) FeeBurnBps() (*big.Int, error) {
+	return _BunkerEscrow.Contract.FeeBurnBps(&_BunkerEscrow.CallOpts)
+}
+
+// FeeTreasuryBps is a free data retrieval call binding the contract method 0x6894fc82.
+//
+// Solidity: function feeTreasuryBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) FeeTreasuryBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "feeTreasuryBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// FeeTreasuryBps is a free data retrieval call binding the contract method 0x6894fc82.
+//
+// Solidity: function feeTreasuryBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) FeeTreasuryBps() (*big.Int, error) {
+	return _BunkerEscrow.Contract.FeeTreasuryBps(&_BunkerEscrow.CallOpts)
+}
+
+// FeeTreasuryBps is a free data retrieval call binding the contract method 0x6894fc82.
+//
+// Solidity: function feeTreasuryBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) FeeTreasuryBps() (*big.Int, error) {
+	return _BunkerEscrow.Contract.FeeTreasuryBps(&_BunkerEscrow.CallOpts)
+}
+
+// GetProviders is a free data retrieval call binding the contract method 0xa9f11583.
+//
+// Solidity: function getProviders(uint256 reservationId) view returns(address[3])
+func (_BunkerEscrow *BunkerEscrowCaller) GetProviders(opts *bind.CallOpts, reservationId *big.Int) ([3]common.Address, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "getProviders", reservationId)
+
+	if err != nil {
+		return *new([3]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([3]common.Address)).(*[3]common.Address)
+
+	return out0, err
+
+}
+
+// GetProviders is a free data retrieval call binding the contract method 0xa9f11583.
+//
+// Solidity: function getProviders(uint256 reservationId) view returns(address[3])
+func (_BunkerEscrow *BunkerEscrowSession) GetProviders(reservationId *big.Int) ([3]common.Address, error) {
+	return _BunkerEscrow.Contract.GetProviders(&_BunkerEscrow.CallOpts, reservationId)
+}
+
+// GetProviders is a free data retrieval call binding the contract method 0xa9f11583.
+//
+// Solidity: function getProviders(uint256 reservationId) view returns(address[3])
+func (_BunkerEscrow *BunkerEscrowCallerSession) GetProviders(reservationId *big.Int) ([3]common.Address, error) {
+	return _BunkerEscrow.Contract.GetProviders(&_BunkerEscrow.CallOpts, reservationId)
+}
+
+// GetReservation is a free data retrieval call binding the contract method 0xd57763c3.
+//
+// Solidity: function getReservation(uint256 reservationId) view returns((address,uint128,uint128,uint48,uint48,uint8,address[3]))
+func (_BunkerEscrow *BunkerEscrowCaller) GetReservation(opts *bind.CallOpts, reservationId *big.Int) (BunkerEscrowReservation, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "getReservation", reservationId)
+
+	if err != nil {
+		return *new(BunkerEscrowReservation), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerEscrowReservation)).(*BunkerEscrowReservation)
+
+	return out0, err
+
+}
+
+// GetReservation is a free data retrieval call binding the contract method 0xd57763c3.
+//
+// Solidity: function getReservation(uint256 reservationId) view returns((address,uint128,uint128,uint48,uint48,uint8,address[3]))
+func (_BunkerEscrow *BunkerEscrowSession) GetReservation(reservationId *big.Int) (BunkerEscrowReservation, error) {
+	return _BunkerEscrow.Contract.GetReservation(&_BunkerEscrow.CallOpts, reservationId)
+}
+
+// GetReservation is a free data retrieval call binding the contract method 0xd57763c3.
+//
+// Solidity: function getReservation(uint256 reservationId) view returns((address,uint128,uint128,uint48,uint48,uint8,address[3]))
+func (_BunkerEscrow *BunkerEscrowCallerSession) GetReservation(reservationId *big.Int) (BunkerEscrowReservation, error) {
+	return _BunkerEscrow.Contract.GetReservation(&_BunkerEscrow.CallOpts, reservationId)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BunkerEscrow.Contract.GetRoleAdmin(&_BunkerEscrow.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerEscrow *BunkerEscrowCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BunkerEscrow.Contract.GetRoleAdmin(&_BunkerEscrow.CallOpts, role)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerEscrow *BunkerEscrowCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerEscrow *BunkerEscrowSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BunkerEscrow.Contract.HasRole(&_BunkerEscrow.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerEscrow *BunkerEscrowCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BunkerEscrow.Contract.HasRole(&_BunkerEscrow.CallOpts, role, account)
+}
+
+// LowBalanceThresholdBps is a free data retrieval call binding the contract method 0xd66b5ea6.
+//
+// Solidity: function lowBalanceThresholdBps() view returns(uint16)
+func (_BunkerEscrow *BunkerEscrowCaller) LowBalanceThresholdBps(opts *bind.CallOpts) (uint16, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "lowBalanceThresholdBps")
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// LowBalanceThresholdBps is a free data retrieval call binding the contract method 0xd66b5ea6.
+//
+// Solidity: function lowBalanceThresholdBps() view returns(uint16)
+func (_BunkerEscrow *BunkerEscrowSession) LowBalanceThresholdBps() (uint16, error) {
+	return _BunkerEscrow.Contract.LowBalanceThresholdBps(&_BunkerEscrow.CallOpts)
+}
+
+// LowBalanceThresholdBps is a free data retrieval call binding the contract method 0xd66b5ea6.
+//
+// Solidity: function lowBalanceThresholdBps() view returns(uint16)
+func (_BunkerEscrow *BunkerEscrowCallerSession) LowBalanceThresholdBps() (uint16, error) {
+	return _BunkerEscrow.Contract.LowBalanceThresholdBps(&_BunkerEscrow.CallOpts)
+}
+
+// NextReservationId is a free data retrieval call binding the contract method 0xc70c26cd.
+//
+// Solidity: function nextReservationId() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) NextReservationId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "nextReservationId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// NextReservationId is a free data retrieval call binding the contract method 0xc70c26cd.
+//
+// Solidity: function nextReservationId() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) NextReservationId() (*big.Int, error) {
+	return _BunkerEscrow.Contract.NextReservationId(&_BunkerEscrow.CallOpts)
+}
+
+// NextReservationId is a free data retrieval call binding the contract method 0xc70c26cd.
+//
+// Solidity: function nextReservationId() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) NextReservationId() (*big.Int, error) {
+	return _BunkerEscrow.Contract.NextReservationId(&_BunkerEscrow.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerEscrow *BunkerEscrowSession) Owner() (common.Address, error) {
+	return _BunkerEscrow.Contract.Owner(&_BunkerEscrow.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCallerSession) Owner() (common.Address, error) {
+	return _BunkerEscrow.Contract.Owner(&_BunkerEscrow.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerEscrow *BunkerEscrowCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerEscrow *BunkerEscrowSession) Paused() (bool, error) {
+	return _BunkerEscrow.Contract.Paused(&_BunkerEscrow.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerEscrow *BunkerEscrowCallerSession) Paused() (bool, error) {
+	return _BunkerEscrow.Contract.Paused(&_BunkerEscrow.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerEscrow *BunkerEscrowSession) PendingOwner() (common.Address, error) {
+	return _BunkerEscrow.Contract.PendingOwner(&_BunkerEscrow.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCallerSession) PendingOwner() (common.Address, error) {
+	return _BunkerEscrow.Contract.PendingOwner(&_BunkerEscrow.CallOpts)
+}
+
+// ProtocolFeeBps is a free data retrieval call binding the contract method 0x35659fb8.
+//
+// Solidity: function protocolFeeBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) ProtocolFeeBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "protocolFeeBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ProtocolFeeBps is a free data retrieval call binding the contract method 0x35659fb8.
+//
+// Solidity: function protocolFeeBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) ProtocolFeeBps() (*big.Int, error) {
+	return _BunkerEscrow.Contract.ProtocolFeeBps(&_BunkerEscrow.CallOpts)
+}
+
+// ProtocolFeeBps is a free data retrieval call binding the contract method 0x35659fb8.
+//
+// Solidity: function protocolFeeBps() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) ProtocolFeeBps() (*big.Int, error) {
+	return _BunkerEscrow.Contract.ProtocolFeeBps(&_BunkerEscrow.CallOpts)
+}
+
+// ReservationFeeBps is a free data retrieval call binding the contract method 0x3d8b28ce.
+//
+// Solidity: function reservationFeeBps(uint256 ) view returns(uint16)
+func (_BunkerEscrow *BunkerEscrowCaller) ReservationFeeBps(opts *bind.CallOpts, arg0 *big.Int) (uint16, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "reservationFeeBps", arg0)
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// ReservationFeeBps is a free data retrieval call binding the contract method 0x3d8b28ce.
+//
+// Solidity: function reservationFeeBps(uint256 ) view returns(uint16)
+func (_BunkerEscrow *BunkerEscrowSession) ReservationFeeBps(arg0 *big.Int) (uint16, error) {
+	return _BunkerEscrow.Contract.ReservationFeeBps(&_BunkerEscrow.CallOpts, arg0)
+}
+
+// ReservationFeeBps is a free data retrieval call binding the contract method 0x3d8b28ce.
+//
+// Solidity: function reservationFeeBps(uint256 ) view returns(uint16)
+func (_BunkerEscrow *BunkerEscrowCallerSession) ReservationFeeBps(arg0 *big.Int) (uint16, error) {
+	return _BunkerEscrow.Contract.ReservationFeeBps(&_BunkerEscrow.CallOpts, arg0)
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCaller) StakingContract(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "stakingContract")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerEscrow *BunkerEscrowSession) StakingContract() (common.Address, error) {
+	return _BunkerEscrow.Contract.StakingContract(&_BunkerEscrow.CallOpts)
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCallerSession) StakingContract() (common.Address, error) {
+	return _BunkerEscrow.Contract.StakingContract(&_BunkerEscrow.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerEscrow *BunkerEscrowCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerEscrow *BunkerEscrowSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BunkerEscrow.Contract.SupportsInterface(&_BunkerEscrow.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerEscrow *BunkerEscrowCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BunkerEscrow.Contract.SupportsInterface(&_BunkerEscrow.CallOpts, interfaceId)
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCaller) Token(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "token")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerEscrow *BunkerEscrowSession) Token() (common.Address, error) {
+	return _BunkerEscrow.Contract.Token(&_BunkerEscrow.CallOpts)
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCallerSession) Token() (common.Address, error) {
+	return _BunkerEscrow.Contract.Token(&_BunkerEscrow.CallOpts)
+}
+
+// TotalBurned is a free data retrieval call binding the contract method 0xd89135cd.
+//
+// Solidity: function totalBurned() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) TotalBurned(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "totalBurned")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalBurned is a free data retrieval call binding the contract method 0xd89135cd.
+//
+// Solidity: function totalBurned() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) TotalBurned() (*big.Int, error) {
+	return _BunkerEscrow.Contract.TotalBurned(&_BunkerEscrow.CallOpts)
+}
+
+// TotalBurned is a free data retrieval call binding the contract method 0xd89135cd.
+//
+// Solidity: function totalBurned() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) TotalBurned() (*big.Int, error) {
+	return _BunkerEscrow.Contract.TotalBurned(&_BunkerEscrow.CallOpts)
+}
+
+// TotalTreasuryFees is a free data retrieval call binding the contract method 0xea280be3.
+//
+// Solidity: function totalTreasuryFees() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCaller) TotalTreasuryFees(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "totalTreasuryFees")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalTreasuryFees is a free data retrieval call binding the contract method 0xea280be3.
+//
+// Solidity: function totalTreasuryFees() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowSession) TotalTreasuryFees() (*big.Int, error) {
+	return _BunkerEscrow.Contract.TotalTreasuryFees(&_BunkerEscrow.CallOpts)
+}
+
+// TotalTreasuryFees is a free data retrieval call binding the contract method 0xea280be3.
+//
+// Solidity: function totalTreasuryFees() view returns(uint256)
+func (_BunkerEscrow *BunkerEscrowCallerSession) TotalTreasuryFees() (*big.Int, error) {
+	return _BunkerEscrow.Contract.TotalTreasuryFees(&_BunkerEscrow.CallOpts)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCaller) Treasury(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerEscrow.contract.Call(opts, &out, "treasury")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerEscrow *BunkerEscrowSession) Treasury() (common.Address, error) {
+	return _BunkerEscrow.Contract.Treasury(&_BunkerEscrow.CallOpts)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerEscrow *BunkerEscrowCallerSession) Treasury() (common.Address, error) {
+	return _BunkerEscrow.Contract.Treasury(&_BunkerEscrow.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerEscrow *BunkerEscrowSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.AcceptOwnership(&_BunkerEscrow.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.AcceptOwnership(&_BunkerEscrow.TransactOpts)
+}
+
+// Claim is a paid mutator transaction binding the contract method 0x379607f5.
+//
+// Solidity: function claim(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) Claim(opts *bind.TransactOpts, reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "claim", reservationId)
+}
+
+// Claim is a paid mutator transaction binding the contract method 0x379607f5.
+//
+// Solidity: function claim(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowSession) Claim(reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.Claim(&_BunkerEscrow.TransactOpts, reservationId)
+}
+
+// Claim is a paid mutator transaction binding the contract method 0x379607f5.
+//
+// Solidity: function claim(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) Claim(reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.Claim(&_BunkerEscrow.TransactOpts, reservationId)
+}
+
+// CreateReservation is a paid mutator transaction binding the contract method 0xbee9d69a.
+//
+// Solidity: function createReservation(uint256 amount, uint256 duration) returns(uint256 reservationId)
+func (_BunkerEscrow *BunkerEscrowTransactor) CreateReservation(opts *bind.TransactOpts, amount *big.Int, duration *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "createReservation", amount, duration)
+}
+
+// CreateReservation is a paid mutator transaction binding the contract method 0xbee9d69a.
+//
+// Solidity: function createReservation(uint256 amount, uint256 duration) returns(uint256 reservationId)
+func (_BunkerEscrow *BunkerEscrowSession) CreateReservation(amount *big.Int, duration *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.CreateReservation(&_BunkerEscrow.TransactOpts, amount, duration)
+}
+
+// CreateReservation is a paid mutator transaction binding the contract method 0xbee9d69a.
+//
+// Solidity: function createReservation(uint256 amount, uint256 duration) returns(uint256 reservationId)
+func (_BunkerEscrow *BunkerEscrowTransactorSession) CreateReservation(amount *big.Int, duration *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.CreateReservation(&_BunkerEscrow.TransactOpts, amount, duration)
+}
+
+// FinalizeReservation is a paid mutator transaction binding the contract method 0xc0a1826c.
+//
+// Solidity: function finalizeReservation(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) FinalizeReservation(opts *bind.TransactOpts, reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "finalizeReservation", reservationId)
+}
+
+// FinalizeReservation is a paid mutator transaction binding the contract method 0xc0a1826c.
+//
+// Solidity: function finalizeReservation(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowSession) FinalizeReservation(reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.FinalizeReservation(&_BunkerEscrow.TransactOpts, reservationId)
+}
+
+// FinalizeReservation is a paid mutator transaction binding the contract method 0xc0a1826c.
+//
+// Solidity: function finalizeReservation(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) FinalizeReservation(reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.FinalizeReservation(&_BunkerEscrow.TransactOpts, reservationId)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerEscrow *BunkerEscrowSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.GrantRole(&_BunkerEscrow.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.GrantRole(&_BunkerEscrow.TransactOpts, role, account)
+}
+
+// IncreaseDeposit is a paid mutator transaction binding the contract method 0xfd28e705.
+//
+// Solidity: function increaseDeposit(uint256 reservationId, uint256 amount) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) IncreaseDeposit(opts *bind.TransactOpts, reservationId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "increaseDeposit", reservationId, amount)
+}
+
+// IncreaseDeposit is a paid mutator transaction binding the contract method 0xfd28e705.
+//
+// Solidity: function increaseDeposit(uint256 reservationId, uint256 amount) returns()
+func (_BunkerEscrow *BunkerEscrowSession) IncreaseDeposit(reservationId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.IncreaseDeposit(&_BunkerEscrow.TransactOpts, reservationId, amount)
+}
+
+// IncreaseDeposit is a paid mutator transaction binding the contract method 0xfd28e705.
+//
+// Solidity: function increaseDeposit(uint256 reservationId, uint256 amount) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) IncreaseDeposit(reservationId *big.Int, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.IncreaseDeposit(&_BunkerEscrow.TransactOpts, reservationId, amount)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerEscrow *BunkerEscrowSession) Pause() (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.Pause(&_BunkerEscrow.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) Pause() (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.Pause(&_BunkerEscrow.TransactOpts)
+}
+
+// Refund is a paid mutator transaction binding the contract method 0x278ecde1.
+//
+// Solidity: function refund(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) Refund(opts *bind.TransactOpts, reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "refund", reservationId)
+}
+
+// Refund is a paid mutator transaction binding the contract method 0x278ecde1.
+//
+// Solidity: function refund(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowSession) Refund(reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.Refund(&_BunkerEscrow.TransactOpts, reservationId)
+}
+
+// Refund is a paid mutator transaction binding the contract method 0x278ecde1.
+//
+// Solidity: function refund(uint256 reservationId) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) Refund(reservationId *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.Refund(&_BunkerEscrow.TransactOpts, reservationId)
+}
+
+// ReleasePayment is a paid mutator transaction binding the contract method 0x97e99a80.
+//
+// Solidity: function releasePayment(uint256 reservationId, uint256 settledDuration) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) ReleasePayment(opts *bind.TransactOpts, reservationId *big.Int, settledDuration *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "releasePayment", reservationId, settledDuration)
+}
+
+// ReleasePayment is a paid mutator transaction binding the contract method 0x97e99a80.
+//
+// Solidity: function releasePayment(uint256 reservationId, uint256 settledDuration) returns()
+func (_BunkerEscrow *BunkerEscrowSession) ReleasePayment(reservationId *big.Int, settledDuration *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.ReleasePayment(&_BunkerEscrow.TransactOpts, reservationId, settledDuration)
+}
+
+// ReleasePayment is a paid mutator transaction binding the contract method 0x97e99a80.
+//
+// Solidity: function releasePayment(uint256 reservationId, uint256 settledDuration) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) ReleasePayment(reservationId *big.Int, settledDuration *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.ReleasePayment(&_BunkerEscrow.TransactOpts, reservationId, settledDuration)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerEscrow *BunkerEscrowSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.RenounceOwnership(&_BunkerEscrow.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.RenounceOwnership(&_BunkerEscrow.TransactOpts)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerEscrow *BunkerEscrowSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.RenounceRole(&_BunkerEscrow.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.RenounceRole(&_BunkerEscrow.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerEscrow *BunkerEscrowSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.RevokeRole(&_BunkerEscrow.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.RevokeRole(&_BunkerEscrow.TransactOpts, role, account)
+}
+
+// SelectProviders is a paid mutator transaction binding the contract method 0x202f5388.
+//
+// Solidity: function selectProviders(uint256 reservationId, address[3] providerAddrs) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) SelectProviders(opts *bind.TransactOpts, reservationId *big.Int, providerAddrs [3]common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "selectProviders", reservationId, providerAddrs)
+}
+
+// SelectProviders is a paid mutator transaction binding the contract method 0x202f5388.
+//
+// Solidity: function selectProviders(uint256 reservationId, address[3] providerAddrs) returns()
+func (_BunkerEscrow *BunkerEscrowSession) SelectProviders(reservationId *big.Int, providerAddrs [3]common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SelectProviders(&_BunkerEscrow.TransactOpts, reservationId, providerAddrs)
+}
+
+// SelectProviders is a paid mutator transaction binding the contract method 0x202f5388.
+//
+// Solidity: function selectProviders(uint256 reservationId, address[3] providerAddrs) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) SelectProviders(reservationId *big.Int, providerAddrs [3]common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SelectProviders(&_BunkerEscrow.TransactOpts, reservationId, providerAddrs)
+}
+
+// SetFeeSplit is a paid mutator transaction binding the contract method 0xf8978401.
+//
+// Solidity: function setFeeSplit(uint16 burnBps, uint16 treasuryBps) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) SetFeeSplit(opts *bind.TransactOpts, burnBps uint16, treasuryBps uint16) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "setFeeSplit", burnBps, treasuryBps)
+}
+
+// SetFeeSplit is a paid mutator transaction binding the contract method 0xf8978401.
+//
+// Solidity: function setFeeSplit(uint16 burnBps, uint16 treasuryBps) returns()
+func (_BunkerEscrow *BunkerEscrowSession) SetFeeSplit(burnBps uint16, treasuryBps uint16) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetFeeSplit(&_BunkerEscrow.TransactOpts, burnBps, treasuryBps)
+}
+
+// SetFeeSplit is a paid mutator transaction binding the contract method 0xf8978401.
+//
+// Solidity: function setFeeSplit(uint16 burnBps, uint16 treasuryBps) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) SetFeeSplit(burnBps uint16, treasuryBps uint16) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetFeeSplit(&_BunkerEscrow.TransactOpts, burnBps, treasuryBps)
+}
+
+// SetLowBalanceThreshold is a paid mutator transaction binding the contract method 0xb881f82e.
+//
+// Solidity: function setLowBalanceThreshold(uint16 newThresholdBps) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) SetLowBalanceThreshold(opts *bind.TransactOpts, newThresholdBps uint16) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "setLowBalanceThreshold", newThresholdBps)
+}
+
+// SetLowBalanceThreshold is a paid mutator transaction binding the contract method 0xb881f82e.
+//
+// Solidity: function setLowBalanceThreshold(uint16 newThresholdBps) returns()
+func (_BunkerEscrow *BunkerEscrowSession) SetLowBalanceThreshold(newThresholdBps uint16) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetLowBalanceThreshold(&_BunkerEscrow.TransactOpts, newThresholdBps)
+}
+
+// SetLowBalanceThreshold is a paid mutator transaction binding the contract method 0xb881f82e.
+//
+// Solidity: function setLowBalanceThreshold(uint16 newThresholdBps) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) SetLowBalanceThreshold(newThresholdBps uint16) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetLowBalanceThreshold(&_BunkerEscrow.TransactOpts, newThresholdBps)
+}
+
+// SetProtocolFee is a paid mutator transaction binding the contract method 0x787dce3d.
+//
+// Solidity: function setProtocolFee(uint256 newFeeBps) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) SetProtocolFee(opts *bind.TransactOpts, newFeeBps *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "setProtocolFee", newFeeBps)
+}
+
+// SetProtocolFee is a paid mutator transaction binding the contract method 0x787dce3d.
+//
+// Solidity: function setProtocolFee(uint256 newFeeBps) returns()
+func (_BunkerEscrow *BunkerEscrowSession) SetProtocolFee(newFeeBps *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetProtocolFee(&_BunkerEscrow.TransactOpts, newFeeBps)
+}
+
+// SetProtocolFee is a paid mutator transaction binding the contract method 0x787dce3d.
+//
+// Solidity: function setProtocolFee(uint256 newFeeBps) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) SetProtocolFee(newFeeBps *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetProtocolFee(&_BunkerEscrow.TransactOpts, newFeeBps)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address _stakingContract) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) SetStakingContract(opts *bind.TransactOpts, _stakingContract common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "setStakingContract", _stakingContract)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address _stakingContract) returns()
+func (_BunkerEscrow *BunkerEscrowSession) SetStakingContract(_stakingContract common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetStakingContract(&_BunkerEscrow.TransactOpts, _stakingContract)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address _stakingContract) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) SetStakingContract(_stakingContract common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetStakingContract(&_BunkerEscrow.TransactOpts, _stakingContract)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) SetTreasury(opts *bind.TransactOpts, newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "setTreasury", newTreasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerEscrow *BunkerEscrowSession) SetTreasury(newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetTreasury(&_BunkerEscrow.TransactOpts, newTreasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) SetTreasury(newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SetTreasury(&_BunkerEscrow.TransactOpts, newTreasury)
+}
+
+// SettleDispute is a paid mutator transaction binding the contract method 0x8ba64218.
+//
+// Solidity: function settleDispute(uint256 reservationId, uint256 requesterAmount, uint256 providerAmount) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) SettleDispute(opts *bind.TransactOpts, reservationId *big.Int, requesterAmount *big.Int, providerAmount *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "settleDispute", reservationId, requesterAmount, providerAmount)
+}
+
+// SettleDispute is a paid mutator transaction binding the contract method 0x8ba64218.
+//
+// Solidity: function settleDispute(uint256 reservationId, uint256 requesterAmount, uint256 providerAmount) returns()
+func (_BunkerEscrow *BunkerEscrowSession) SettleDispute(reservationId *big.Int, requesterAmount *big.Int, providerAmount *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SettleDispute(&_BunkerEscrow.TransactOpts, reservationId, requesterAmount, providerAmount)
+}
+
+// SettleDispute is a paid mutator transaction binding the contract method 0x8ba64218.
+//
+// Solidity: function settleDispute(uint256 reservationId, uint256 requesterAmount, uint256 providerAmount) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) SettleDispute(reservationId *big.Int, requesterAmount *big.Int, providerAmount *big.Int) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.SettleDispute(&_BunkerEscrow.TransactOpts, reservationId, requesterAmount, providerAmount)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerEscrow *BunkerEscrowSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.TransferOwnership(&_BunkerEscrow.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.TransferOwnership(&_BunkerEscrow.TransactOpts, newOwner)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerEscrow *BunkerEscrowTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerEscrow.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerEscrow *BunkerEscrowSession) Unpause() (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.Unpause(&_BunkerEscrow.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerEscrow *BunkerEscrowTransactorSession) Unpause() (*types.Transaction, error) {
+	return _BunkerEscrow.Contract.Unpause(&_BunkerEscrow.TransactOpts)
+}
+
+// BunkerEscrowDepositIncreasedIterator is returned from FilterDepositIncreased and is used to iterate over the raw logs and unpacked data for DepositIncreased events raised by the BunkerEscrow contract.
+type BunkerEscrowDepositIncreasedIterator struct {
+	Event *BunkerEscrowDepositIncreased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowDepositIncreasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowDepositIncreased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowDepositIncreased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowDepositIncreasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowDepositIncreasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowDepositIncreased represents a DepositIncreased event raised by the BunkerEscrow contract.
+type BunkerEscrowDepositIncreased struct {
+	ReservationId    *big.Int
+	Requester        common.Address
+	AdditionalAmount *big.Int
+	NewTotal         *big.Int
+	Raw              types.Log // Blockchain specific contextual infos
+}
+
+// FilterDepositIncreased is a free log retrieval operation binding the contract event 0x55d9d468c420c3892a429ebbcdaaf1ac722f8b49bba8b4f0b986cf6103f4fd29.
+//
+// Solidity: event DepositIncreased(uint256 indexed reservationId, address indexed requester, uint256 additionalAmount, uint256 newTotal)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterDepositIncreased(opts *bind.FilterOpts, reservationId []*big.Int, requester []common.Address) (*BunkerEscrowDepositIncreasedIterator, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+	var requesterRule []interface{}
+	for _, requesterItem := range requester {
+		requesterRule = append(requesterRule, requesterItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "DepositIncreased", reservationIdRule, requesterRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowDepositIncreasedIterator{contract: _BunkerEscrow.contract, event: "DepositIncreased", logs: logs, sub: sub}, nil
+}
+
+// WatchDepositIncreased is a free log subscription operation binding the contract event 0x55d9d468c420c3892a429ebbcdaaf1ac722f8b49bba8b4f0b986cf6103f4fd29.
+//
+// Solidity: event DepositIncreased(uint256 indexed reservationId, address indexed requester, uint256 additionalAmount, uint256 newTotal)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchDepositIncreased(opts *bind.WatchOpts, sink chan<- *BunkerEscrowDepositIncreased, reservationId []*big.Int, requester []common.Address) (event.Subscription, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+	var requesterRule []interface{}
+	for _, requesterItem := range requester {
+		requesterRule = append(requesterRule, requesterItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "DepositIncreased", reservationIdRule, requesterRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowDepositIncreased)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "DepositIncreased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDepositIncreased is a log parse operation binding the contract event 0x55d9d468c420c3892a429ebbcdaaf1ac722f8b49bba8b4f0b986cf6103f4fd29.
+//
+// Solidity: event DepositIncreased(uint256 indexed reservationId, address indexed requester, uint256 additionalAmount, uint256 newTotal)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseDepositIncreased(log types.Log) (*BunkerEscrowDepositIncreased, error) {
+	event := new(BunkerEscrowDepositIncreased)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "DepositIncreased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowDisputeSettledIterator is returned from FilterDisputeSettled and is used to iterate over the raw logs and unpacked data for DisputeSettled events raised by the BunkerEscrow contract.
+type BunkerEscrowDisputeSettledIterator struct {
+	Event *BunkerEscrowDisputeSettled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowDisputeSettledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowDisputeSettled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowDisputeSettled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowDisputeSettledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowDisputeSettledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowDisputeSettled represents a DisputeSettled event raised by the BunkerEscrow contract.
+type BunkerEscrowDisputeSettled struct {
+	ReservationId   *big.Int
+	RequesterAmount *big.Int
+	ProviderAmount  *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterDisputeSettled is a free log retrieval operation binding the contract event 0x3d8191766196c966cf505eceed889b6820ad155ebfa6d53b8b0760d144250a8c.
+//
+// Solidity: event DisputeSettled(uint256 indexed reservationId, uint256 requesterAmount, uint256 providerAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterDisputeSettled(opts *bind.FilterOpts, reservationId []*big.Int) (*BunkerEscrowDisputeSettledIterator, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "DisputeSettled", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowDisputeSettledIterator{contract: _BunkerEscrow.contract, event: "DisputeSettled", logs: logs, sub: sub}, nil
+}
+
+// WatchDisputeSettled is a free log subscription operation binding the contract event 0x3d8191766196c966cf505eceed889b6820ad155ebfa6d53b8b0760d144250a8c.
+//
+// Solidity: event DisputeSettled(uint256 indexed reservationId, uint256 requesterAmount, uint256 providerAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchDisputeSettled(opts *bind.WatchOpts, sink chan<- *BunkerEscrowDisputeSettled, reservationId []*big.Int) (event.Subscription, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "DisputeSettled", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowDisputeSettled)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "DisputeSettled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDisputeSettled is a log parse operation binding the contract event 0x3d8191766196c966cf505eceed889b6820ad155ebfa6d53b8b0760d144250a8c.
+//
+// Solidity: event DisputeSettled(uint256 indexed reservationId, uint256 requesterAmount, uint256 providerAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseDisputeSettled(log types.Log) (*BunkerEscrowDisputeSettled, error) {
+	event := new(BunkerEscrowDisputeSettled)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "DisputeSettled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowFeeSplitUpdatedIterator is returned from FilterFeeSplitUpdated and is used to iterate over the raw logs and unpacked data for FeeSplitUpdated events raised by the BunkerEscrow contract.
+type BunkerEscrowFeeSplitUpdatedIterator struct {
+	Event *BunkerEscrowFeeSplitUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowFeeSplitUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowFeeSplitUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowFeeSplitUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowFeeSplitUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowFeeSplitUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowFeeSplitUpdated represents a FeeSplitUpdated event raised by the BunkerEscrow contract.
+type BunkerEscrowFeeSplitUpdated struct {
+	BurnBps     uint16
+	TreasuryBps uint16
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterFeeSplitUpdated is a free log retrieval operation binding the contract event 0x63589f8fbdb3a42e8e990c853b4c0b704151472642497f8e5a435e7547d4b26b.
+//
+// Solidity: event FeeSplitUpdated(uint16 burnBps, uint16 treasuryBps)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterFeeSplitUpdated(opts *bind.FilterOpts) (*BunkerEscrowFeeSplitUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "FeeSplitUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowFeeSplitUpdatedIterator{contract: _BunkerEscrow.contract, event: "FeeSplitUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchFeeSplitUpdated is a free log subscription operation binding the contract event 0x63589f8fbdb3a42e8e990c853b4c0b704151472642497f8e5a435e7547d4b26b.
+//
+// Solidity: event FeeSplitUpdated(uint16 burnBps, uint16 treasuryBps)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchFeeSplitUpdated(opts *bind.WatchOpts, sink chan<- *BunkerEscrowFeeSplitUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "FeeSplitUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowFeeSplitUpdated)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "FeeSplitUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFeeSplitUpdated is a log parse operation binding the contract event 0x63589f8fbdb3a42e8e990c853b4c0b704151472642497f8e5a435e7547d4b26b.
+//
+// Solidity: event FeeSplitUpdated(uint16 burnBps, uint16 treasuryBps)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseFeeSplitUpdated(log types.Log) (*BunkerEscrowFeeSplitUpdated, error) {
+	event := new(BunkerEscrowFeeSplitUpdated)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "FeeSplitUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowLowBalanceIterator is returned from FilterLowBalance and is used to iterate over the raw logs and unpacked data for LowBalance events raised by the BunkerEscrow contract.
+type BunkerEscrowLowBalanceIterator struct {
+	Event *BunkerEscrowLowBalance // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowLowBalanceIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowLowBalance)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowLowBalance)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowLowBalanceIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowLowBalanceIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowLowBalance represents a LowBalance event raised by the BunkerEscrow contract.
+type BunkerEscrowLowBalance struct {
+	ReservationId *big.Int
+	Remaining     *big.Int
+	Threshold     *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterLowBalance is a free log retrieval operation binding the contract event 0x08b79c53a755f9dd3a4d2c9461ab4c2eea8a0475de654ec1353add8a72f1b94f.
+//
+// Solidity: event LowBalance(uint256 indexed reservationId, uint256 remaining, uint256 threshold)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterLowBalance(opts *bind.FilterOpts, reservationId []*big.Int) (*BunkerEscrowLowBalanceIterator, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "LowBalance", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowLowBalanceIterator{contract: _BunkerEscrow.contract, event: "LowBalance", logs: logs, sub: sub}, nil
+}
+
+// WatchLowBalance is a free log subscription operation binding the contract event 0x08b79c53a755f9dd3a4d2c9461ab4c2eea8a0475de654ec1353add8a72f1b94f.
+//
+// Solidity: event LowBalance(uint256 indexed reservationId, uint256 remaining, uint256 threshold)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchLowBalance(opts *bind.WatchOpts, sink chan<- *BunkerEscrowLowBalance, reservationId []*big.Int) (event.Subscription, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "LowBalance", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowLowBalance)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "LowBalance", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseLowBalance is a log parse operation binding the contract event 0x08b79c53a755f9dd3a4d2c9461ab4c2eea8a0475de654ec1353add8a72f1b94f.
+//
+// Solidity: event LowBalance(uint256 indexed reservationId, uint256 remaining, uint256 threshold)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseLowBalance(log types.Log) (*BunkerEscrowLowBalance, error) {
+	event := new(BunkerEscrowLowBalance)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "LowBalance", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the BunkerEscrow contract.
+type BunkerEscrowOwnershipTransferStartedIterator struct {
+	Event *BunkerEscrowOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the BunkerEscrow contract.
+type BunkerEscrowOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerEscrowOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowOwnershipTransferStartedIterator{contract: _BunkerEscrow.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BunkerEscrowOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowOwnershipTransferStarted)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseOwnershipTransferStarted(log types.Log) (*BunkerEscrowOwnershipTransferStarted, error) {
+	event := new(BunkerEscrowOwnershipTransferStarted)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BunkerEscrow contract.
+type BunkerEscrowOwnershipTransferredIterator struct {
+	Event *BunkerEscrowOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowOwnershipTransferred represents a OwnershipTransferred event raised by the BunkerEscrow contract.
+type BunkerEscrowOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerEscrowOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowOwnershipTransferredIterator{contract: _BunkerEscrow.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BunkerEscrowOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowOwnershipTransferred)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseOwnershipTransferred(log types.Log) (*BunkerEscrowOwnershipTransferred, error) {
+	event := new(BunkerEscrowOwnershipTransferred)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the BunkerEscrow contract.
+type BunkerEscrowPausedIterator struct {
+	Event *BunkerEscrowPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowPaused represents a Paused event raised by the BunkerEscrow contract.
+type BunkerEscrowPaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterPaused(opts *bind.FilterOpts) (*BunkerEscrowPausedIterator, error) {
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowPausedIterator{contract: _BunkerEscrow.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *BunkerEscrowPaused) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowPaused)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParsePaused(log types.Log) (*BunkerEscrowPaused, error) {
+	event := new(BunkerEscrowPaused)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowPaymentReleasedIterator is returned from FilterPaymentReleased and is used to iterate over the raw logs and unpacked data for PaymentReleased events raised by the BunkerEscrow contract.
+type BunkerEscrowPaymentReleasedIterator struct {
+	Event *BunkerEscrowPaymentReleased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowPaymentReleasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowPaymentReleased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowPaymentReleased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowPaymentReleasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowPaymentReleasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowPaymentReleased represents a PaymentReleased event raised by the BunkerEscrow contract.
+type BunkerEscrowPaymentReleased struct {
+	ReservationId  *big.Int
+	GrossAmount    *big.Int
+	NetToProviders *big.Int
+	ProtocolFee    *big.Int
+	BurnedAmount   *big.Int
+	TreasuryAmount *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaymentReleased is a free log retrieval operation binding the contract event 0x28e2a1a217824c8e7d741818f656c447b4f3cdbe3b07e34ac32d9dc13b36b212.
+//
+// Solidity: event PaymentReleased(uint256 indexed reservationId, uint256 grossAmount, uint256 netToProviders, uint256 protocolFee, uint256 burnedAmount, uint256 treasuryAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterPaymentReleased(opts *bind.FilterOpts, reservationId []*big.Int) (*BunkerEscrowPaymentReleasedIterator, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "PaymentReleased", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowPaymentReleasedIterator{contract: _BunkerEscrow.contract, event: "PaymentReleased", logs: logs, sub: sub}, nil
+}
+
+// WatchPaymentReleased is a free log subscription operation binding the contract event 0x28e2a1a217824c8e7d741818f656c447b4f3cdbe3b07e34ac32d9dc13b36b212.
+//
+// Solidity: event PaymentReleased(uint256 indexed reservationId, uint256 grossAmount, uint256 netToProviders, uint256 protocolFee, uint256 burnedAmount, uint256 treasuryAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchPaymentReleased(opts *bind.WatchOpts, sink chan<- *BunkerEscrowPaymentReleased, reservationId []*big.Int) (event.Subscription, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "PaymentReleased", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowPaymentReleased)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "PaymentReleased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaymentReleased is a log parse operation binding the contract event 0x28e2a1a217824c8e7d741818f656c447b4f3cdbe3b07e34ac32d9dc13b36b212.
+//
+// Solidity: event PaymentReleased(uint256 indexed reservationId, uint256 grossAmount, uint256 netToProviders, uint256 protocolFee, uint256 burnedAmount, uint256 treasuryAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParsePaymentReleased(log types.Log) (*BunkerEscrowPaymentReleased, error) {
+	event := new(BunkerEscrowPaymentReleased)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "PaymentReleased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowProtocolFeeUpdatedIterator is returned from FilterProtocolFeeUpdated and is used to iterate over the raw logs and unpacked data for ProtocolFeeUpdated events raised by the BunkerEscrow contract.
+type BunkerEscrowProtocolFeeUpdatedIterator struct {
+	Event *BunkerEscrowProtocolFeeUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowProtocolFeeUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowProtocolFeeUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowProtocolFeeUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowProtocolFeeUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowProtocolFeeUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowProtocolFeeUpdated represents a ProtocolFeeUpdated event raised by the BunkerEscrow contract.
+type BunkerEscrowProtocolFeeUpdated struct {
+	OldFeeBps *big.Int
+	NewFeeBps *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterProtocolFeeUpdated is a free log retrieval operation binding the contract event 0xb404cac19fb1cbeff98d325795b08886e3cd8fe8cb1a2f193aac66f13fb239c3.
+//
+// Solidity: event ProtocolFeeUpdated(uint256 oldFeeBps, uint256 newFeeBps)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterProtocolFeeUpdated(opts *bind.FilterOpts) (*BunkerEscrowProtocolFeeUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "ProtocolFeeUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowProtocolFeeUpdatedIterator{contract: _BunkerEscrow.contract, event: "ProtocolFeeUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchProtocolFeeUpdated is a free log subscription operation binding the contract event 0xb404cac19fb1cbeff98d325795b08886e3cd8fe8cb1a2f193aac66f13fb239c3.
+//
+// Solidity: event ProtocolFeeUpdated(uint256 oldFeeBps, uint256 newFeeBps)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchProtocolFeeUpdated(opts *bind.WatchOpts, sink chan<- *BunkerEscrowProtocolFeeUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "ProtocolFeeUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowProtocolFeeUpdated)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "ProtocolFeeUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProtocolFeeUpdated is a log parse operation binding the contract event 0xb404cac19fb1cbeff98d325795b08886e3cd8fe8cb1a2f193aac66f13fb239c3.
+//
+// Solidity: event ProtocolFeeUpdated(uint256 oldFeeBps, uint256 newFeeBps)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseProtocolFeeUpdated(log types.Log) (*BunkerEscrowProtocolFeeUpdated, error) {
+	event := new(BunkerEscrowProtocolFeeUpdated)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "ProtocolFeeUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowProvidersSelectedIterator is returned from FilterProvidersSelected and is used to iterate over the raw logs and unpacked data for ProvidersSelected events raised by the BunkerEscrow contract.
+type BunkerEscrowProvidersSelectedIterator struct {
+	Event *BunkerEscrowProvidersSelected // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowProvidersSelectedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowProvidersSelected)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowProvidersSelected)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowProvidersSelectedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowProvidersSelectedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowProvidersSelected represents a ProvidersSelected event raised by the BunkerEscrow contract.
+type BunkerEscrowProvidersSelected struct {
+	ReservationId *big.Int
+	Provider0     common.Address
+	Provider1     common.Address
+	Provider2     common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterProvidersSelected is a free log retrieval operation binding the contract event 0x45e176f25eb06939d4744053c7279ff21fc46c1a62b147a766dd1b7e75123e24.
+//
+// Solidity: event ProvidersSelected(uint256 indexed reservationId, address provider0, address provider1, address provider2)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterProvidersSelected(opts *bind.FilterOpts, reservationId []*big.Int) (*BunkerEscrowProvidersSelectedIterator, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "ProvidersSelected", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowProvidersSelectedIterator{contract: _BunkerEscrow.contract, event: "ProvidersSelected", logs: logs, sub: sub}, nil
+}
+
+// WatchProvidersSelected is a free log subscription operation binding the contract event 0x45e176f25eb06939d4744053c7279ff21fc46c1a62b147a766dd1b7e75123e24.
+//
+// Solidity: event ProvidersSelected(uint256 indexed reservationId, address provider0, address provider1, address provider2)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchProvidersSelected(opts *bind.WatchOpts, sink chan<- *BunkerEscrowProvidersSelected, reservationId []*big.Int) (event.Subscription, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "ProvidersSelected", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowProvidersSelected)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "ProvidersSelected", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProvidersSelected is a log parse operation binding the contract event 0x45e176f25eb06939d4744053c7279ff21fc46c1a62b147a766dd1b7e75123e24.
+//
+// Solidity: event ProvidersSelected(uint256 indexed reservationId, address provider0, address provider1, address provider2)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseProvidersSelected(log types.Log) (*BunkerEscrowProvidersSelected, error) {
+	event := new(BunkerEscrowProvidersSelected)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "ProvidersSelected", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowRefundedIterator is returned from FilterRefunded and is used to iterate over the raw logs and unpacked data for Refunded events raised by the BunkerEscrow contract.
+type BunkerEscrowRefundedIterator struct {
+	Event *BunkerEscrowRefunded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowRefundedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowRefunded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowRefunded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowRefundedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowRefundedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowRefunded represents a Refunded event raised by the BunkerEscrow contract.
+type BunkerEscrowRefunded struct {
+	ReservationId *big.Int
+	Requester     common.Address
+	RefundAmount  *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterRefunded is a free log retrieval operation binding the contract event 0x7ca5472b7ea78c2c0141c5a12ee6d170cf4ce8ed06be3d22c8252ddfc7a6a2c4.
+//
+// Solidity: event Refunded(uint256 indexed reservationId, address indexed requester, uint256 refundAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterRefunded(opts *bind.FilterOpts, reservationId []*big.Int, requester []common.Address) (*BunkerEscrowRefundedIterator, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+	var requesterRule []interface{}
+	for _, requesterItem := range requester {
+		requesterRule = append(requesterRule, requesterItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "Refunded", reservationIdRule, requesterRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowRefundedIterator{contract: _BunkerEscrow.contract, event: "Refunded", logs: logs, sub: sub}, nil
+}
+
+// WatchRefunded is a free log subscription operation binding the contract event 0x7ca5472b7ea78c2c0141c5a12ee6d170cf4ce8ed06be3d22c8252ddfc7a6a2c4.
+//
+// Solidity: event Refunded(uint256 indexed reservationId, address indexed requester, uint256 refundAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchRefunded(opts *bind.WatchOpts, sink chan<- *BunkerEscrowRefunded, reservationId []*big.Int, requester []common.Address) (event.Subscription, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+	var requesterRule []interface{}
+	for _, requesterItem := range requester {
+		requesterRule = append(requesterRule, requesterItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "Refunded", reservationIdRule, requesterRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowRefunded)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "Refunded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRefunded is a log parse operation binding the contract event 0x7ca5472b7ea78c2c0141c5a12ee6d170cf4ce8ed06be3d22c8252ddfc7a6a2c4.
+//
+// Solidity: event Refunded(uint256 indexed reservationId, address indexed requester, uint256 refundAmount)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseRefunded(log types.Log) (*BunkerEscrowRefunded, error) {
+	event := new(BunkerEscrowRefunded)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "Refunded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowReservationCreatedIterator is returned from FilterReservationCreated and is used to iterate over the raw logs and unpacked data for ReservationCreated events raised by the BunkerEscrow contract.
+type BunkerEscrowReservationCreatedIterator struct {
+	Event *BunkerEscrowReservationCreated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowReservationCreatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowReservationCreated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowReservationCreated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowReservationCreatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowReservationCreatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowReservationCreated represents a ReservationCreated event raised by the BunkerEscrow contract.
+type BunkerEscrowReservationCreated struct {
+	ReservationId *big.Int
+	Requester     common.Address
+	Amount        *big.Int
+	Duration      *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterReservationCreated is a free log retrieval operation binding the contract event 0x33461db70ae41500095642332d9a39420948b9b034c6edc55b6f44c9819e68c6.
+//
+// Solidity: event ReservationCreated(uint256 indexed reservationId, address indexed requester, uint256 amount, uint256 duration)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterReservationCreated(opts *bind.FilterOpts, reservationId []*big.Int, requester []common.Address) (*BunkerEscrowReservationCreatedIterator, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+	var requesterRule []interface{}
+	for _, requesterItem := range requester {
+		requesterRule = append(requesterRule, requesterItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "ReservationCreated", reservationIdRule, requesterRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowReservationCreatedIterator{contract: _BunkerEscrow.contract, event: "ReservationCreated", logs: logs, sub: sub}, nil
+}
+
+// WatchReservationCreated is a free log subscription operation binding the contract event 0x33461db70ae41500095642332d9a39420948b9b034c6edc55b6f44c9819e68c6.
+//
+// Solidity: event ReservationCreated(uint256 indexed reservationId, address indexed requester, uint256 amount, uint256 duration)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchReservationCreated(opts *bind.WatchOpts, sink chan<- *BunkerEscrowReservationCreated, reservationId []*big.Int, requester []common.Address) (event.Subscription, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+	var requesterRule []interface{}
+	for _, requesterItem := range requester {
+		requesterRule = append(requesterRule, requesterItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "ReservationCreated", reservationIdRule, requesterRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowReservationCreated)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "ReservationCreated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReservationCreated is a log parse operation binding the contract event 0x33461db70ae41500095642332d9a39420948b9b034c6edc55b6f44c9819e68c6.
+//
+// Solidity: event ReservationCreated(uint256 indexed reservationId, address indexed requester, uint256 amount, uint256 duration)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseReservationCreated(log types.Log) (*BunkerEscrowReservationCreated, error) {
+	event := new(BunkerEscrowReservationCreated)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "ReservationCreated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowReservationFinalizedIterator is returned from FilterReservationFinalized and is used to iterate over the raw logs and unpacked data for ReservationFinalized events raised by the BunkerEscrow contract.
+type BunkerEscrowReservationFinalizedIterator struct {
+	Event *BunkerEscrowReservationFinalized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowReservationFinalizedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowReservationFinalized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowReservationFinalized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowReservationFinalizedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowReservationFinalizedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowReservationFinalized represents a ReservationFinalized event raised by the BunkerEscrow contract.
+type BunkerEscrowReservationFinalized struct {
+	ReservationId *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterReservationFinalized is a free log retrieval operation binding the contract event 0xe9a0dea3b9b7ff7aa31f919eb39def4bd959c40dfcef05fd5bc29f85bd90ff7b.
+//
+// Solidity: event ReservationFinalized(uint256 indexed reservationId)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterReservationFinalized(opts *bind.FilterOpts, reservationId []*big.Int) (*BunkerEscrowReservationFinalizedIterator, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "ReservationFinalized", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowReservationFinalizedIterator{contract: _BunkerEscrow.contract, event: "ReservationFinalized", logs: logs, sub: sub}, nil
+}
+
+// WatchReservationFinalized is a free log subscription operation binding the contract event 0xe9a0dea3b9b7ff7aa31f919eb39def4bd959c40dfcef05fd5bc29f85bd90ff7b.
+//
+// Solidity: event ReservationFinalized(uint256 indexed reservationId)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchReservationFinalized(opts *bind.WatchOpts, sink chan<- *BunkerEscrowReservationFinalized, reservationId []*big.Int) (event.Subscription, error) {
+
+	var reservationIdRule []interface{}
+	for _, reservationIdItem := range reservationId {
+		reservationIdRule = append(reservationIdRule, reservationIdItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "ReservationFinalized", reservationIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowReservationFinalized)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "ReservationFinalized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReservationFinalized is a log parse operation binding the contract event 0xe9a0dea3b9b7ff7aa31f919eb39def4bd959c40dfcef05fd5bc29f85bd90ff7b.
+//
+// Solidity: event ReservationFinalized(uint256 indexed reservationId)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseReservationFinalized(log types.Log) (*BunkerEscrowReservationFinalized, error) {
+	event := new(BunkerEscrowReservationFinalized)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "ReservationFinalized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the BunkerEscrow contract.
+type BunkerEscrowRoleAdminChangedIterator struct {
+	Event *BunkerEscrowRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowRoleAdminChanged represents a RoleAdminChanged event raised by the BunkerEscrow contract.
+type BunkerEscrowRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*BunkerEscrowRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowRoleAdminChangedIterator{contract: _BunkerEscrow.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *BunkerEscrowRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowRoleAdminChanged)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseRoleAdminChanged(log types.Log) (*BunkerEscrowRoleAdminChanged, error) {
+	event := new(BunkerEscrowRoleAdminChanged)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the BunkerEscrow contract.
+type BunkerEscrowRoleGrantedIterator struct {
+	Event *BunkerEscrowRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowRoleGranted represents a RoleGranted event raised by the BunkerEscrow contract.
+type BunkerEscrowRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BunkerEscrowRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowRoleGrantedIterator{contract: _BunkerEscrow.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *BunkerEscrowRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowRoleGranted)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseRoleGranted(log types.Log) (*BunkerEscrowRoleGranted, error) {
+	event := new(BunkerEscrowRoleGranted)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the BunkerEscrow contract.
+type BunkerEscrowRoleRevokedIterator struct {
+	Event *BunkerEscrowRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowRoleRevoked represents a RoleRevoked event raised by the BunkerEscrow contract.
+type BunkerEscrowRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BunkerEscrowRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowRoleRevokedIterator{contract: _BunkerEscrow.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *BunkerEscrowRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowRoleRevoked)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseRoleRevoked(log types.Log) (*BunkerEscrowRoleRevoked, error) {
+	event := new(BunkerEscrowRoleRevoked)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowStakingContractUpdatedIterator is returned from FilterStakingContractUpdated and is used to iterate over the raw logs and unpacked data for StakingContractUpdated events raised by the BunkerEscrow contract.
+type BunkerEscrowStakingContractUpdatedIterator struct {
+	Event *BunkerEscrowStakingContractUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowStakingContractUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowStakingContractUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowStakingContractUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowStakingContractUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowStakingContractUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowStakingContractUpdated represents a StakingContractUpdated event raised by the BunkerEscrow contract.
+type BunkerEscrowStakingContractUpdated struct {
+	OldStaking common.Address
+	NewStaking common.Address
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakingContractUpdated is a free log retrieval operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address indexed oldStaking, address indexed newStaking)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterStakingContractUpdated(opts *bind.FilterOpts, oldStaking []common.Address, newStaking []common.Address) (*BunkerEscrowStakingContractUpdatedIterator, error) {
+
+	var oldStakingRule []interface{}
+	for _, oldStakingItem := range oldStaking {
+		oldStakingRule = append(oldStakingRule, oldStakingItem)
+	}
+	var newStakingRule []interface{}
+	for _, newStakingItem := range newStaking {
+		newStakingRule = append(newStakingRule, newStakingItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "StakingContractUpdated", oldStakingRule, newStakingRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowStakingContractUpdatedIterator{contract: _BunkerEscrow.contract, event: "StakingContractUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakingContractUpdated is a free log subscription operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address indexed oldStaking, address indexed newStaking)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchStakingContractUpdated(opts *bind.WatchOpts, sink chan<- *BunkerEscrowStakingContractUpdated, oldStaking []common.Address, newStaking []common.Address) (event.Subscription, error) {
+
+	var oldStakingRule []interface{}
+	for _, oldStakingItem := range oldStaking {
+		oldStakingRule = append(oldStakingRule, oldStakingItem)
+	}
+	var newStakingRule []interface{}
+	for _, newStakingItem := range newStaking {
+		newStakingRule = append(newStakingRule, newStakingItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "StakingContractUpdated", oldStakingRule, newStakingRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowStakingContractUpdated)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "StakingContractUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakingContractUpdated is a log parse operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address indexed oldStaking, address indexed newStaking)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseStakingContractUpdated(log types.Log) (*BunkerEscrowStakingContractUpdated, error) {
+	event := new(BunkerEscrowStakingContractUpdated)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "StakingContractUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowTreasuryUpdatedIterator is returned from FilterTreasuryUpdated and is used to iterate over the raw logs and unpacked data for TreasuryUpdated events raised by the BunkerEscrow contract.
+type BunkerEscrowTreasuryUpdatedIterator struct {
+	Event *BunkerEscrowTreasuryUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowTreasuryUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowTreasuryUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowTreasuryUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowTreasuryUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowTreasuryUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowTreasuryUpdated represents a TreasuryUpdated event raised by the BunkerEscrow contract.
+type BunkerEscrowTreasuryUpdated struct {
+	OldTreasury common.Address
+	NewTreasury common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterTreasuryUpdated is a free log retrieval operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterTreasuryUpdated(opts *bind.FilterOpts, oldTreasury []common.Address, newTreasury []common.Address) (*BunkerEscrowTreasuryUpdatedIterator, error) {
+
+	var oldTreasuryRule []interface{}
+	for _, oldTreasuryItem := range oldTreasury {
+		oldTreasuryRule = append(oldTreasuryRule, oldTreasuryItem)
+	}
+	var newTreasuryRule []interface{}
+	for _, newTreasuryItem := range newTreasury {
+		newTreasuryRule = append(newTreasuryRule, newTreasuryItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "TreasuryUpdated", oldTreasuryRule, newTreasuryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowTreasuryUpdatedIterator{contract: _BunkerEscrow.contract, event: "TreasuryUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchTreasuryUpdated is a free log subscription operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchTreasuryUpdated(opts *bind.WatchOpts, sink chan<- *BunkerEscrowTreasuryUpdated, oldTreasury []common.Address, newTreasury []common.Address) (event.Subscription, error) {
+
+	var oldTreasuryRule []interface{}
+	for _, oldTreasuryItem := range oldTreasury {
+		oldTreasuryRule = append(oldTreasuryRule, oldTreasuryItem)
+	}
+	var newTreasuryRule []interface{}
+	for _, newTreasuryItem := range newTreasury {
+		newTreasuryRule = append(newTreasuryRule, newTreasuryItem)
+	}
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "TreasuryUpdated", oldTreasuryRule, newTreasuryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowTreasuryUpdated)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "TreasuryUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTreasuryUpdated is a log parse operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseTreasuryUpdated(log types.Log) (*BunkerEscrowTreasuryUpdated, error) {
+	event := new(BunkerEscrowTreasuryUpdated)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "TreasuryUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerEscrowUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the BunkerEscrow contract.
+type BunkerEscrowUnpausedIterator struct {
+	Event *BunkerEscrowUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerEscrowUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerEscrowUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerEscrowUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerEscrowUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerEscrowUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerEscrowUnpaused represents a Unpaused event raised by the BunkerEscrow contract.
+type BunkerEscrowUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerEscrow *BunkerEscrowFilterer) FilterUnpaused(opts *bind.FilterOpts) (*BunkerEscrowUnpausedIterator, error) {
+
+	logs, sub, err := _BunkerEscrow.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerEscrowUnpausedIterator{contract: _BunkerEscrow.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerEscrow *BunkerEscrowFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *BunkerEscrowUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerEscrow.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerEscrowUnpaused)
+				if err := _BunkerEscrow.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerEscrow *BunkerEscrowFilterer) ParseUnpaused(log types.Log) (*BunkerEscrowUnpaused, error) {
+	event := new(BunkerEscrowUnpaused)
+	if err := _BunkerEscrow.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/payment/bindings/bunkerpricing.go
+++ b/internal/payment/bindings/bunkerpricing.go
@@ -1,0 +1,3083 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BunkerPricingMultipliers is an auto generated low-level Go binding around an user-defined struct.
+type BunkerPricingMultipliers struct {
+	Redundancy *big.Int
+	Tor        *big.Int
+	PremiumSLA *big.Int
+	Spot       *big.Int
+}
+
+// BunkerPricingProviderPricing is an auto generated low-level Go binding around an user-defined struct.
+type BunkerPricingProviderPricing struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	IsSet             bool
+}
+
+// BunkerPricingResourcePrices is an auto generated low-level Go binding around an user-defined struct.
+type BunkerPricingResourcePrices struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	GpuBasicPerHour   *big.Int
+	GpuPremiumPerHour *big.Int
+}
+
+// BunkerPricingResourceRequest is an auto generated low-level Go binding around an user-defined struct.
+type BunkerPricingResourceRequest struct {
+	CpuCores      *big.Int
+	MemoryGB      *big.Int
+	StorageGB     *big.Int
+	NetworkGB     *big.Int
+	DurationHours *big.Int
+	UseGPUBasic   bool
+	UseGPUPremium bool
+	UseTor        bool
+	UsePremiumSLA bool
+	UseSpot       bool
+}
+
+// BunkerPricingMetaData contains all meta data concerning the BunkerPricing contract.
+var BunkerPricingMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_initialOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BPS_DENOMINATOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"calculateCost\",\"inputs\":[{\"name\":\"req\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.ResourceRequest\",\"components\":[{\"name\":\"cpuCores\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storageGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"durationHours\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"useGPUBasic\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useGPUPremium\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useTor\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"usePremiumSLA\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useSpot\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"outputs\":[{\"name\":\"totalCost\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateCostUSD\",\"inputs\":[{\"name\":\"req\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.ResourceRequest\",\"components\":[{\"name\":\"cpuCores\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storageGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"durationHours\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"useGPUBasic\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useGPUPremium\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useTor\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"usePremiumSLA\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useSpot\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"outputs\":[{\"name\":\"usdCost\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculateProviderCost\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"req\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.ResourceRequest\",\"components\":[{\"name\":\"cpuCores\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storageGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"durationHours\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"useGPUBasic\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useGPUPremium\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useTor\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"usePremiumSLA\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"useSpot\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"outputs\":[{\"name\":\"totalCost\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"clearProviderPrices\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"enableOraclePricing\",\"inputs\":[{\"name\":\"enabled\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getMultipliers\",\"inputs\":[],\"outputs\":[{\"name\":\"m\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.Multipliers\",\"components\":[{\"name\":\"redundancy\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"tor\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"premiumSLA\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"spot\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getPrices\",\"inputs\":[],\"outputs\":[{\"name\":\"p\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.ResourcePrices\",\"components\":[{\"name\":\"cpuPerCoreHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryPerGBHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storagePerGBMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkPerGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"gpuBasicPerHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"gpuPremiumPerHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderPrices\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"pp\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.ProviderPricing\",\"components\":[{\"name\":\"cpuPerCoreHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryPerGBHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storagePerGBMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkPerGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"isSet\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getTokenPrice\",\"inputs\":[],\"outputs\":[{\"name\":\"price\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"decimals_\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"maxMultiplierBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"maxPriceMultiplierBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"maxStaleThreshold\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"minPriceMultiplierBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"minStaleThreshold\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"multipliers\",\"inputs\":[],\"outputs\":[{\"name\":\"redundancy\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"tor\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"premiumSLA\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"spot\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"priceOracle\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractAggregatorV3Interface\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"prices\",\"inputs\":[],\"outputs\":[{\"name\":\"cpuPerCoreHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryPerGBHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storagePerGBMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkPerGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"gpuBasicPerHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"gpuPremiumPerHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"providerPrices\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"cpuPerCoreHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryPerGBHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storagePerGBMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkPerGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"isSet\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setCPUPrice\",\"inputs\":[{\"name\":\"newPrice\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setGPUPrices\",\"inputs\":[{\"name\":\"basicPerHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"premiumPerHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMaxMultiplierBps\",\"inputs\":[{\"name\":\"newMax\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMemoryPrice\",\"inputs\":[{\"name\":\"newPrice\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMultipliers\",\"inputs\":[{\"name\":\"newMultipliers\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.Multipliers\",\"components\":[{\"name\":\"redundancy\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"tor\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"premiumSLA\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"spot\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setNetworkPrice\",\"inputs\":[{\"name\":\"newPrice\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setPriceOracle\",\"inputs\":[{\"name\":\"newOracle\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setPrices\",\"inputs\":[{\"name\":\"newPrices\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.ResourcePrices\",\"components\":[{\"name\":\"cpuPerCoreHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryPerGBHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storagePerGBMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkPerGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"gpuBasicPerHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"gpuPremiumPerHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setProviderPriceBounds\",\"inputs\":[{\"name\":\"minBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setProviderPrices\",\"inputs\":[{\"name\":\"pp\",\"type\":\"tuple\",\"internalType\":\"structBunkerPricing.ProviderPricing\",\"components\":[{\"name\":\"cpuPerCoreHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"memoryPerGBHour\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"storagePerGBMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"networkPerGB\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"isSet\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setStalePriceThreshold\",\"inputs\":[{\"name\":\"newThreshold\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setStaleThresholdBounds\",\"inputs\":[{\"name\":\"newMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"newMax\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setStoragePrice\",\"inputs\":[{\"name\":\"newPrice\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"stalePriceThreshold\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"useOracleForPricing\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"MaxMultiplierUpdated\",\"inputs\":[{\"name\":\"newMax\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MultipliersUpdated\",\"inputs\":[{\"name\":\"redundancy\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"tor\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"premiumSLA\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"spot\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OraclePricingEnabled\",\"inputs\":[{\"name\":\"enabled\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PriceOracleUpdated\",\"inputs\":[{\"name\":\"oldOracle\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOracle\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PricesUpdated\",\"inputs\":[{\"name\":\"cpuPerCoreHour\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"memoryPerGBHour\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"storagePerGBMonth\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"networkPerGB\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"gpuBasicPerHour\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"gpuPremiumPerHour\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderPriceBoundsUpdated\",\"inputs\":[{\"name\":\"minBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"maxBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderPricesCleared\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderPricesSet\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"cpu\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"memory_\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"storage_\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"network\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StalePriceThresholdUpdated\",\"inputs\":[{\"name\":\"oldThreshold\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newThreshold\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StaleThresholdBoundsUpdated\",\"inputs\":[{\"name\":\"newMin\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newMax\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"InvalidMultiplier\",\"inputs\":[{\"name\":\"multiplier\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidMultiplierCap\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidPriceBounds\",\"inputs\":[{\"name\":\"minBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidStalePriceThreshold\",\"inputs\":[{\"name\":\"threshold\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidThresholdBounds\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MultiplierTooHigh\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NegativePrice\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OracleNotSet\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"PriceAboveMaximum\",\"inputs\":[{\"name\":\"price\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maximum\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"PriceBelowMinimum\",\"inputs\":[{\"name\":\"price\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minimum\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"StalePriceData\",\"inputs\":[{\"name\":\"updatedAt\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"threshold\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ThresholdTooLong\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroMultiplier\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroPrice\",\"inputs\":[]}]",
+}
+
+// BunkerPricingABI is the input ABI used to generate the binding from.
+// Deprecated: Use BunkerPricingMetaData.ABI instead.
+var BunkerPricingABI = BunkerPricingMetaData.ABI
+
+// BunkerPricing is an auto generated Go binding around an Ethereum contract.
+type BunkerPricing struct {
+	BunkerPricingCaller     // Read-only binding to the contract
+	BunkerPricingTransactor // Write-only binding to the contract
+	BunkerPricingFilterer   // Log filterer for contract events
+}
+
+// BunkerPricingCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BunkerPricingCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerPricingTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BunkerPricingTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerPricingFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BunkerPricingFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerPricingSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BunkerPricingSession struct {
+	Contract     *BunkerPricing    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BunkerPricingCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BunkerPricingCallerSession struct {
+	Contract *BunkerPricingCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// BunkerPricingTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BunkerPricingTransactorSession struct {
+	Contract     *BunkerPricingTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// BunkerPricingRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BunkerPricingRaw struct {
+	Contract *BunkerPricing // Generic contract binding to access the raw methods on
+}
+
+// BunkerPricingCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BunkerPricingCallerRaw struct {
+	Contract *BunkerPricingCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BunkerPricingTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BunkerPricingTransactorRaw struct {
+	Contract *BunkerPricingTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBunkerPricing creates a new instance of BunkerPricing, bound to a specific deployed contract.
+func NewBunkerPricing(address common.Address, backend bind.ContractBackend) (*BunkerPricing, error) {
+	contract, err := bindBunkerPricing(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricing{BunkerPricingCaller: BunkerPricingCaller{contract: contract}, BunkerPricingTransactor: BunkerPricingTransactor{contract: contract}, BunkerPricingFilterer: BunkerPricingFilterer{contract: contract}}, nil
+}
+
+// NewBunkerPricingCaller creates a new read-only instance of BunkerPricing, bound to a specific deployed contract.
+func NewBunkerPricingCaller(address common.Address, caller bind.ContractCaller) (*BunkerPricingCaller, error) {
+	contract, err := bindBunkerPricing(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingCaller{contract: contract}, nil
+}
+
+// NewBunkerPricingTransactor creates a new write-only instance of BunkerPricing, bound to a specific deployed contract.
+func NewBunkerPricingTransactor(address common.Address, transactor bind.ContractTransactor) (*BunkerPricingTransactor, error) {
+	contract, err := bindBunkerPricing(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingTransactor{contract: contract}, nil
+}
+
+// NewBunkerPricingFilterer creates a new log filterer instance of BunkerPricing, bound to a specific deployed contract.
+func NewBunkerPricingFilterer(address common.Address, filterer bind.ContractFilterer) (*BunkerPricingFilterer, error) {
+	contract, err := bindBunkerPricing(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingFilterer{contract: contract}, nil
+}
+
+// bindBunkerPricing binds a generic wrapper to an already deployed contract.
+func bindBunkerPricing(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BunkerPricingMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerPricing *BunkerPricingRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerPricing.Contract.BunkerPricingCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerPricing *BunkerPricingRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.BunkerPricingTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerPricing *BunkerPricingRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.BunkerPricingTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerPricing *BunkerPricingCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerPricing.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerPricing *BunkerPricingTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerPricing *BunkerPricingTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.contract.Transact(opts, method, params...)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCaller) BPSDENOMINATOR(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "BPS_DENOMINATOR")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerPricing *BunkerPricingSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerPricing.Contract.BPSDENOMINATOR(&_BunkerPricing.CallOpts)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCallerSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerPricing.Contract.BPSDENOMINATOR(&_BunkerPricing.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerPricing *BunkerPricingCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerPricing *BunkerPricingSession) VERSION() (string, error) {
+	return _BunkerPricing.Contract.VERSION(&_BunkerPricing.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerPricing *BunkerPricingCallerSession) VERSION() (string, error) {
+	return _BunkerPricing.Contract.VERSION(&_BunkerPricing.CallOpts)
+}
+
+// CalculateCost is a free data retrieval call binding the contract method 0x0a5b1570.
+//
+// Solidity: function calculateCost((uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 totalCost)
+func (_BunkerPricing *BunkerPricingCaller) CalculateCost(opts *bind.CallOpts, req BunkerPricingResourceRequest) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "calculateCost", req)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// CalculateCost is a free data retrieval call binding the contract method 0x0a5b1570.
+//
+// Solidity: function calculateCost((uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 totalCost)
+func (_BunkerPricing *BunkerPricingSession) CalculateCost(req BunkerPricingResourceRequest) (*big.Int, error) {
+	return _BunkerPricing.Contract.CalculateCost(&_BunkerPricing.CallOpts, req)
+}
+
+// CalculateCost is a free data retrieval call binding the contract method 0x0a5b1570.
+//
+// Solidity: function calculateCost((uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 totalCost)
+func (_BunkerPricing *BunkerPricingCallerSession) CalculateCost(req BunkerPricingResourceRequest) (*big.Int, error) {
+	return _BunkerPricing.Contract.CalculateCost(&_BunkerPricing.CallOpts, req)
+}
+
+// CalculateCostUSD is a free data retrieval call binding the contract method 0x9201d7cd.
+//
+// Solidity: function calculateCostUSD((uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 usdCost)
+func (_BunkerPricing *BunkerPricingCaller) CalculateCostUSD(opts *bind.CallOpts, req BunkerPricingResourceRequest) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "calculateCostUSD", req)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// CalculateCostUSD is a free data retrieval call binding the contract method 0x9201d7cd.
+//
+// Solidity: function calculateCostUSD((uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 usdCost)
+func (_BunkerPricing *BunkerPricingSession) CalculateCostUSD(req BunkerPricingResourceRequest) (*big.Int, error) {
+	return _BunkerPricing.Contract.CalculateCostUSD(&_BunkerPricing.CallOpts, req)
+}
+
+// CalculateCostUSD is a free data retrieval call binding the contract method 0x9201d7cd.
+//
+// Solidity: function calculateCostUSD((uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 usdCost)
+func (_BunkerPricing *BunkerPricingCallerSession) CalculateCostUSD(req BunkerPricingResourceRequest) (*big.Int, error) {
+	return _BunkerPricing.Contract.CalculateCostUSD(&_BunkerPricing.CallOpts, req)
+}
+
+// CalculateProviderCost is a free data retrieval call binding the contract method 0x0f9198d8.
+//
+// Solidity: function calculateProviderCost(address provider, (uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 totalCost)
+func (_BunkerPricing *BunkerPricingCaller) CalculateProviderCost(opts *bind.CallOpts, provider common.Address, req BunkerPricingResourceRequest) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "calculateProviderCost", provider, req)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// CalculateProviderCost is a free data retrieval call binding the contract method 0x0f9198d8.
+//
+// Solidity: function calculateProviderCost(address provider, (uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 totalCost)
+func (_BunkerPricing *BunkerPricingSession) CalculateProviderCost(provider common.Address, req BunkerPricingResourceRequest) (*big.Int, error) {
+	return _BunkerPricing.Contract.CalculateProviderCost(&_BunkerPricing.CallOpts, provider, req)
+}
+
+// CalculateProviderCost is a free data retrieval call binding the contract method 0x0f9198d8.
+//
+// Solidity: function calculateProviderCost(address provider, (uint256,uint256,uint256,uint256,uint256,bool,bool,bool,bool,bool) req) view returns(uint256 totalCost)
+func (_BunkerPricing *BunkerPricingCallerSession) CalculateProviderCost(provider common.Address, req BunkerPricingResourceRequest) (*big.Int, error) {
+	return _BunkerPricing.Contract.CalculateProviderCost(&_BunkerPricing.CallOpts, provider, req)
+}
+
+// GetMultipliers is a free data retrieval call binding the contract method 0x79873f8a.
+//
+// Solidity: function getMultipliers() view returns((uint256,uint256,uint256,uint256) m)
+func (_BunkerPricing *BunkerPricingCaller) GetMultipliers(opts *bind.CallOpts) (BunkerPricingMultipliers, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "getMultipliers")
+
+	if err != nil {
+		return *new(BunkerPricingMultipliers), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerPricingMultipliers)).(*BunkerPricingMultipliers)
+
+	return out0, err
+
+}
+
+// GetMultipliers is a free data retrieval call binding the contract method 0x79873f8a.
+//
+// Solidity: function getMultipliers() view returns((uint256,uint256,uint256,uint256) m)
+func (_BunkerPricing *BunkerPricingSession) GetMultipliers() (BunkerPricingMultipliers, error) {
+	return _BunkerPricing.Contract.GetMultipliers(&_BunkerPricing.CallOpts)
+}
+
+// GetMultipliers is a free data retrieval call binding the contract method 0x79873f8a.
+//
+// Solidity: function getMultipliers() view returns((uint256,uint256,uint256,uint256) m)
+func (_BunkerPricing *BunkerPricingCallerSession) GetMultipliers() (BunkerPricingMultipliers, error) {
+	return _BunkerPricing.Contract.GetMultipliers(&_BunkerPricing.CallOpts)
+}
+
+// GetPrices is a free data retrieval call binding the contract method 0xbd9a548b.
+//
+// Solidity: function getPrices() view returns((uint256,uint256,uint256,uint256,uint256,uint256) p)
+func (_BunkerPricing *BunkerPricingCaller) GetPrices(opts *bind.CallOpts) (BunkerPricingResourcePrices, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "getPrices")
+
+	if err != nil {
+		return *new(BunkerPricingResourcePrices), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerPricingResourcePrices)).(*BunkerPricingResourcePrices)
+
+	return out0, err
+
+}
+
+// GetPrices is a free data retrieval call binding the contract method 0xbd9a548b.
+//
+// Solidity: function getPrices() view returns((uint256,uint256,uint256,uint256,uint256,uint256) p)
+func (_BunkerPricing *BunkerPricingSession) GetPrices() (BunkerPricingResourcePrices, error) {
+	return _BunkerPricing.Contract.GetPrices(&_BunkerPricing.CallOpts)
+}
+
+// GetPrices is a free data retrieval call binding the contract method 0xbd9a548b.
+//
+// Solidity: function getPrices() view returns((uint256,uint256,uint256,uint256,uint256,uint256) p)
+func (_BunkerPricing *BunkerPricingCallerSession) GetPrices() (BunkerPricingResourcePrices, error) {
+	return _BunkerPricing.Contract.GetPrices(&_BunkerPricing.CallOpts)
+}
+
+// GetProviderPrices is a free data retrieval call binding the contract method 0x106859b6.
+//
+// Solidity: function getProviderPrices(address provider) view returns((uint256,uint256,uint256,uint256,bool) pp)
+func (_BunkerPricing *BunkerPricingCaller) GetProviderPrices(opts *bind.CallOpts, provider common.Address) (BunkerPricingProviderPricing, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "getProviderPrices", provider)
+
+	if err != nil {
+		return *new(BunkerPricingProviderPricing), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerPricingProviderPricing)).(*BunkerPricingProviderPricing)
+
+	return out0, err
+
+}
+
+// GetProviderPrices is a free data retrieval call binding the contract method 0x106859b6.
+//
+// Solidity: function getProviderPrices(address provider) view returns((uint256,uint256,uint256,uint256,bool) pp)
+func (_BunkerPricing *BunkerPricingSession) GetProviderPrices(provider common.Address) (BunkerPricingProviderPricing, error) {
+	return _BunkerPricing.Contract.GetProviderPrices(&_BunkerPricing.CallOpts, provider)
+}
+
+// GetProviderPrices is a free data retrieval call binding the contract method 0x106859b6.
+//
+// Solidity: function getProviderPrices(address provider) view returns((uint256,uint256,uint256,uint256,bool) pp)
+func (_BunkerPricing *BunkerPricingCallerSession) GetProviderPrices(provider common.Address) (BunkerPricingProviderPricing, error) {
+	return _BunkerPricing.Contract.GetProviderPrices(&_BunkerPricing.CallOpts, provider)
+}
+
+// GetTokenPrice is a free data retrieval call binding the contract method 0x4b94f50e.
+//
+// Solidity: function getTokenPrice() view returns(uint256 price, uint8 decimals_)
+func (_BunkerPricing *BunkerPricingCaller) GetTokenPrice(opts *bind.CallOpts) (struct {
+	Price    *big.Int
+	Decimals uint8
+}, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "getTokenPrice")
+
+	outstruct := new(struct {
+		Price    *big.Int
+		Decimals uint8
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Price = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Decimals = *abi.ConvertType(out[1], new(uint8)).(*uint8)
+
+	return *outstruct, err
+
+}
+
+// GetTokenPrice is a free data retrieval call binding the contract method 0x4b94f50e.
+//
+// Solidity: function getTokenPrice() view returns(uint256 price, uint8 decimals_)
+func (_BunkerPricing *BunkerPricingSession) GetTokenPrice() (struct {
+	Price    *big.Int
+	Decimals uint8
+}, error) {
+	return _BunkerPricing.Contract.GetTokenPrice(&_BunkerPricing.CallOpts)
+}
+
+// GetTokenPrice is a free data retrieval call binding the contract method 0x4b94f50e.
+//
+// Solidity: function getTokenPrice() view returns(uint256 price, uint8 decimals_)
+func (_BunkerPricing *BunkerPricingCallerSession) GetTokenPrice() (struct {
+	Price    *big.Int
+	Decimals uint8
+}, error) {
+	return _BunkerPricing.Contract.GetTokenPrice(&_BunkerPricing.CallOpts)
+}
+
+// MaxMultiplierBps is a free data retrieval call binding the contract method 0x97313841.
+//
+// Solidity: function maxMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCaller) MaxMultiplierBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "maxMultiplierBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MaxMultiplierBps is a free data retrieval call binding the contract method 0x97313841.
+//
+// Solidity: function maxMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingSession) MaxMultiplierBps() (*big.Int, error) {
+	return _BunkerPricing.Contract.MaxMultiplierBps(&_BunkerPricing.CallOpts)
+}
+
+// MaxMultiplierBps is a free data retrieval call binding the contract method 0x97313841.
+//
+// Solidity: function maxMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCallerSession) MaxMultiplierBps() (*big.Int, error) {
+	return _BunkerPricing.Contract.MaxMultiplierBps(&_BunkerPricing.CallOpts)
+}
+
+// MaxPriceMultiplierBps is a free data retrieval call binding the contract method 0xad2e64d0.
+//
+// Solidity: function maxPriceMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCaller) MaxPriceMultiplierBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "maxPriceMultiplierBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MaxPriceMultiplierBps is a free data retrieval call binding the contract method 0xad2e64d0.
+//
+// Solidity: function maxPriceMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingSession) MaxPriceMultiplierBps() (*big.Int, error) {
+	return _BunkerPricing.Contract.MaxPriceMultiplierBps(&_BunkerPricing.CallOpts)
+}
+
+// MaxPriceMultiplierBps is a free data retrieval call binding the contract method 0xad2e64d0.
+//
+// Solidity: function maxPriceMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCallerSession) MaxPriceMultiplierBps() (*big.Int, error) {
+	return _BunkerPricing.Contract.MaxPriceMultiplierBps(&_BunkerPricing.CallOpts)
+}
+
+// MaxStaleThreshold is a free data retrieval call binding the contract method 0x13594a90.
+//
+// Solidity: function maxStaleThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCaller) MaxStaleThreshold(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "maxStaleThreshold")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MaxStaleThreshold is a free data retrieval call binding the contract method 0x13594a90.
+//
+// Solidity: function maxStaleThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingSession) MaxStaleThreshold() (*big.Int, error) {
+	return _BunkerPricing.Contract.MaxStaleThreshold(&_BunkerPricing.CallOpts)
+}
+
+// MaxStaleThreshold is a free data retrieval call binding the contract method 0x13594a90.
+//
+// Solidity: function maxStaleThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCallerSession) MaxStaleThreshold() (*big.Int, error) {
+	return _BunkerPricing.Contract.MaxStaleThreshold(&_BunkerPricing.CallOpts)
+}
+
+// MinPriceMultiplierBps is a free data retrieval call binding the contract method 0xa8b80047.
+//
+// Solidity: function minPriceMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCaller) MinPriceMultiplierBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "minPriceMultiplierBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MinPriceMultiplierBps is a free data retrieval call binding the contract method 0xa8b80047.
+//
+// Solidity: function minPriceMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingSession) MinPriceMultiplierBps() (*big.Int, error) {
+	return _BunkerPricing.Contract.MinPriceMultiplierBps(&_BunkerPricing.CallOpts)
+}
+
+// MinPriceMultiplierBps is a free data retrieval call binding the contract method 0xa8b80047.
+//
+// Solidity: function minPriceMultiplierBps() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCallerSession) MinPriceMultiplierBps() (*big.Int, error) {
+	return _BunkerPricing.Contract.MinPriceMultiplierBps(&_BunkerPricing.CallOpts)
+}
+
+// MinStaleThreshold is a free data retrieval call binding the contract method 0x3165e9d3.
+//
+// Solidity: function minStaleThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCaller) MinStaleThreshold(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "minStaleThreshold")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MinStaleThreshold is a free data retrieval call binding the contract method 0x3165e9d3.
+//
+// Solidity: function minStaleThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingSession) MinStaleThreshold() (*big.Int, error) {
+	return _BunkerPricing.Contract.MinStaleThreshold(&_BunkerPricing.CallOpts)
+}
+
+// MinStaleThreshold is a free data retrieval call binding the contract method 0x3165e9d3.
+//
+// Solidity: function minStaleThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCallerSession) MinStaleThreshold() (*big.Int, error) {
+	return _BunkerPricing.Contract.MinStaleThreshold(&_BunkerPricing.CallOpts)
+}
+
+// Multipliers is a free data retrieval call binding the contract method 0x9d7d6667.
+//
+// Solidity: function multipliers() view returns(uint256 redundancy, uint256 tor, uint256 premiumSLA, uint256 spot)
+func (_BunkerPricing *BunkerPricingCaller) Multipliers(opts *bind.CallOpts) (struct {
+	Redundancy *big.Int
+	Tor        *big.Int
+	PremiumSLA *big.Int
+	Spot       *big.Int
+}, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "multipliers")
+
+	outstruct := new(struct {
+		Redundancy *big.Int
+		Tor        *big.Int
+		PremiumSLA *big.Int
+		Spot       *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Redundancy = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Tor = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.PremiumSLA = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.Spot = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// Multipliers is a free data retrieval call binding the contract method 0x9d7d6667.
+//
+// Solidity: function multipliers() view returns(uint256 redundancy, uint256 tor, uint256 premiumSLA, uint256 spot)
+func (_BunkerPricing *BunkerPricingSession) Multipliers() (struct {
+	Redundancy *big.Int
+	Tor        *big.Int
+	PremiumSLA *big.Int
+	Spot       *big.Int
+}, error) {
+	return _BunkerPricing.Contract.Multipliers(&_BunkerPricing.CallOpts)
+}
+
+// Multipliers is a free data retrieval call binding the contract method 0x9d7d6667.
+//
+// Solidity: function multipliers() view returns(uint256 redundancy, uint256 tor, uint256 premiumSLA, uint256 spot)
+func (_BunkerPricing *BunkerPricingCallerSession) Multipliers() (struct {
+	Redundancy *big.Int
+	Tor        *big.Int
+	PremiumSLA *big.Int
+	Spot       *big.Int
+}, error) {
+	return _BunkerPricing.Contract.Multipliers(&_BunkerPricing.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerPricing *BunkerPricingCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerPricing *BunkerPricingSession) Owner() (common.Address, error) {
+	return _BunkerPricing.Contract.Owner(&_BunkerPricing.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerPricing *BunkerPricingCallerSession) Owner() (common.Address, error) {
+	return _BunkerPricing.Contract.Owner(&_BunkerPricing.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerPricing *BunkerPricingCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerPricing *BunkerPricingSession) PendingOwner() (common.Address, error) {
+	return _BunkerPricing.Contract.PendingOwner(&_BunkerPricing.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerPricing *BunkerPricingCallerSession) PendingOwner() (common.Address, error) {
+	return _BunkerPricing.Contract.PendingOwner(&_BunkerPricing.CallOpts)
+}
+
+// PriceOracle is a free data retrieval call binding the contract method 0x2630c12f.
+//
+// Solidity: function priceOracle() view returns(address)
+func (_BunkerPricing *BunkerPricingCaller) PriceOracle(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "priceOracle")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PriceOracle is a free data retrieval call binding the contract method 0x2630c12f.
+//
+// Solidity: function priceOracle() view returns(address)
+func (_BunkerPricing *BunkerPricingSession) PriceOracle() (common.Address, error) {
+	return _BunkerPricing.Contract.PriceOracle(&_BunkerPricing.CallOpts)
+}
+
+// PriceOracle is a free data retrieval call binding the contract method 0x2630c12f.
+//
+// Solidity: function priceOracle() view returns(address)
+func (_BunkerPricing *BunkerPricingCallerSession) PriceOracle() (common.Address, error) {
+	return _BunkerPricing.Contract.PriceOracle(&_BunkerPricing.CallOpts)
+}
+
+// Prices is a free data retrieval call binding the contract method 0xd3419bf3.
+//
+// Solidity: function prices() view returns(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, uint256 gpuBasicPerHour, uint256 gpuPremiumPerHour)
+func (_BunkerPricing *BunkerPricingCaller) Prices(opts *bind.CallOpts) (struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	GpuBasicPerHour   *big.Int
+	GpuPremiumPerHour *big.Int
+}, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "prices")
+
+	outstruct := new(struct {
+		CpuPerCoreHour    *big.Int
+		MemoryPerGBHour   *big.Int
+		StoragePerGBMonth *big.Int
+		NetworkPerGB      *big.Int
+		GpuBasicPerHour   *big.Int
+		GpuPremiumPerHour *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.CpuPerCoreHour = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.MemoryPerGBHour = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StoragePerGBMonth = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.NetworkPerGB = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.GpuBasicPerHour = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+	outstruct.GpuPremiumPerHour = *abi.ConvertType(out[5], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// Prices is a free data retrieval call binding the contract method 0xd3419bf3.
+//
+// Solidity: function prices() view returns(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, uint256 gpuBasicPerHour, uint256 gpuPremiumPerHour)
+func (_BunkerPricing *BunkerPricingSession) Prices() (struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	GpuBasicPerHour   *big.Int
+	GpuPremiumPerHour *big.Int
+}, error) {
+	return _BunkerPricing.Contract.Prices(&_BunkerPricing.CallOpts)
+}
+
+// Prices is a free data retrieval call binding the contract method 0xd3419bf3.
+//
+// Solidity: function prices() view returns(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, uint256 gpuBasicPerHour, uint256 gpuPremiumPerHour)
+func (_BunkerPricing *BunkerPricingCallerSession) Prices() (struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	GpuBasicPerHour   *big.Int
+	GpuPremiumPerHour *big.Int
+}, error) {
+	return _BunkerPricing.Contract.Prices(&_BunkerPricing.CallOpts)
+}
+
+// ProviderPrices is a free data retrieval call binding the contract method 0x48595aad.
+//
+// Solidity: function providerPrices(address ) view returns(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, bool isSet)
+func (_BunkerPricing *BunkerPricingCaller) ProviderPrices(opts *bind.CallOpts, arg0 common.Address) (struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	IsSet             bool
+}, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "providerPrices", arg0)
+
+	outstruct := new(struct {
+		CpuPerCoreHour    *big.Int
+		MemoryPerGBHour   *big.Int
+		StoragePerGBMonth *big.Int
+		NetworkPerGB      *big.Int
+		IsSet             bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.CpuPerCoreHour = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.MemoryPerGBHour = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StoragePerGBMonth = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.NetworkPerGB = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.IsSet = *abi.ConvertType(out[4], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// ProviderPrices is a free data retrieval call binding the contract method 0x48595aad.
+//
+// Solidity: function providerPrices(address ) view returns(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, bool isSet)
+func (_BunkerPricing *BunkerPricingSession) ProviderPrices(arg0 common.Address) (struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	IsSet             bool
+}, error) {
+	return _BunkerPricing.Contract.ProviderPrices(&_BunkerPricing.CallOpts, arg0)
+}
+
+// ProviderPrices is a free data retrieval call binding the contract method 0x48595aad.
+//
+// Solidity: function providerPrices(address ) view returns(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, bool isSet)
+func (_BunkerPricing *BunkerPricingCallerSession) ProviderPrices(arg0 common.Address) (struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	IsSet             bool
+}, error) {
+	return _BunkerPricing.Contract.ProviderPrices(&_BunkerPricing.CallOpts, arg0)
+}
+
+// StalePriceThreshold is a free data retrieval call binding the contract method 0x08cb2210.
+//
+// Solidity: function stalePriceThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCaller) StalePriceThreshold(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "stalePriceThreshold")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// StalePriceThreshold is a free data retrieval call binding the contract method 0x08cb2210.
+//
+// Solidity: function stalePriceThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingSession) StalePriceThreshold() (*big.Int, error) {
+	return _BunkerPricing.Contract.StalePriceThreshold(&_BunkerPricing.CallOpts)
+}
+
+// StalePriceThreshold is a free data retrieval call binding the contract method 0x08cb2210.
+//
+// Solidity: function stalePriceThreshold() view returns(uint256)
+func (_BunkerPricing *BunkerPricingCallerSession) StalePriceThreshold() (*big.Int, error) {
+	return _BunkerPricing.Contract.StalePriceThreshold(&_BunkerPricing.CallOpts)
+}
+
+// UseOracleForPricing is a free data retrieval call binding the contract method 0xcadf8ac0.
+//
+// Solidity: function useOracleForPricing() view returns(bool)
+func (_BunkerPricing *BunkerPricingCaller) UseOracleForPricing(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _BunkerPricing.contract.Call(opts, &out, "useOracleForPricing")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// UseOracleForPricing is a free data retrieval call binding the contract method 0xcadf8ac0.
+//
+// Solidity: function useOracleForPricing() view returns(bool)
+func (_BunkerPricing *BunkerPricingSession) UseOracleForPricing() (bool, error) {
+	return _BunkerPricing.Contract.UseOracleForPricing(&_BunkerPricing.CallOpts)
+}
+
+// UseOracleForPricing is a free data retrieval call binding the contract method 0xcadf8ac0.
+//
+// Solidity: function useOracleForPricing() view returns(bool)
+func (_BunkerPricing *BunkerPricingCallerSession) UseOracleForPricing() (bool, error) {
+	return _BunkerPricing.Contract.UseOracleForPricing(&_BunkerPricing.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerPricing *BunkerPricingTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerPricing *BunkerPricingSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerPricing.Contract.AcceptOwnership(&_BunkerPricing.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerPricing.Contract.AcceptOwnership(&_BunkerPricing.TransactOpts)
+}
+
+// ClearProviderPrices is a paid mutator transaction binding the contract method 0x6152ee17.
+//
+// Solidity: function clearProviderPrices() returns()
+func (_BunkerPricing *BunkerPricingTransactor) ClearProviderPrices(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "clearProviderPrices")
+}
+
+// ClearProviderPrices is a paid mutator transaction binding the contract method 0x6152ee17.
+//
+// Solidity: function clearProviderPrices() returns()
+func (_BunkerPricing *BunkerPricingSession) ClearProviderPrices() (*types.Transaction, error) {
+	return _BunkerPricing.Contract.ClearProviderPrices(&_BunkerPricing.TransactOpts)
+}
+
+// ClearProviderPrices is a paid mutator transaction binding the contract method 0x6152ee17.
+//
+// Solidity: function clearProviderPrices() returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) ClearProviderPrices() (*types.Transaction, error) {
+	return _BunkerPricing.Contract.ClearProviderPrices(&_BunkerPricing.TransactOpts)
+}
+
+// EnableOraclePricing is a paid mutator transaction binding the contract method 0x827055f5.
+//
+// Solidity: function enableOraclePricing(bool enabled) returns()
+func (_BunkerPricing *BunkerPricingTransactor) EnableOraclePricing(opts *bind.TransactOpts, enabled bool) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "enableOraclePricing", enabled)
+}
+
+// EnableOraclePricing is a paid mutator transaction binding the contract method 0x827055f5.
+//
+// Solidity: function enableOraclePricing(bool enabled) returns()
+func (_BunkerPricing *BunkerPricingSession) EnableOraclePricing(enabled bool) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.EnableOraclePricing(&_BunkerPricing.TransactOpts, enabled)
+}
+
+// EnableOraclePricing is a paid mutator transaction binding the contract method 0x827055f5.
+//
+// Solidity: function enableOraclePricing(bool enabled) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) EnableOraclePricing(enabled bool) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.EnableOraclePricing(&_BunkerPricing.TransactOpts, enabled)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerPricing *BunkerPricingTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerPricing *BunkerPricingSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerPricing.Contract.RenounceOwnership(&_BunkerPricing.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerPricing.Contract.RenounceOwnership(&_BunkerPricing.TransactOpts)
+}
+
+// SetCPUPrice is a paid mutator transaction binding the contract method 0xd20bb1d3.
+//
+// Solidity: function setCPUPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetCPUPrice(opts *bind.TransactOpts, newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setCPUPrice", newPrice)
+}
+
+// SetCPUPrice is a paid mutator transaction binding the contract method 0xd20bb1d3.
+//
+// Solidity: function setCPUPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingSession) SetCPUPrice(newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetCPUPrice(&_BunkerPricing.TransactOpts, newPrice)
+}
+
+// SetCPUPrice is a paid mutator transaction binding the contract method 0xd20bb1d3.
+//
+// Solidity: function setCPUPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetCPUPrice(newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetCPUPrice(&_BunkerPricing.TransactOpts, newPrice)
+}
+
+// SetGPUPrices is a paid mutator transaction binding the contract method 0xac2cc61e.
+//
+// Solidity: function setGPUPrices(uint256 basicPerHour, uint256 premiumPerHour) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetGPUPrices(opts *bind.TransactOpts, basicPerHour *big.Int, premiumPerHour *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setGPUPrices", basicPerHour, premiumPerHour)
+}
+
+// SetGPUPrices is a paid mutator transaction binding the contract method 0xac2cc61e.
+//
+// Solidity: function setGPUPrices(uint256 basicPerHour, uint256 premiumPerHour) returns()
+func (_BunkerPricing *BunkerPricingSession) SetGPUPrices(basicPerHour *big.Int, premiumPerHour *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetGPUPrices(&_BunkerPricing.TransactOpts, basicPerHour, premiumPerHour)
+}
+
+// SetGPUPrices is a paid mutator transaction binding the contract method 0xac2cc61e.
+//
+// Solidity: function setGPUPrices(uint256 basicPerHour, uint256 premiumPerHour) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetGPUPrices(basicPerHour *big.Int, premiumPerHour *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetGPUPrices(&_BunkerPricing.TransactOpts, basicPerHour, premiumPerHour)
+}
+
+// SetMaxMultiplierBps is a paid mutator transaction binding the contract method 0x1f403947.
+//
+// Solidity: function setMaxMultiplierBps(uint256 newMax) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetMaxMultiplierBps(opts *bind.TransactOpts, newMax *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setMaxMultiplierBps", newMax)
+}
+
+// SetMaxMultiplierBps is a paid mutator transaction binding the contract method 0x1f403947.
+//
+// Solidity: function setMaxMultiplierBps(uint256 newMax) returns()
+func (_BunkerPricing *BunkerPricingSession) SetMaxMultiplierBps(newMax *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetMaxMultiplierBps(&_BunkerPricing.TransactOpts, newMax)
+}
+
+// SetMaxMultiplierBps is a paid mutator transaction binding the contract method 0x1f403947.
+//
+// Solidity: function setMaxMultiplierBps(uint256 newMax) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetMaxMultiplierBps(newMax *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetMaxMultiplierBps(&_BunkerPricing.TransactOpts, newMax)
+}
+
+// SetMemoryPrice is a paid mutator transaction binding the contract method 0x65b1b3ef.
+//
+// Solidity: function setMemoryPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetMemoryPrice(opts *bind.TransactOpts, newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setMemoryPrice", newPrice)
+}
+
+// SetMemoryPrice is a paid mutator transaction binding the contract method 0x65b1b3ef.
+//
+// Solidity: function setMemoryPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingSession) SetMemoryPrice(newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetMemoryPrice(&_BunkerPricing.TransactOpts, newPrice)
+}
+
+// SetMemoryPrice is a paid mutator transaction binding the contract method 0x65b1b3ef.
+//
+// Solidity: function setMemoryPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetMemoryPrice(newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetMemoryPrice(&_BunkerPricing.TransactOpts, newPrice)
+}
+
+// SetMultipliers is a paid mutator transaction binding the contract method 0xee02c360.
+//
+// Solidity: function setMultipliers((uint256,uint256,uint256,uint256) newMultipliers) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetMultipliers(opts *bind.TransactOpts, newMultipliers BunkerPricingMultipliers) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setMultipliers", newMultipliers)
+}
+
+// SetMultipliers is a paid mutator transaction binding the contract method 0xee02c360.
+//
+// Solidity: function setMultipliers((uint256,uint256,uint256,uint256) newMultipliers) returns()
+func (_BunkerPricing *BunkerPricingSession) SetMultipliers(newMultipliers BunkerPricingMultipliers) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetMultipliers(&_BunkerPricing.TransactOpts, newMultipliers)
+}
+
+// SetMultipliers is a paid mutator transaction binding the contract method 0xee02c360.
+//
+// Solidity: function setMultipliers((uint256,uint256,uint256,uint256) newMultipliers) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetMultipliers(newMultipliers BunkerPricingMultipliers) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetMultipliers(&_BunkerPricing.TransactOpts, newMultipliers)
+}
+
+// SetNetworkPrice is a paid mutator transaction binding the contract method 0xd2c5ed86.
+//
+// Solidity: function setNetworkPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetNetworkPrice(opts *bind.TransactOpts, newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setNetworkPrice", newPrice)
+}
+
+// SetNetworkPrice is a paid mutator transaction binding the contract method 0xd2c5ed86.
+//
+// Solidity: function setNetworkPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingSession) SetNetworkPrice(newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetNetworkPrice(&_BunkerPricing.TransactOpts, newPrice)
+}
+
+// SetNetworkPrice is a paid mutator transaction binding the contract method 0xd2c5ed86.
+//
+// Solidity: function setNetworkPrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetNetworkPrice(newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetNetworkPrice(&_BunkerPricing.TransactOpts, newPrice)
+}
+
+// SetPriceOracle is a paid mutator transaction binding the contract method 0x530e784f.
+//
+// Solidity: function setPriceOracle(address newOracle) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetPriceOracle(opts *bind.TransactOpts, newOracle common.Address) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setPriceOracle", newOracle)
+}
+
+// SetPriceOracle is a paid mutator transaction binding the contract method 0x530e784f.
+//
+// Solidity: function setPriceOracle(address newOracle) returns()
+func (_BunkerPricing *BunkerPricingSession) SetPriceOracle(newOracle common.Address) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetPriceOracle(&_BunkerPricing.TransactOpts, newOracle)
+}
+
+// SetPriceOracle is a paid mutator transaction binding the contract method 0x530e784f.
+//
+// Solidity: function setPriceOracle(address newOracle) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetPriceOracle(newOracle common.Address) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetPriceOracle(&_BunkerPricing.TransactOpts, newOracle)
+}
+
+// SetPrices is a paid mutator transaction binding the contract method 0x03d4b7c1.
+//
+// Solidity: function setPrices((uint256,uint256,uint256,uint256,uint256,uint256) newPrices) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetPrices(opts *bind.TransactOpts, newPrices BunkerPricingResourcePrices) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setPrices", newPrices)
+}
+
+// SetPrices is a paid mutator transaction binding the contract method 0x03d4b7c1.
+//
+// Solidity: function setPrices((uint256,uint256,uint256,uint256,uint256,uint256) newPrices) returns()
+func (_BunkerPricing *BunkerPricingSession) SetPrices(newPrices BunkerPricingResourcePrices) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetPrices(&_BunkerPricing.TransactOpts, newPrices)
+}
+
+// SetPrices is a paid mutator transaction binding the contract method 0x03d4b7c1.
+//
+// Solidity: function setPrices((uint256,uint256,uint256,uint256,uint256,uint256) newPrices) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetPrices(newPrices BunkerPricingResourcePrices) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetPrices(&_BunkerPricing.TransactOpts, newPrices)
+}
+
+// SetProviderPriceBounds is a paid mutator transaction binding the contract method 0xaa1328f1.
+//
+// Solidity: function setProviderPriceBounds(uint256 minBps, uint256 maxBps) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetProviderPriceBounds(opts *bind.TransactOpts, minBps *big.Int, maxBps *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setProviderPriceBounds", minBps, maxBps)
+}
+
+// SetProviderPriceBounds is a paid mutator transaction binding the contract method 0xaa1328f1.
+//
+// Solidity: function setProviderPriceBounds(uint256 minBps, uint256 maxBps) returns()
+func (_BunkerPricing *BunkerPricingSession) SetProviderPriceBounds(minBps *big.Int, maxBps *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetProviderPriceBounds(&_BunkerPricing.TransactOpts, minBps, maxBps)
+}
+
+// SetProviderPriceBounds is a paid mutator transaction binding the contract method 0xaa1328f1.
+//
+// Solidity: function setProviderPriceBounds(uint256 minBps, uint256 maxBps) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetProviderPriceBounds(minBps *big.Int, maxBps *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetProviderPriceBounds(&_BunkerPricing.TransactOpts, minBps, maxBps)
+}
+
+// SetProviderPrices is a paid mutator transaction binding the contract method 0x5efb84df.
+//
+// Solidity: function setProviderPrices((uint256,uint256,uint256,uint256,bool) pp) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetProviderPrices(opts *bind.TransactOpts, pp BunkerPricingProviderPricing) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setProviderPrices", pp)
+}
+
+// SetProviderPrices is a paid mutator transaction binding the contract method 0x5efb84df.
+//
+// Solidity: function setProviderPrices((uint256,uint256,uint256,uint256,bool) pp) returns()
+func (_BunkerPricing *BunkerPricingSession) SetProviderPrices(pp BunkerPricingProviderPricing) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetProviderPrices(&_BunkerPricing.TransactOpts, pp)
+}
+
+// SetProviderPrices is a paid mutator transaction binding the contract method 0x5efb84df.
+//
+// Solidity: function setProviderPrices((uint256,uint256,uint256,uint256,bool) pp) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetProviderPrices(pp BunkerPricingProviderPricing) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetProviderPrices(&_BunkerPricing.TransactOpts, pp)
+}
+
+// SetStalePriceThreshold is a paid mutator transaction binding the contract method 0x2599af34.
+//
+// Solidity: function setStalePriceThreshold(uint256 newThreshold) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetStalePriceThreshold(opts *bind.TransactOpts, newThreshold *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setStalePriceThreshold", newThreshold)
+}
+
+// SetStalePriceThreshold is a paid mutator transaction binding the contract method 0x2599af34.
+//
+// Solidity: function setStalePriceThreshold(uint256 newThreshold) returns()
+func (_BunkerPricing *BunkerPricingSession) SetStalePriceThreshold(newThreshold *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetStalePriceThreshold(&_BunkerPricing.TransactOpts, newThreshold)
+}
+
+// SetStalePriceThreshold is a paid mutator transaction binding the contract method 0x2599af34.
+//
+// Solidity: function setStalePriceThreshold(uint256 newThreshold) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetStalePriceThreshold(newThreshold *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetStalePriceThreshold(&_BunkerPricing.TransactOpts, newThreshold)
+}
+
+// SetStaleThresholdBounds is a paid mutator transaction binding the contract method 0x2ac310a3.
+//
+// Solidity: function setStaleThresholdBounds(uint256 newMin, uint256 newMax) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetStaleThresholdBounds(opts *bind.TransactOpts, newMin *big.Int, newMax *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setStaleThresholdBounds", newMin, newMax)
+}
+
+// SetStaleThresholdBounds is a paid mutator transaction binding the contract method 0x2ac310a3.
+//
+// Solidity: function setStaleThresholdBounds(uint256 newMin, uint256 newMax) returns()
+func (_BunkerPricing *BunkerPricingSession) SetStaleThresholdBounds(newMin *big.Int, newMax *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetStaleThresholdBounds(&_BunkerPricing.TransactOpts, newMin, newMax)
+}
+
+// SetStaleThresholdBounds is a paid mutator transaction binding the contract method 0x2ac310a3.
+//
+// Solidity: function setStaleThresholdBounds(uint256 newMin, uint256 newMax) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetStaleThresholdBounds(newMin *big.Int, newMax *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetStaleThresholdBounds(&_BunkerPricing.TransactOpts, newMin, newMax)
+}
+
+// SetStoragePrice is a paid mutator transaction binding the contract method 0x6e838911.
+//
+// Solidity: function setStoragePrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingTransactor) SetStoragePrice(opts *bind.TransactOpts, newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "setStoragePrice", newPrice)
+}
+
+// SetStoragePrice is a paid mutator transaction binding the contract method 0x6e838911.
+//
+// Solidity: function setStoragePrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingSession) SetStoragePrice(newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetStoragePrice(&_BunkerPricing.TransactOpts, newPrice)
+}
+
+// SetStoragePrice is a paid mutator transaction binding the contract method 0x6e838911.
+//
+// Solidity: function setStoragePrice(uint256 newPrice) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) SetStoragePrice(newPrice *big.Int) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.SetStoragePrice(&_BunkerPricing.TransactOpts, newPrice)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerPricing *BunkerPricingTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerPricing.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerPricing *BunkerPricingSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.TransferOwnership(&_BunkerPricing.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerPricing *BunkerPricingTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerPricing.Contract.TransferOwnership(&_BunkerPricing.TransactOpts, newOwner)
+}
+
+// BunkerPricingMaxMultiplierUpdatedIterator is returned from FilterMaxMultiplierUpdated and is used to iterate over the raw logs and unpacked data for MaxMultiplierUpdated events raised by the BunkerPricing contract.
+type BunkerPricingMaxMultiplierUpdatedIterator struct {
+	Event *BunkerPricingMaxMultiplierUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingMaxMultiplierUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingMaxMultiplierUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingMaxMultiplierUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingMaxMultiplierUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingMaxMultiplierUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingMaxMultiplierUpdated represents a MaxMultiplierUpdated event raised by the BunkerPricing contract.
+type BunkerPricingMaxMultiplierUpdated struct {
+	NewMax *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterMaxMultiplierUpdated is a free log retrieval operation binding the contract event 0xc1ba18bc88cda71f03136908dce4e1a2319aeed38972c3c1a6a470f2d87a7432.
+//
+// Solidity: event MaxMultiplierUpdated(uint256 newMax)
+func (_BunkerPricing *BunkerPricingFilterer) FilterMaxMultiplierUpdated(opts *bind.FilterOpts) (*BunkerPricingMaxMultiplierUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "MaxMultiplierUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingMaxMultiplierUpdatedIterator{contract: _BunkerPricing.contract, event: "MaxMultiplierUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMaxMultiplierUpdated is a free log subscription operation binding the contract event 0xc1ba18bc88cda71f03136908dce4e1a2319aeed38972c3c1a6a470f2d87a7432.
+//
+// Solidity: event MaxMultiplierUpdated(uint256 newMax)
+func (_BunkerPricing *BunkerPricingFilterer) WatchMaxMultiplierUpdated(opts *bind.WatchOpts, sink chan<- *BunkerPricingMaxMultiplierUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "MaxMultiplierUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingMaxMultiplierUpdated)
+				if err := _BunkerPricing.contract.UnpackLog(event, "MaxMultiplierUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMaxMultiplierUpdated is a log parse operation binding the contract event 0xc1ba18bc88cda71f03136908dce4e1a2319aeed38972c3c1a6a470f2d87a7432.
+//
+// Solidity: event MaxMultiplierUpdated(uint256 newMax)
+func (_BunkerPricing *BunkerPricingFilterer) ParseMaxMultiplierUpdated(log types.Log) (*BunkerPricingMaxMultiplierUpdated, error) {
+	event := new(BunkerPricingMaxMultiplierUpdated)
+	if err := _BunkerPricing.contract.UnpackLog(event, "MaxMultiplierUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingMultipliersUpdatedIterator is returned from FilterMultipliersUpdated and is used to iterate over the raw logs and unpacked data for MultipliersUpdated events raised by the BunkerPricing contract.
+type BunkerPricingMultipliersUpdatedIterator struct {
+	Event *BunkerPricingMultipliersUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingMultipliersUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingMultipliersUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingMultipliersUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingMultipliersUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingMultipliersUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingMultipliersUpdated represents a MultipliersUpdated event raised by the BunkerPricing contract.
+type BunkerPricingMultipliersUpdated struct {
+	Redundancy *big.Int
+	Tor        *big.Int
+	PremiumSLA *big.Int
+	Spot       *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterMultipliersUpdated is a free log retrieval operation binding the contract event 0x0d49a1e5ea8841770dfddfd4823e83d41b1f8f573baf50150c7455986f5033c1.
+//
+// Solidity: event MultipliersUpdated(uint256 redundancy, uint256 tor, uint256 premiumSLA, uint256 spot)
+func (_BunkerPricing *BunkerPricingFilterer) FilterMultipliersUpdated(opts *bind.FilterOpts) (*BunkerPricingMultipliersUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "MultipliersUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingMultipliersUpdatedIterator{contract: _BunkerPricing.contract, event: "MultipliersUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMultipliersUpdated is a free log subscription operation binding the contract event 0x0d49a1e5ea8841770dfddfd4823e83d41b1f8f573baf50150c7455986f5033c1.
+//
+// Solidity: event MultipliersUpdated(uint256 redundancy, uint256 tor, uint256 premiumSLA, uint256 spot)
+func (_BunkerPricing *BunkerPricingFilterer) WatchMultipliersUpdated(opts *bind.WatchOpts, sink chan<- *BunkerPricingMultipliersUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "MultipliersUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingMultipliersUpdated)
+				if err := _BunkerPricing.contract.UnpackLog(event, "MultipliersUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMultipliersUpdated is a log parse operation binding the contract event 0x0d49a1e5ea8841770dfddfd4823e83d41b1f8f573baf50150c7455986f5033c1.
+//
+// Solidity: event MultipliersUpdated(uint256 redundancy, uint256 tor, uint256 premiumSLA, uint256 spot)
+func (_BunkerPricing *BunkerPricingFilterer) ParseMultipliersUpdated(log types.Log) (*BunkerPricingMultipliersUpdated, error) {
+	event := new(BunkerPricingMultipliersUpdated)
+	if err := _BunkerPricing.contract.UnpackLog(event, "MultipliersUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingOraclePricingEnabledIterator is returned from FilterOraclePricingEnabled and is used to iterate over the raw logs and unpacked data for OraclePricingEnabled events raised by the BunkerPricing contract.
+type BunkerPricingOraclePricingEnabledIterator struct {
+	Event *BunkerPricingOraclePricingEnabled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingOraclePricingEnabledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingOraclePricingEnabled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingOraclePricingEnabled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingOraclePricingEnabledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingOraclePricingEnabledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingOraclePricingEnabled represents a OraclePricingEnabled event raised by the BunkerPricing contract.
+type BunkerPricingOraclePricingEnabled struct {
+	Enabled bool
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterOraclePricingEnabled is a free log retrieval operation binding the contract event 0xfceaa4c758e5decf6cc9a516d36edad4529d05d7f343a5e589b1ed36ee49991f.
+//
+// Solidity: event OraclePricingEnabled(bool enabled)
+func (_BunkerPricing *BunkerPricingFilterer) FilterOraclePricingEnabled(opts *bind.FilterOpts) (*BunkerPricingOraclePricingEnabledIterator, error) {
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "OraclePricingEnabled")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingOraclePricingEnabledIterator{contract: _BunkerPricing.contract, event: "OraclePricingEnabled", logs: logs, sub: sub}, nil
+}
+
+// WatchOraclePricingEnabled is a free log subscription operation binding the contract event 0xfceaa4c758e5decf6cc9a516d36edad4529d05d7f343a5e589b1ed36ee49991f.
+//
+// Solidity: event OraclePricingEnabled(bool enabled)
+func (_BunkerPricing *BunkerPricingFilterer) WatchOraclePricingEnabled(opts *bind.WatchOpts, sink chan<- *BunkerPricingOraclePricingEnabled) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "OraclePricingEnabled")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingOraclePricingEnabled)
+				if err := _BunkerPricing.contract.UnpackLog(event, "OraclePricingEnabled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOraclePricingEnabled is a log parse operation binding the contract event 0xfceaa4c758e5decf6cc9a516d36edad4529d05d7f343a5e589b1ed36ee49991f.
+//
+// Solidity: event OraclePricingEnabled(bool enabled)
+func (_BunkerPricing *BunkerPricingFilterer) ParseOraclePricingEnabled(log types.Log) (*BunkerPricingOraclePricingEnabled, error) {
+	event := new(BunkerPricingOraclePricingEnabled)
+	if err := _BunkerPricing.contract.UnpackLog(event, "OraclePricingEnabled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the BunkerPricing contract.
+type BunkerPricingOwnershipTransferStartedIterator struct {
+	Event *BunkerPricingOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the BunkerPricing contract.
+type BunkerPricingOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerPricing *BunkerPricingFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerPricingOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingOwnershipTransferStartedIterator{contract: _BunkerPricing.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerPricing *BunkerPricingFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BunkerPricingOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingOwnershipTransferStarted)
+				if err := _BunkerPricing.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerPricing *BunkerPricingFilterer) ParseOwnershipTransferStarted(log types.Log) (*BunkerPricingOwnershipTransferStarted, error) {
+	event := new(BunkerPricingOwnershipTransferStarted)
+	if err := _BunkerPricing.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BunkerPricing contract.
+type BunkerPricingOwnershipTransferredIterator struct {
+	Event *BunkerPricingOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingOwnershipTransferred represents a OwnershipTransferred event raised by the BunkerPricing contract.
+type BunkerPricingOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerPricing *BunkerPricingFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerPricingOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingOwnershipTransferredIterator{contract: _BunkerPricing.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerPricing *BunkerPricingFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BunkerPricingOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingOwnershipTransferred)
+				if err := _BunkerPricing.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerPricing *BunkerPricingFilterer) ParseOwnershipTransferred(log types.Log) (*BunkerPricingOwnershipTransferred, error) {
+	event := new(BunkerPricingOwnershipTransferred)
+	if err := _BunkerPricing.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingPriceOracleUpdatedIterator is returned from FilterPriceOracleUpdated and is used to iterate over the raw logs and unpacked data for PriceOracleUpdated events raised by the BunkerPricing contract.
+type BunkerPricingPriceOracleUpdatedIterator struct {
+	Event *BunkerPricingPriceOracleUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingPriceOracleUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingPriceOracleUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingPriceOracleUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingPriceOracleUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingPriceOracleUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingPriceOracleUpdated represents a PriceOracleUpdated event raised by the BunkerPricing contract.
+type BunkerPricingPriceOracleUpdated struct {
+	OldOracle common.Address
+	NewOracle common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterPriceOracleUpdated is a free log retrieval operation binding the contract event 0x56b5f80d8cac1479698aa7d01605fd6111e90b15fc4d2b377417f46034876cbd.
+//
+// Solidity: event PriceOracleUpdated(address indexed oldOracle, address indexed newOracle)
+func (_BunkerPricing *BunkerPricingFilterer) FilterPriceOracleUpdated(opts *bind.FilterOpts, oldOracle []common.Address, newOracle []common.Address) (*BunkerPricingPriceOracleUpdatedIterator, error) {
+
+	var oldOracleRule []interface{}
+	for _, oldOracleItem := range oldOracle {
+		oldOracleRule = append(oldOracleRule, oldOracleItem)
+	}
+	var newOracleRule []interface{}
+	for _, newOracleItem := range newOracle {
+		newOracleRule = append(newOracleRule, newOracleItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "PriceOracleUpdated", oldOracleRule, newOracleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingPriceOracleUpdatedIterator{contract: _BunkerPricing.contract, event: "PriceOracleUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchPriceOracleUpdated is a free log subscription operation binding the contract event 0x56b5f80d8cac1479698aa7d01605fd6111e90b15fc4d2b377417f46034876cbd.
+//
+// Solidity: event PriceOracleUpdated(address indexed oldOracle, address indexed newOracle)
+func (_BunkerPricing *BunkerPricingFilterer) WatchPriceOracleUpdated(opts *bind.WatchOpts, sink chan<- *BunkerPricingPriceOracleUpdated, oldOracle []common.Address, newOracle []common.Address) (event.Subscription, error) {
+
+	var oldOracleRule []interface{}
+	for _, oldOracleItem := range oldOracle {
+		oldOracleRule = append(oldOracleRule, oldOracleItem)
+	}
+	var newOracleRule []interface{}
+	for _, newOracleItem := range newOracle {
+		newOracleRule = append(newOracleRule, newOracleItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "PriceOracleUpdated", oldOracleRule, newOracleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingPriceOracleUpdated)
+				if err := _BunkerPricing.contract.UnpackLog(event, "PriceOracleUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePriceOracleUpdated is a log parse operation binding the contract event 0x56b5f80d8cac1479698aa7d01605fd6111e90b15fc4d2b377417f46034876cbd.
+//
+// Solidity: event PriceOracleUpdated(address indexed oldOracle, address indexed newOracle)
+func (_BunkerPricing *BunkerPricingFilterer) ParsePriceOracleUpdated(log types.Log) (*BunkerPricingPriceOracleUpdated, error) {
+	event := new(BunkerPricingPriceOracleUpdated)
+	if err := _BunkerPricing.contract.UnpackLog(event, "PriceOracleUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingPricesUpdatedIterator is returned from FilterPricesUpdated and is used to iterate over the raw logs and unpacked data for PricesUpdated events raised by the BunkerPricing contract.
+type BunkerPricingPricesUpdatedIterator struct {
+	Event *BunkerPricingPricesUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingPricesUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingPricesUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingPricesUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingPricesUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingPricesUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingPricesUpdated represents a PricesUpdated event raised by the BunkerPricing contract.
+type BunkerPricingPricesUpdated struct {
+	CpuPerCoreHour    *big.Int
+	MemoryPerGBHour   *big.Int
+	StoragePerGBMonth *big.Int
+	NetworkPerGB      *big.Int
+	GpuBasicPerHour   *big.Int
+	GpuPremiumPerHour *big.Int
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterPricesUpdated is a free log retrieval operation binding the contract event 0xc73ec39986e464014d46dae8bdefb70d710adbcc1c342b49333817b40f4ab525.
+//
+// Solidity: event PricesUpdated(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, uint256 gpuBasicPerHour, uint256 gpuPremiumPerHour)
+func (_BunkerPricing *BunkerPricingFilterer) FilterPricesUpdated(opts *bind.FilterOpts) (*BunkerPricingPricesUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "PricesUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingPricesUpdatedIterator{contract: _BunkerPricing.contract, event: "PricesUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchPricesUpdated is a free log subscription operation binding the contract event 0xc73ec39986e464014d46dae8bdefb70d710adbcc1c342b49333817b40f4ab525.
+//
+// Solidity: event PricesUpdated(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, uint256 gpuBasicPerHour, uint256 gpuPremiumPerHour)
+func (_BunkerPricing *BunkerPricingFilterer) WatchPricesUpdated(opts *bind.WatchOpts, sink chan<- *BunkerPricingPricesUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "PricesUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingPricesUpdated)
+				if err := _BunkerPricing.contract.UnpackLog(event, "PricesUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePricesUpdated is a log parse operation binding the contract event 0xc73ec39986e464014d46dae8bdefb70d710adbcc1c342b49333817b40f4ab525.
+//
+// Solidity: event PricesUpdated(uint256 cpuPerCoreHour, uint256 memoryPerGBHour, uint256 storagePerGBMonth, uint256 networkPerGB, uint256 gpuBasicPerHour, uint256 gpuPremiumPerHour)
+func (_BunkerPricing *BunkerPricingFilterer) ParsePricesUpdated(log types.Log) (*BunkerPricingPricesUpdated, error) {
+	event := new(BunkerPricingPricesUpdated)
+	if err := _BunkerPricing.contract.UnpackLog(event, "PricesUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingProviderPriceBoundsUpdatedIterator is returned from FilterProviderPriceBoundsUpdated and is used to iterate over the raw logs and unpacked data for ProviderPriceBoundsUpdated events raised by the BunkerPricing contract.
+type BunkerPricingProviderPriceBoundsUpdatedIterator struct {
+	Event *BunkerPricingProviderPriceBoundsUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingProviderPriceBoundsUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingProviderPriceBoundsUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingProviderPriceBoundsUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingProviderPriceBoundsUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingProviderPriceBoundsUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingProviderPriceBoundsUpdated represents a ProviderPriceBoundsUpdated event raised by the BunkerPricing contract.
+type BunkerPricingProviderPriceBoundsUpdated struct {
+	MinBps *big.Int
+	MaxBps *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderPriceBoundsUpdated is a free log retrieval operation binding the contract event 0x6d6efa34d855535fa7f3ce1ee66a59c789265ead9418832223c17979816badb8.
+//
+// Solidity: event ProviderPriceBoundsUpdated(uint256 minBps, uint256 maxBps)
+func (_BunkerPricing *BunkerPricingFilterer) FilterProviderPriceBoundsUpdated(opts *bind.FilterOpts) (*BunkerPricingProviderPriceBoundsUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "ProviderPriceBoundsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingProviderPriceBoundsUpdatedIterator{contract: _BunkerPricing.contract, event: "ProviderPriceBoundsUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderPriceBoundsUpdated is a free log subscription operation binding the contract event 0x6d6efa34d855535fa7f3ce1ee66a59c789265ead9418832223c17979816badb8.
+//
+// Solidity: event ProviderPriceBoundsUpdated(uint256 minBps, uint256 maxBps)
+func (_BunkerPricing *BunkerPricingFilterer) WatchProviderPriceBoundsUpdated(opts *bind.WatchOpts, sink chan<- *BunkerPricingProviderPriceBoundsUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "ProviderPriceBoundsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingProviderPriceBoundsUpdated)
+				if err := _BunkerPricing.contract.UnpackLog(event, "ProviderPriceBoundsUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderPriceBoundsUpdated is a log parse operation binding the contract event 0x6d6efa34d855535fa7f3ce1ee66a59c789265ead9418832223c17979816badb8.
+//
+// Solidity: event ProviderPriceBoundsUpdated(uint256 minBps, uint256 maxBps)
+func (_BunkerPricing *BunkerPricingFilterer) ParseProviderPriceBoundsUpdated(log types.Log) (*BunkerPricingProviderPriceBoundsUpdated, error) {
+	event := new(BunkerPricingProviderPriceBoundsUpdated)
+	if err := _BunkerPricing.contract.UnpackLog(event, "ProviderPriceBoundsUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingProviderPricesClearedIterator is returned from FilterProviderPricesCleared and is used to iterate over the raw logs and unpacked data for ProviderPricesCleared events raised by the BunkerPricing contract.
+type BunkerPricingProviderPricesClearedIterator struct {
+	Event *BunkerPricingProviderPricesCleared // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingProviderPricesClearedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingProviderPricesCleared)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingProviderPricesCleared)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingProviderPricesClearedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingProviderPricesClearedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingProviderPricesCleared represents a ProviderPricesCleared event raised by the BunkerPricing contract.
+type BunkerPricingProviderPricesCleared struct {
+	Provider common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderPricesCleared is a free log retrieval operation binding the contract event 0xe71ed8b6608cadd98920dbe666b4ed5a79bbe13107ca2685bda11eabc73aef06.
+//
+// Solidity: event ProviderPricesCleared(address indexed provider)
+func (_BunkerPricing *BunkerPricingFilterer) FilterProviderPricesCleared(opts *bind.FilterOpts, provider []common.Address) (*BunkerPricingProviderPricesClearedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "ProviderPricesCleared", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingProviderPricesClearedIterator{contract: _BunkerPricing.contract, event: "ProviderPricesCleared", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderPricesCleared is a free log subscription operation binding the contract event 0xe71ed8b6608cadd98920dbe666b4ed5a79bbe13107ca2685bda11eabc73aef06.
+//
+// Solidity: event ProviderPricesCleared(address indexed provider)
+func (_BunkerPricing *BunkerPricingFilterer) WatchProviderPricesCleared(opts *bind.WatchOpts, sink chan<- *BunkerPricingProviderPricesCleared, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "ProviderPricesCleared", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingProviderPricesCleared)
+				if err := _BunkerPricing.contract.UnpackLog(event, "ProviderPricesCleared", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderPricesCleared is a log parse operation binding the contract event 0xe71ed8b6608cadd98920dbe666b4ed5a79bbe13107ca2685bda11eabc73aef06.
+//
+// Solidity: event ProviderPricesCleared(address indexed provider)
+func (_BunkerPricing *BunkerPricingFilterer) ParseProviderPricesCleared(log types.Log) (*BunkerPricingProviderPricesCleared, error) {
+	event := new(BunkerPricingProviderPricesCleared)
+	if err := _BunkerPricing.contract.UnpackLog(event, "ProviderPricesCleared", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingProviderPricesSetIterator is returned from FilterProviderPricesSet and is used to iterate over the raw logs and unpacked data for ProviderPricesSet events raised by the BunkerPricing contract.
+type BunkerPricingProviderPricesSetIterator struct {
+	Event *BunkerPricingProviderPricesSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingProviderPricesSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingProviderPricesSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingProviderPricesSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingProviderPricesSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingProviderPricesSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingProviderPricesSet represents a ProviderPricesSet event raised by the BunkerPricing contract.
+type BunkerPricingProviderPricesSet struct {
+	Provider common.Address
+	Cpu      *big.Int
+	Memory   *big.Int
+	Storage  *big.Int
+	Network  *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderPricesSet is a free log retrieval operation binding the contract event 0xa1dab754312a0c4e3f91ed4dc76f7d8467b9e0405c1531fc59049da78aabef80.
+//
+// Solidity: event ProviderPricesSet(address indexed provider, uint256 cpu, uint256 memory_, uint256 storage_, uint256 network)
+func (_BunkerPricing *BunkerPricingFilterer) FilterProviderPricesSet(opts *bind.FilterOpts, provider []common.Address) (*BunkerPricingProviderPricesSetIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "ProviderPricesSet", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingProviderPricesSetIterator{contract: _BunkerPricing.contract, event: "ProviderPricesSet", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderPricesSet is a free log subscription operation binding the contract event 0xa1dab754312a0c4e3f91ed4dc76f7d8467b9e0405c1531fc59049da78aabef80.
+//
+// Solidity: event ProviderPricesSet(address indexed provider, uint256 cpu, uint256 memory_, uint256 storage_, uint256 network)
+func (_BunkerPricing *BunkerPricingFilterer) WatchProviderPricesSet(opts *bind.WatchOpts, sink chan<- *BunkerPricingProviderPricesSet, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "ProviderPricesSet", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingProviderPricesSet)
+				if err := _BunkerPricing.contract.UnpackLog(event, "ProviderPricesSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderPricesSet is a log parse operation binding the contract event 0xa1dab754312a0c4e3f91ed4dc76f7d8467b9e0405c1531fc59049da78aabef80.
+//
+// Solidity: event ProviderPricesSet(address indexed provider, uint256 cpu, uint256 memory_, uint256 storage_, uint256 network)
+func (_BunkerPricing *BunkerPricingFilterer) ParseProviderPricesSet(log types.Log) (*BunkerPricingProviderPricesSet, error) {
+	event := new(BunkerPricingProviderPricesSet)
+	if err := _BunkerPricing.contract.UnpackLog(event, "ProviderPricesSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingStalePriceThresholdUpdatedIterator is returned from FilterStalePriceThresholdUpdated and is used to iterate over the raw logs and unpacked data for StalePriceThresholdUpdated events raised by the BunkerPricing contract.
+type BunkerPricingStalePriceThresholdUpdatedIterator struct {
+	Event *BunkerPricingStalePriceThresholdUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingStalePriceThresholdUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingStalePriceThresholdUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingStalePriceThresholdUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingStalePriceThresholdUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingStalePriceThresholdUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingStalePriceThresholdUpdated represents a StalePriceThresholdUpdated event raised by the BunkerPricing contract.
+type BunkerPricingStalePriceThresholdUpdated struct {
+	OldThreshold *big.Int
+	NewThreshold *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterStalePriceThresholdUpdated is a free log retrieval operation binding the contract event 0x8f83b069a278bb20c05e2fd368a9a7a7bca85964a493d16acea1bf1864df3920.
+//
+// Solidity: event StalePriceThresholdUpdated(uint256 oldThreshold, uint256 newThreshold)
+func (_BunkerPricing *BunkerPricingFilterer) FilterStalePriceThresholdUpdated(opts *bind.FilterOpts) (*BunkerPricingStalePriceThresholdUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "StalePriceThresholdUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingStalePriceThresholdUpdatedIterator{contract: _BunkerPricing.contract, event: "StalePriceThresholdUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchStalePriceThresholdUpdated is a free log subscription operation binding the contract event 0x8f83b069a278bb20c05e2fd368a9a7a7bca85964a493d16acea1bf1864df3920.
+//
+// Solidity: event StalePriceThresholdUpdated(uint256 oldThreshold, uint256 newThreshold)
+func (_BunkerPricing *BunkerPricingFilterer) WatchStalePriceThresholdUpdated(opts *bind.WatchOpts, sink chan<- *BunkerPricingStalePriceThresholdUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "StalePriceThresholdUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingStalePriceThresholdUpdated)
+				if err := _BunkerPricing.contract.UnpackLog(event, "StalePriceThresholdUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStalePriceThresholdUpdated is a log parse operation binding the contract event 0x8f83b069a278bb20c05e2fd368a9a7a7bca85964a493d16acea1bf1864df3920.
+//
+// Solidity: event StalePriceThresholdUpdated(uint256 oldThreshold, uint256 newThreshold)
+func (_BunkerPricing *BunkerPricingFilterer) ParseStalePriceThresholdUpdated(log types.Log) (*BunkerPricingStalePriceThresholdUpdated, error) {
+	event := new(BunkerPricingStalePriceThresholdUpdated)
+	if err := _BunkerPricing.contract.UnpackLog(event, "StalePriceThresholdUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerPricingStaleThresholdBoundsUpdatedIterator is returned from FilterStaleThresholdBoundsUpdated and is used to iterate over the raw logs and unpacked data for StaleThresholdBoundsUpdated events raised by the BunkerPricing contract.
+type BunkerPricingStaleThresholdBoundsUpdatedIterator struct {
+	Event *BunkerPricingStaleThresholdBoundsUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerPricingStaleThresholdBoundsUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerPricingStaleThresholdBoundsUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerPricingStaleThresholdBoundsUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerPricingStaleThresholdBoundsUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerPricingStaleThresholdBoundsUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerPricingStaleThresholdBoundsUpdated represents a StaleThresholdBoundsUpdated event raised by the BunkerPricing contract.
+type BunkerPricingStaleThresholdBoundsUpdated struct {
+	NewMin *big.Int
+	NewMax *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterStaleThresholdBoundsUpdated is a free log retrieval operation binding the contract event 0xd38397e3dccaeef2b961fb2d310645505e2c8df40fbbbcea679d2689b79698e1.
+//
+// Solidity: event StaleThresholdBoundsUpdated(uint256 newMin, uint256 newMax)
+func (_BunkerPricing *BunkerPricingFilterer) FilterStaleThresholdBoundsUpdated(opts *bind.FilterOpts) (*BunkerPricingStaleThresholdBoundsUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerPricing.contract.FilterLogs(opts, "StaleThresholdBoundsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerPricingStaleThresholdBoundsUpdatedIterator{contract: _BunkerPricing.contract, event: "StaleThresholdBoundsUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchStaleThresholdBoundsUpdated is a free log subscription operation binding the contract event 0xd38397e3dccaeef2b961fb2d310645505e2c8df40fbbbcea679d2689b79698e1.
+//
+// Solidity: event StaleThresholdBoundsUpdated(uint256 newMin, uint256 newMax)
+func (_BunkerPricing *BunkerPricingFilterer) WatchStaleThresholdBoundsUpdated(opts *bind.WatchOpts, sink chan<- *BunkerPricingStaleThresholdBoundsUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerPricing.contract.WatchLogs(opts, "StaleThresholdBoundsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerPricingStaleThresholdBoundsUpdated)
+				if err := _BunkerPricing.contract.UnpackLog(event, "StaleThresholdBoundsUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStaleThresholdBoundsUpdated is a log parse operation binding the contract event 0xd38397e3dccaeef2b961fb2d310645505e2c8df40fbbbcea679d2689b79698e1.
+//
+// Solidity: event StaleThresholdBoundsUpdated(uint256 newMin, uint256 newMax)
+func (_BunkerPricing *BunkerPricingFilterer) ParseStaleThresholdBoundsUpdated(log types.Log) (*BunkerPricingStaleThresholdBoundsUpdated, error) {
+	event := new(BunkerPricingStaleThresholdBoundsUpdated)
+	if err := _BunkerPricing.contract.UnpackLog(event, "StaleThresholdBoundsUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/payment/bindings/bunkerregistry.go
+++ b/internal/payment/bindings/bunkerregistry.go
@@ -1,0 +1,6076 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BunkerRegistryMetaData contains all meta data concerning the BunkerRegistry contract.
+var BunkerRegistryMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_treasury\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_registrationFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_stakingContract\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BPS_DENOMINATOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"BURN_BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_AVATAR_URL_LENGTH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_BULK_SIZE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_DESCRIPTION_LENGTH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_NAMES_PER_OWNER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MIN_REGISTRATION_FEE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"PREMIUM_1_CHAR_MULTIPLIER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"PREMIUM_2_CHAR_MULTIPLIER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"PREMIUM_3_CHAR_MULTIPLIER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"PREMIUM_4_CHAR_MULTIPLIER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"batchReserveNames\",\"inputs\":[{\"name\":\"names\",\"type\":\"string[]\",\"internalType\":\"string[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"bulkRegister\",\"inputs\":[{\"name\":\"names\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"deploymentIDs\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"bulkRenew\",\"inputs\":[{\"name\":\"names\",\"type\":\"string[]\",\"internalType\":\"string[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"bunkerToken\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"calculatePrice\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"user\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"price\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"cancelReservation\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"changeFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"claimReservation\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"expirationPeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"gracePeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isAvailable\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isExpired\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isInGracePeriod\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"metadata\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"avatarURL\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"nameCount\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"nameOf\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"ownedNameAt\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"primaryName\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"reclaimSquatted\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"referralDiscountBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"referralRewardBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"register\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerWithReferral\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"referrer\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registrationFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"release\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renew\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"reservationPeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"reserve\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"reservedNames\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"resolve\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"registeredAt\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"reverseResolve\",\"inputs\":[{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setChangeFee\",\"inputs\":[{\"name\":\"fee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setExpirationPeriod\",\"inputs\":[{\"name\":\"period\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setGracePeriod\",\"inputs\":[{\"name\":\"period\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMetadata\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"avatarURL\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setPrimaryName\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setReferralDiscountBps\",\"inputs\":[{\"name\":\"bps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setReferralRewardBps\",\"inputs\":[{\"name\":\"bps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRegistrationFee\",\"inputs\":[{\"name\":\"newFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setReservationPeriod\",\"inputs\":[{\"name\":\"period\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setReservedName\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"reserved\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setShortNamesEnabled\",\"inputs\":[{\"name\":\"enabled\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSquattingGracePeriod\",\"inputs\":[{\"name\":\"period\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setStakingContract\",\"inputs\":[{\"name\":\"addr\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTreasury\",\"inputs\":[{\"name\":\"newTreasury\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"shortNamesEnabled\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"squattingGracePeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"stakingContract\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIBunkerStakingTier\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"subdomains\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"registeredAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"expiresAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"reservedUntil\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"referrer\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transfer\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"treasury\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateDeployment\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"newDeploymentID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"ChangeFeeUpdated\",\"inputs\":[{\"name\":\"oldFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ExpirationPeriodUpdated\",\"inputs\":[{\"name\":\"oldPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"GracePeriodUpdated\",\"inputs\":[{\"name\":\"oldPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MetadataUpdated\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PrimaryNameSet\",\"inputs\":[{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReferralDiscountUpdated\",\"inputs\":[{\"name\":\"oldBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReferralRewardUpdated\",\"inputs\":[{\"name\":\"oldBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RegistrationFeeUpdated\",\"inputs\":[{\"name\":\"oldFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newFee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReservationCancelled\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReservationClaimed\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReservationPeriodUpdated\",\"inputs\":[{\"name\":\"oldPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReservedNameUpdated\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"reserved\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ShortNamesEnabledUpdated\",\"inputs\":[{\"name\":\"enabled\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SquattedNameReclaimed\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"reclaimer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SquattingGracePeriodUpdated\",\"inputs\":[{\"name\":\"oldPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"StakingContractUpdated\",\"inputs\":[{\"name\":\"oldAddr\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newAddr\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SubdomainRegistered\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"fee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SubdomainReleased\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SubdomainRenewed\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newExpiry\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"fee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SubdomainReserved\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"reserver\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"reservedUntil\",\"type\":\"uint48\",\"indexed\":false,\"internalType\":\"uint48\"},{\"name\":\"fee\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SubdomainTransferred\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"from\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SubdomainUpdated\",\"inputs\":[{\"name\":\"nameIndexed\",\"type\":\"string\",\"indexed\":true,\"internalType\":\"string\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"oldDeploymentID\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"newDeploymentID\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TreasuryUpdated\",\"inputs\":[{\"name\":\"oldTreasury\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newTreasury\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ArrayLengthMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ArrayTooLarge\",\"inputs\":[{\"name\":\"length\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"max\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"CannotTransferToSelf\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DeploymentNotOwned\",\"inputs\":[{\"name\":\"deploymentID\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FeeBelowMinimum\",\"inputs\":[{\"name\":\"fee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minimum\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"FeeTransferFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidDeploymentID\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidName\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"InvalidPeriod\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidReferrer\",\"inputs\":[{\"name\":\"referrer\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"MetadataAvatarURLTooLong\",\"inputs\":[{\"name\":\"length\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"max\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"MetadataDescriptionTooLong\",\"inputs\":[{\"name\":\"length\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"max\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NameAlreadyRegistered\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"NameExpired\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"NameInGracePeriod\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"NameNotExpired\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"NameNotRegistered\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"NameNotSquatted\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"NameReserved\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"NotNameOwner\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NotReservationOwner\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ReservationExpired\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ShortNamesDisabled\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TooManyNames\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"max\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}]",
+}
+
+// BunkerRegistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use BunkerRegistryMetaData.ABI instead.
+var BunkerRegistryABI = BunkerRegistryMetaData.ABI
+
+// BunkerRegistry is an auto generated Go binding around an Ethereum contract.
+type BunkerRegistry struct {
+	BunkerRegistryCaller     // Read-only binding to the contract
+	BunkerRegistryTransactor // Write-only binding to the contract
+	BunkerRegistryFilterer   // Log filterer for contract events
+}
+
+// BunkerRegistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BunkerRegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerRegistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BunkerRegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerRegistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BunkerRegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerRegistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BunkerRegistrySession struct {
+	Contract     *BunkerRegistry   // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BunkerRegistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BunkerRegistryCallerSession struct {
+	Contract *BunkerRegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts         // Call options to use throughout this session
+}
+
+// BunkerRegistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BunkerRegistryTransactorSession struct {
+	Contract     *BunkerRegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// BunkerRegistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BunkerRegistryRaw struct {
+	Contract *BunkerRegistry // Generic contract binding to access the raw methods on
+}
+
+// BunkerRegistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BunkerRegistryCallerRaw struct {
+	Contract *BunkerRegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BunkerRegistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BunkerRegistryTransactorRaw struct {
+	Contract *BunkerRegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBunkerRegistry creates a new instance of BunkerRegistry, bound to a specific deployed contract.
+func NewBunkerRegistry(address common.Address, backend bind.ContractBackend) (*BunkerRegistry, error) {
+	contract, err := bindBunkerRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistry{BunkerRegistryCaller: BunkerRegistryCaller{contract: contract}, BunkerRegistryTransactor: BunkerRegistryTransactor{contract: contract}, BunkerRegistryFilterer: BunkerRegistryFilterer{contract: contract}}, nil
+}
+
+// NewBunkerRegistryCaller creates a new read-only instance of BunkerRegistry, bound to a specific deployed contract.
+func NewBunkerRegistryCaller(address common.Address, caller bind.ContractCaller) (*BunkerRegistryCaller, error) {
+	contract, err := bindBunkerRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryCaller{contract: contract}, nil
+}
+
+// NewBunkerRegistryTransactor creates a new write-only instance of BunkerRegistry, bound to a specific deployed contract.
+func NewBunkerRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*BunkerRegistryTransactor, error) {
+	contract, err := bindBunkerRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryTransactor{contract: contract}, nil
+}
+
+// NewBunkerRegistryFilterer creates a new log filterer instance of BunkerRegistry, bound to a specific deployed contract.
+func NewBunkerRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*BunkerRegistryFilterer, error) {
+	contract, err := bindBunkerRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryFilterer{contract: contract}, nil
+}
+
+// bindBunkerRegistry binds a generic wrapper to an already deployed contract.
+func bindBunkerRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BunkerRegistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerRegistry *BunkerRegistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerRegistry.Contract.BunkerRegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerRegistry *BunkerRegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.BunkerRegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerRegistry *BunkerRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.BunkerRegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerRegistry *BunkerRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerRegistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerRegistry *BunkerRegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerRegistry *BunkerRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) BPSDENOMINATOR(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "BPS_DENOMINATOR")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerRegistry.Contract.BPSDENOMINATOR(&_BunkerRegistry.CallOpts)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerRegistry.Contract.BPSDENOMINATOR(&_BunkerRegistry.CallOpts)
+}
+
+// BURNBPS is a free data retrieval call binding the contract method 0xa37a9fc0.
+//
+// Solidity: function BURN_BPS() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) BURNBPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "BURN_BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BURNBPS is a free data retrieval call binding the contract method 0xa37a9fc0.
+//
+// Solidity: function BURN_BPS() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) BURNBPS() (*big.Int, error) {
+	return _BunkerRegistry.Contract.BURNBPS(&_BunkerRegistry.CallOpts)
+}
+
+// BURNBPS is a free data retrieval call binding the contract method 0xa37a9fc0.
+//
+// Solidity: function BURN_BPS() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) BURNBPS() (*big.Int, error) {
+	return _BunkerRegistry.Contract.BURNBPS(&_BunkerRegistry.CallOpts)
+}
+
+// MAXAVATARURLLENGTH is a free data retrieval call binding the contract method 0x8dbffb12.
+//
+// Solidity: function MAX_AVATAR_URL_LENGTH() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) MAXAVATARURLLENGTH(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "MAX_AVATAR_URL_LENGTH")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXAVATARURLLENGTH is a free data retrieval call binding the contract method 0x8dbffb12.
+//
+// Solidity: function MAX_AVATAR_URL_LENGTH() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) MAXAVATARURLLENGTH() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MAXAVATARURLLENGTH(&_BunkerRegistry.CallOpts)
+}
+
+// MAXAVATARURLLENGTH is a free data retrieval call binding the contract method 0x8dbffb12.
+//
+// Solidity: function MAX_AVATAR_URL_LENGTH() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) MAXAVATARURLLENGTH() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MAXAVATARURLLENGTH(&_BunkerRegistry.CallOpts)
+}
+
+// MAXBULKSIZE is a free data retrieval call binding the contract method 0xc3225549.
+//
+// Solidity: function MAX_BULK_SIZE() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) MAXBULKSIZE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "MAX_BULK_SIZE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXBULKSIZE is a free data retrieval call binding the contract method 0xc3225549.
+//
+// Solidity: function MAX_BULK_SIZE() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) MAXBULKSIZE() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MAXBULKSIZE(&_BunkerRegistry.CallOpts)
+}
+
+// MAXBULKSIZE is a free data retrieval call binding the contract method 0xc3225549.
+//
+// Solidity: function MAX_BULK_SIZE() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) MAXBULKSIZE() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MAXBULKSIZE(&_BunkerRegistry.CallOpts)
+}
+
+// MAXDESCRIPTIONLENGTH is a free data retrieval call binding the contract method 0x9201ea0a.
+//
+// Solidity: function MAX_DESCRIPTION_LENGTH() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) MAXDESCRIPTIONLENGTH(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "MAX_DESCRIPTION_LENGTH")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXDESCRIPTIONLENGTH is a free data retrieval call binding the contract method 0x9201ea0a.
+//
+// Solidity: function MAX_DESCRIPTION_LENGTH() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) MAXDESCRIPTIONLENGTH() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MAXDESCRIPTIONLENGTH(&_BunkerRegistry.CallOpts)
+}
+
+// MAXDESCRIPTIONLENGTH is a free data retrieval call binding the contract method 0x9201ea0a.
+//
+// Solidity: function MAX_DESCRIPTION_LENGTH() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) MAXDESCRIPTIONLENGTH() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MAXDESCRIPTIONLENGTH(&_BunkerRegistry.CallOpts)
+}
+
+// MAXNAMESPEROWNER is a free data retrieval call binding the contract method 0xe33ea45e.
+//
+// Solidity: function MAX_NAMES_PER_OWNER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) MAXNAMESPEROWNER(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "MAX_NAMES_PER_OWNER")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXNAMESPEROWNER is a free data retrieval call binding the contract method 0xe33ea45e.
+//
+// Solidity: function MAX_NAMES_PER_OWNER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) MAXNAMESPEROWNER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MAXNAMESPEROWNER(&_BunkerRegistry.CallOpts)
+}
+
+// MAXNAMESPEROWNER is a free data retrieval call binding the contract method 0xe33ea45e.
+//
+// Solidity: function MAX_NAMES_PER_OWNER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) MAXNAMESPEROWNER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MAXNAMESPEROWNER(&_BunkerRegistry.CallOpts)
+}
+
+// MINREGISTRATIONFEE is a free data retrieval call binding the contract method 0x418cc2ae.
+//
+// Solidity: function MIN_REGISTRATION_FEE() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) MINREGISTRATIONFEE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "MIN_REGISTRATION_FEE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MINREGISTRATIONFEE is a free data retrieval call binding the contract method 0x418cc2ae.
+//
+// Solidity: function MIN_REGISTRATION_FEE() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) MINREGISTRATIONFEE() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MINREGISTRATIONFEE(&_BunkerRegistry.CallOpts)
+}
+
+// MINREGISTRATIONFEE is a free data retrieval call binding the contract method 0x418cc2ae.
+//
+// Solidity: function MIN_REGISTRATION_FEE() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) MINREGISTRATIONFEE() (*big.Int, error) {
+	return _BunkerRegistry.Contract.MINREGISTRATIONFEE(&_BunkerRegistry.CallOpts)
+}
+
+// PREMIUM1CHARMULTIPLIER is a free data retrieval call binding the contract method 0x0b436a20.
+//
+// Solidity: function PREMIUM_1_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) PREMIUM1CHARMULTIPLIER(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "PREMIUM_1_CHAR_MULTIPLIER")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PREMIUM1CHARMULTIPLIER is a free data retrieval call binding the contract method 0x0b436a20.
+//
+// Solidity: function PREMIUM_1_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) PREMIUM1CHARMULTIPLIER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.PREMIUM1CHARMULTIPLIER(&_BunkerRegistry.CallOpts)
+}
+
+// PREMIUM1CHARMULTIPLIER is a free data retrieval call binding the contract method 0x0b436a20.
+//
+// Solidity: function PREMIUM_1_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) PREMIUM1CHARMULTIPLIER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.PREMIUM1CHARMULTIPLIER(&_BunkerRegistry.CallOpts)
+}
+
+// PREMIUM2CHARMULTIPLIER is a free data retrieval call binding the contract method 0xe420f838.
+//
+// Solidity: function PREMIUM_2_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) PREMIUM2CHARMULTIPLIER(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "PREMIUM_2_CHAR_MULTIPLIER")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PREMIUM2CHARMULTIPLIER is a free data retrieval call binding the contract method 0xe420f838.
+//
+// Solidity: function PREMIUM_2_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) PREMIUM2CHARMULTIPLIER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.PREMIUM2CHARMULTIPLIER(&_BunkerRegistry.CallOpts)
+}
+
+// PREMIUM2CHARMULTIPLIER is a free data retrieval call binding the contract method 0xe420f838.
+//
+// Solidity: function PREMIUM_2_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) PREMIUM2CHARMULTIPLIER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.PREMIUM2CHARMULTIPLIER(&_BunkerRegistry.CallOpts)
+}
+
+// PREMIUM3CHARMULTIPLIER is a free data retrieval call binding the contract method 0xb7f096a1.
+//
+// Solidity: function PREMIUM_3_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) PREMIUM3CHARMULTIPLIER(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "PREMIUM_3_CHAR_MULTIPLIER")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PREMIUM3CHARMULTIPLIER is a free data retrieval call binding the contract method 0xb7f096a1.
+//
+// Solidity: function PREMIUM_3_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) PREMIUM3CHARMULTIPLIER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.PREMIUM3CHARMULTIPLIER(&_BunkerRegistry.CallOpts)
+}
+
+// PREMIUM3CHARMULTIPLIER is a free data retrieval call binding the contract method 0xb7f096a1.
+//
+// Solidity: function PREMIUM_3_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) PREMIUM3CHARMULTIPLIER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.PREMIUM3CHARMULTIPLIER(&_BunkerRegistry.CallOpts)
+}
+
+// PREMIUM4CHARMULTIPLIER is a free data retrieval call binding the contract method 0x6e6902c8.
+//
+// Solidity: function PREMIUM_4_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) PREMIUM4CHARMULTIPLIER(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "PREMIUM_4_CHAR_MULTIPLIER")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PREMIUM4CHARMULTIPLIER is a free data retrieval call binding the contract method 0x6e6902c8.
+//
+// Solidity: function PREMIUM_4_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) PREMIUM4CHARMULTIPLIER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.PREMIUM4CHARMULTIPLIER(&_BunkerRegistry.CallOpts)
+}
+
+// PREMIUM4CHARMULTIPLIER is a free data retrieval call binding the contract method 0x6e6902c8.
+//
+// Solidity: function PREMIUM_4_CHAR_MULTIPLIER() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) PREMIUM4CHARMULTIPLIER() (*big.Int, error) {
+	return _BunkerRegistry.Contract.PREMIUM4CHARMULTIPLIER(&_BunkerRegistry.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerRegistry *BunkerRegistryCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerRegistry *BunkerRegistrySession) VERSION() (string, error) {
+	return _BunkerRegistry.Contract.VERSION(&_BunkerRegistry.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerRegistry *BunkerRegistryCallerSession) VERSION() (string, error) {
+	return _BunkerRegistry.Contract.VERSION(&_BunkerRegistry.CallOpts)
+}
+
+// BunkerToken is a free data retrieval call binding the contract method 0x0b38d902.
+//
+// Solidity: function bunkerToken() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCaller) BunkerToken(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "bunkerToken")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// BunkerToken is a free data retrieval call binding the contract method 0x0b38d902.
+//
+// Solidity: function bunkerToken() view returns(address)
+func (_BunkerRegistry *BunkerRegistrySession) BunkerToken() (common.Address, error) {
+	return _BunkerRegistry.Contract.BunkerToken(&_BunkerRegistry.CallOpts)
+}
+
+// BunkerToken is a free data retrieval call binding the contract method 0x0b38d902.
+//
+// Solidity: function bunkerToken() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCallerSession) BunkerToken() (common.Address, error) {
+	return _BunkerRegistry.Contract.BunkerToken(&_BunkerRegistry.CallOpts)
+}
+
+// CalculatePrice is a free data retrieval call binding the contract method 0xf8a3fce1.
+//
+// Solidity: function calculatePrice(string name, address user) view returns(uint256 price)
+func (_BunkerRegistry *BunkerRegistryCaller) CalculatePrice(opts *bind.CallOpts, name string, user common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "calculatePrice", name, user)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// CalculatePrice is a free data retrieval call binding the contract method 0xf8a3fce1.
+//
+// Solidity: function calculatePrice(string name, address user) view returns(uint256 price)
+func (_BunkerRegistry *BunkerRegistrySession) CalculatePrice(name string, user common.Address) (*big.Int, error) {
+	return _BunkerRegistry.Contract.CalculatePrice(&_BunkerRegistry.CallOpts, name, user)
+}
+
+// CalculatePrice is a free data retrieval call binding the contract method 0xf8a3fce1.
+//
+// Solidity: function calculatePrice(string name, address user) view returns(uint256 price)
+func (_BunkerRegistry *BunkerRegistryCallerSession) CalculatePrice(name string, user common.Address) (*big.Int, error) {
+	return _BunkerRegistry.Contract.CalculatePrice(&_BunkerRegistry.CallOpts, name, user)
+}
+
+// ChangeFee is a free data retrieval call binding the contract method 0x0040ff6c.
+//
+// Solidity: function changeFee() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) ChangeFee(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "changeFee")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ChangeFee is a free data retrieval call binding the contract method 0x0040ff6c.
+//
+// Solidity: function changeFee() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) ChangeFee() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ChangeFee(&_BunkerRegistry.CallOpts)
+}
+
+// ChangeFee is a free data retrieval call binding the contract method 0x0040ff6c.
+//
+// Solidity: function changeFee() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) ChangeFee() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ChangeFee(&_BunkerRegistry.CallOpts)
+}
+
+// ExpirationPeriod is a free data retrieval call binding the contract method 0x8897cad3.
+//
+// Solidity: function expirationPeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) ExpirationPeriod(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "expirationPeriod")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ExpirationPeriod is a free data retrieval call binding the contract method 0x8897cad3.
+//
+// Solidity: function expirationPeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) ExpirationPeriod() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ExpirationPeriod(&_BunkerRegistry.CallOpts)
+}
+
+// ExpirationPeriod is a free data retrieval call binding the contract method 0x8897cad3.
+//
+// Solidity: function expirationPeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) ExpirationPeriod() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ExpirationPeriod(&_BunkerRegistry.CallOpts)
+}
+
+// GracePeriod is a free data retrieval call binding the contract method 0xa06db7dc.
+//
+// Solidity: function gracePeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) GracePeriod(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "gracePeriod")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GracePeriod is a free data retrieval call binding the contract method 0xa06db7dc.
+//
+// Solidity: function gracePeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) GracePeriod() (*big.Int, error) {
+	return _BunkerRegistry.Contract.GracePeriod(&_BunkerRegistry.CallOpts)
+}
+
+// GracePeriod is a free data retrieval call binding the contract method 0xa06db7dc.
+//
+// Solidity: function gracePeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) GracePeriod() (*big.Int, error) {
+	return _BunkerRegistry.Contract.GracePeriod(&_BunkerRegistry.CallOpts)
+}
+
+// IsAvailable is a free data retrieval call binding the contract method 0x965306aa.
+//
+// Solidity: function isAvailable(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCaller) IsAvailable(opts *bind.CallOpts, name string) (bool, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "isAvailable", name)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsAvailable is a free data retrieval call binding the contract method 0x965306aa.
+//
+// Solidity: function isAvailable(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistrySession) IsAvailable(name string) (bool, error) {
+	return _BunkerRegistry.Contract.IsAvailable(&_BunkerRegistry.CallOpts, name)
+}
+
+// IsAvailable is a free data retrieval call binding the contract method 0x965306aa.
+//
+// Solidity: function isAvailable(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCallerSession) IsAvailable(name string) (bool, error) {
+	return _BunkerRegistry.Contract.IsAvailable(&_BunkerRegistry.CallOpts, name)
+}
+
+// IsExpired is a free data retrieval call binding the contract method 0xc64fafbc.
+//
+// Solidity: function isExpired(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCaller) IsExpired(opts *bind.CallOpts, name string) (bool, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "isExpired", name)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsExpired is a free data retrieval call binding the contract method 0xc64fafbc.
+//
+// Solidity: function isExpired(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistrySession) IsExpired(name string) (bool, error) {
+	return _BunkerRegistry.Contract.IsExpired(&_BunkerRegistry.CallOpts, name)
+}
+
+// IsExpired is a free data retrieval call binding the contract method 0xc64fafbc.
+//
+// Solidity: function isExpired(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCallerSession) IsExpired(name string) (bool, error) {
+	return _BunkerRegistry.Contract.IsExpired(&_BunkerRegistry.CallOpts, name)
+}
+
+// IsInGracePeriod is a free data retrieval call binding the contract method 0x1499651f.
+//
+// Solidity: function isInGracePeriod(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCaller) IsInGracePeriod(opts *bind.CallOpts, name string) (bool, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "isInGracePeriod", name)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsInGracePeriod is a free data retrieval call binding the contract method 0x1499651f.
+//
+// Solidity: function isInGracePeriod(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistrySession) IsInGracePeriod(name string) (bool, error) {
+	return _BunkerRegistry.Contract.IsInGracePeriod(&_BunkerRegistry.CallOpts, name)
+}
+
+// IsInGracePeriod is a free data retrieval call binding the contract method 0x1499651f.
+//
+// Solidity: function isInGracePeriod(string name) view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCallerSession) IsInGracePeriod(name string) (bool, error) {
+	return _BunkerRegistry.Contract.IsInGracePeriod(&_BunkerRegistry.CallOpts, name)
+}
+
+// Metadata is a free data retrieval call binding the contract method 0x7122ba06.
+//
+// Solidity: function metadata(bytes32 ) view returns(string description, string avatarURL)
+func (_BunkerRegistry *BunkerRegistryCaller) Metadata(opts *bind.CallOpts, arg0 [32]byte) (struct {
+	Description string
+	AvatarURL   string
+}, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "metadata", arg0)
+
+	outstruct := new(struct {
+		Description string
+		AvatarURL   string
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Description = *abi.ConvertType(out[0], new(string)).(*string)
+	outstruct.AvatarURL = *abi.ConvertType(out[1], new(string)).(*string)
+
+	return *outstruct, err
+
+}
+
+// Metadata is a free data retrieval call binding the contract method 0x7122ba06.
+//
+// Solidity: function metadata(bytes32 ) view returns(string description, string avatarURL)
+func (_BunkerRegistry *BunkerRegistrySession) Metadata(arg0 [32]byte) (struct {
+	Description string
+	AvatarURL   string
+}, error) {
+	return _BunkerRegistry.Contract.Metadata(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// Metadata is a free data retrieval call binding the contract method 0x7122ba06.
+//
+// Solidity: function metadata(bytes32 ) view returns(string description, string avatarURL)
+func (_BunkerRegistry *BunkerRegistryCallerSession) Metadata(arg0 [32]byte) (struct {
+	Description string
+	AvatarURL   string
+}, error) {
+	return _BunkerRegistry.Contract.Metadata(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// NameCount is a free data retrieval call binding the contract method 0x79bba73b.
+//
+// Solidity: function nameCount(address owner) view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) NameCount(opts *bind.CallOpts, owner common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "nameCount", owner)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// NameCount is a free data retrieval call binding the contract method 0x79bba73b.
+//
+// Solidity: function nameCount(address owner) view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) NameCount(owner common.Address) (*big.Int, error) {
+	return _BunkerRegistry.Contract.NameCount(&_BunkerRegistry.CallOpts, owner)
+}
+
+// NameCount is a free data retrieval call binding the contract method 0x79bba73b.
+//
+// Solidity: function nameCount(address owner) view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) NameCount(owner common.Address) (*big.Int, error) {
+	return _BunkerRegistry.Contract.NameCount(&_BunkerRegistry.CallOpts, owner)
+}
+
+// NameOf is a free data retrieval call binding the contract method 0xe532a034.
+//
+// Solidity: function nameOf(bytes32 ) view returns(string)
+func (_BunkerRegistry *BunkerRegistryCaller) NameOf(opts *bind.CallOpts, arg0 [32]byte) (string, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "nameOf", arg0)
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// NameOf is a free data retrieval call binding the contract method 0xe532a034.
+//
+// Solidity: function nameOf(bytes32 ) view returns(string)
+func (_BunkerRegistry *BunkerRegistrySession) NameOf(arg0 [32]byte) (string, error) {
+	return _BunkerRegistry.Contract.NameOf(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// NameOf is a free data retrieval call binding the contract method 0xe532a034.
+//
+// Solidity: function nameOf(bytes32 ) view returns(string)
+func (_BunkerRegistry *BunkerRegistryCallerSession) NameOf(arg0 [32]byte) (string, error) {
+	return _BunkerRegistry.Contract.NameOf(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// OwnedNameAt is a free data retrieval call binding the contract method 0x7059c7b8.
+//
+// Solidity: function ownedNameAt(address owner, uint256 index) view returns(bytes32)
+func (_BunkerRegistry *BunkerRegistryCaller) OwnedNameAt(opts *bind.CallOpts, owner common.Address, index *big.Int) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "ownedNameAt", owner, index)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// OwnedNameAt is a free data retrieval call binding the contract method 0x7059c7b8.
+//
+// Solidity: function ownedNameAt(address owner, uint256 index) view returns(bytes32)
+func (_BunkerRegistry *BunkerRegistrySession) OwnedNameAt(owner common.Address, index *big.Int) ([32]byte, error) {
+	return _BunkerRegistry.Contract.OwnedNameAt(&_BunkerRegistry.CallOpts, owner, index)
+}
+
+// OwnedNameAt is a free data retrieval call binding the contract method 0x7059c7b8.
+//
+// Solidity: function ownedNameAt(address owner, uint256 index) view returns(bytes32)
+func (_BunkerRegistry *BunkerRegistryCallerSession) OwnedNameAt(owner common.Address, index *big.Int) ([32]byte, error) {
+	return _BunkerRegistry.Contract.OwnedNameAt(&_BunkerRegistry.CallOpts, owner, index)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerRegistry *BunkerRegistrySession) Owner() (common.Address, error) {
+	return _BunkerRegistry.Contract.Owner(&_BunkerRegistry.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCallerSession) Owner() (common.Address, error) {
+	return _BunkerRegistry.Contract.Owner(&_BunkerRegistry.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerRegistry *BunkerRegistrySession) Paused() (bool, error) {
+	return _BunkerRegistry.Contract.Paused(&_BunkerRegistry.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCallerSession) Paused() (bool, error) {
+	return _BunkerRegistry.Contract.Paused(&_BunkerRegistry.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerRegistry *BunkerRegistrySession) PendingOwner() (common.Address, error) {
+	return _BunkerRegistry.Contract.PendingOwner(&_BunkerRegistry.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCallerSession) PendingOwner() (common.Address, error) {
+	return _BunkerRegistry.Contract.PendingOwner(&_BunkerRegistry.CallOpts)
+}
+
+// PrimaryName is a free data retrieval call binding the contract method 0x8f87f7a8.
+//
+// Solidity: function primaryName(bytes32 ) view returns(bytes32)
+func (_BunkerRegistry *BunkerRegistryCaller) PrimaryName(opts *bind.CallOpts, arg0 [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "primaryName", arg0)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// PrimaryName is a free data retrieval call binding the contract method 0x8f87f7a8.
+//
+// Solidity: function primaryName(bytes32 ) view returns(bytes32)
+func (_BunkerRegistry *BunkerRegistrySession) PrimaryName(arg0 [32]byte) ([32]byte, error) {
+	return _BunkerRegistry.Contract.PrimaryName(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// PrimaryName is a free data retrieval call binding the contract method 0x8f87f7a8.
+//
+// Solidity: function primaryName(bytes32 ) view returns(bytes32)
+func (_BunkerRegistry *BunkerRegistryCallerSession) PrimaryName(arg0 [32]byte) ([32]byte, error) {
+	return _BunkerRegistry.Contract.PrimaryName(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// ReferralDiscountBps is a free data retrieval call binding the contract method 0x30ab6943.
+//
+// Solidity: function referralDiscountBps() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) ReferralDiscountBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "referralDiscountBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ReferralDiscountBps is a free data retrieval call binding the contract method 0x30ab6943.
+//
+// Solidity: function referralDiscountBps() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) ReferralDiscountBps() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ReferralDiscountBps(&_BunkerRegistry.CallOpts)
+}
+
+// ReferralDiscountBps is a free data retrieval call binding the contract method 0x30ab6943.
+//
+// Solidity: function referralDiscountBps() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) ReferralDiscountBps() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ReferralDiscountBps(&_BunkerRegistry.CallOpts)
+}
+
+// ReferralRewardBps is a free data retrieval call binding the contract method 0x75f4c059.
+//
+// Solidity: function referralRewardBps() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) ReferralRewardBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "referralRewardBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ReferralRewardBps is a free data retrieval call binding the contract method 0x75f4c059.
+//
+// Solidity: function referralRewardBps() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) ReferralRewardBps() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ReferralRewardBps(&_BunkerRegistry.CallOpts)
+}
+
+// ReferralRewardBps is a free data retrieval call binding the contract method 0x75f4c059.
+//
+// Solidity: function referralRewardBps() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) ReferralRewardBps() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ReferralRewardBps(&_BunkerRegistry.CallOpts)
+}
+
+// RegistrationFee is a free data retrieval call binding the contract method 0x14c44e09.
+//
+// Solidity: function registrationFee() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) RegistrationFee(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "registrationFee")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// RegistrationFee is a free data retrieval call binding the contract method 0x14c44e09.
+//
+// Solidity: function registrationFee() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) RegistrationFee() (*big.Int, error) {
+	return _BunkerRegistry.Contract.RegistrationFee(&_BunkerRegistry.CallOpts)
+}
+
+// RegistrationFee is a free data retrieval call binding the contract method 0x14c44e09.
+//
+// Solidity: function registrationFee() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) RegistrationFee() (*big.Int, error) {
+	return _BunkerRegistry.Contract.RegistrationFee(&_BunkerRegistry.CallOpts)
+}
+
+// ReservationPeriod is a free data retrieval call binding the contract method 0x89af5e60.
+//
+// Solidity: function reservationPeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) ReservationPeriod(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "reservationPeriod")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ReservationPeriod is a free data retrieval call binding the contract method 0x89af5e60.
+//
+// Solidity: function reservationPeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) ReservationPeriod() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ReservationPeriod(&_BunkerRegistry.CallOpts)
+}
+
+// ReservationPeriod is a free data retrieval call binding the contract method 0x89af5e60.
+//
+// Solidity: function reservationPeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) ReservationPeriod() (*big.Int, error) {
+	return _BunkerRegistry.Contract.ReservationPeriod(&_BunkerRegistry.CallOpts)
+}
+
+// ReservedNames is a free data retrieval call binding the contract method 0x389c0748.
+//
+// Solidity: function reservedNames(bytes32 ) view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCaller) ReservedNames(opts *bind.CallOpts, arg0 [32]byte) (bool, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "reservedNames", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ReservedNames is a free data retrieval call binding the contract method 0x389c0748.
+//
+// Solidity: function reservedNames(bytes32 ) view returns(bool)
+func (_BunkerRegistry *BunkerRegistrySession) ReservedNames(arg0 [32]byte) (bool, error) {
+	return _BunkerRegistry.Contract.ReservedNames(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// ReservedNames is a free data retrieval call binding the contract method 0x389c0748.
+//
+// Solidity: function reservedNames(bytes32 ) view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCallerSession) ReservedNames(arg0 [32]byte) (bool, error) {
+	return _BunkerRegistry.Contract.ReservedNames(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// Resolve is a free data retrieval call binding the contract method 0x461a4478.
+//
+// Solidity: function resolve(string name) view returns(address owner, bytes32 deploymentID, uint256 registeredAt)
+func (_BunkerRegistry *BunkerRegistryCaller) Resolve(opts *bind.CallOpts, name string) (struct {
+	Owner        common.Address
+	DeploymentID [32]byte
+	RegisteredAt *big.Int
+}, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "resolve", name)
+
+	outstruct := new(struct {
+		Owner        common.Address
+		DeploymentID [32]byte
+		RegisteredAt *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Owner = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.DeploymentID = *abi.ConvertType(out[1], new([32]byte)).(*[32]byte)
+	outstruct.RegisteredAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// Resolve is a free data retrieval call binding the contract method 0x461a4478.
+//
+// Solidity: function resolve(string name) view returns(address owner, bytes32 deploymentID, uint256 registeredAt)
+func (_BunkerRegistry *BunkerRegistrySession) Resolve(name string) (struct {
+	Owner        common.Address
+	DeploymentID [32]byte
+	RegisteredAt *big.Int
+}, error) {
+	return _BunkerRegistry.Contract.Resolve(&_BunkerRegistry.CallOpts, name)
+}
+
+// Resolve is a free data retrieval call binding the contract method 0x461a4478.
+//
+// Solidity: function resolve(string name) view returns(address owner, bytes32 deploymentID, uint256 registeredAt)
+func (_BunkerRegistry *BunkerRegistryCallerSession) Resolve(name string) (struct {
+	Owner        common.Address
+	DeploymentID [32]byte
+	RegisteredAt *big.Int
+}, error) {
+	return _BunkerRegistry.Contract.Resolve(&_BunkerRegistry.CallOpts, name)
+}
+
+// ReverseResolve is a free data retrieval call binding the contract method 0x6315f9d0.
+//
+// Solidity: function reverseResolve(bytes32 deploymentID) view returns(string name)
+func (_BunkerRegistry *BunkerRegistryCaller) ReverseResolve(opts *bind.CallOpts, deploymentID [32]byte) (string, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "reverseResolve", deploymentID)
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// ReverseResolve is a free data retrieval call binding the contract method 0x6315f9d0.
+//
+// Solidity: function reverseResolve(bytes32 deploymentID) view returns(string name)
+func (_BunkerRegistry *BunkerRegistrySession) ReverseResolve(deploymentID [32]byte) (string, error) {
+	return _BunkerRegistry.Contract.ReverseResolve(&_BunkerRegistry.CallOpts, deploymentID)
+}
+
+// ReverseResolve is a free data retrieval call binding the contract method 0x6315f9d0.
+//
+// Solidity: function reverseResolve(bytes32 deploymentID) view returns(string name)
+func (_BunkerRegistry *BunkerRegistryCallerSession) ReverseResolve(deploymentID [32]byte) (string, error) {
+	return _BunkerRegistry.Contract.ReverseResolve(&_BunkerRegistry.CallOpts, deploymentID)
+}
+
+// ShortNamesEnabled is a free data retrieval call binding the contract method 0xbae7e108.
+//
+// Solidity: function shortNamesEnabled() view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCaller) ShortNamesEnabled(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "shortNamesEnabled")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ShortNamesEnabled is a free data retrieval call binding the contract method 0xbae7e108.
+//
+// Solidity: function shortNamesEnabled() view returns(bool)
+func (_BunkerRegistry *BunkerRegistrySession) ShortNamesEnabled() (bool, error) {
+	return _BunkerRegistry.Contract.ShortNamesEnabled(&_BunkerRegistry.CallOpts)
+}
+
+// ShortNamesEnabled is a free data retrieval call binding the contract method 0xbae7e108.
+//
+// Solidity: function shortNamesEnabled() view returns(bool)
+func (_BunkerRegistry *BunkerRegistryCallerSession) ShortNamesEnabled() (bool, error) {
+	return _BunkerRegistry.Contract.ShortNamesEnabled(&_BunkerRegistry.CallOpts)
+}
+
+// SquattingGracePeriod is a free data retrieval call binding the contract method 0xa5b67776.
+//
+// Solidity: function squattingGracePeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCaller) SquattingGracePeriod(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "squattingGracePeriod")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SquattingGracePeriod is a free data retrieval call binding the contract method 0xa5b67776.
+//
+// Solidity: function squattingGracePeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistrySession) SquattingGracePeriod() (*big.Int, error) {
+	return _BunkerRegistry.Contract.SquattingGracePeriod(&_BunkerRegistry.CallOpts)
+}
+
+// SquattingGracePeriod is a free data retrieval call binding the contract method 0xa5b67776.
+//
+// Solidity: function squattingGracePeriod() view returns(uint256)
+func (_BunkerRegistry *BunkerRegistryCallerSession) SquattingGracePeriod() (*big.Int, error) {
+	return _BunkerRegistry.Contract.SquattingGracePeriod(&_BunkerRegistry.CallOpts)
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCaller) StakingContract(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "stakingContract")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerRegistry *BunkerRegistrySession) StakingContract() (common.Address, error) {
+	return _BunkerRegistry.Contract.StakingContract(&_BunkerRegistry.CallOpts)
+}
+
+// StakingContract is a free data retrieval call binding the contract method 0xee99205c.
+//
+// Solidity: function stakingContract() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCallerSession) StakingContract() (common.Address, error) {
+	return _BunkerRegistry.Contract.StakingContract(&_BunkerRegistry.CallOpts)
+}
+
+// Subdomains is a free data retrieval call binding the contract method 0x9d79d081.
+//
+// Solidity: function subdomains(bytes32 ) view returns(address owner, bytes32 deploymentID, uint48 registeredAt, uint48 expiresAt, uint48 reservedUntil, address referrer)
+func (_BunkerRegistry *BunkerRegistryCaller) Subdomains(opts *bind.CallOpts, arg0 [32]byte) (struct {
+	Owner         common.Address
+	DeploymentID  [32]byte
+	RegisteredAt  *big.Int
+	ExpiresAt     *big.Int
+	ReservedUntil *big.Int
+	Referrer      common.Address
+}, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "subdomains", arg0)
+
+	outstruct := new(struct {
+		Owner         common.Address
+		DeploymentID  [32]byte
+		RegisteredAt  *big.Int
+		ExpiresAt     *big.Int
+		ReservedUntil *big.Int
+		Referrer      common.Address
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Owner = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.DeploymentID = *abi.ConvertType(out[1], new([32]byte)).(*[32]byte)
+	outstruct.RegisteredAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.ExpiresAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.ReservedUntil = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+	outstruct.Referrer = *abi.ConvertType(out[5], new(common.Address)).(*common.Address)
+
+	return *outstruct, err
+
+}
+
+// Subdomains is a free data retrieval call binding the contract method 0x9d79d081.
+//
+// Solidity: function subdomains(bytes32 ) view returns(address owner, bytes32 deploymentID, uint48 registeredAt, uint48 expiresAt, uint48 reservedUntil, address referrer)
+func (_BunkerRegistry *BunkerRegistrySession) Subdomains(arg0 [32]byte) (struct {
+	Owner         common.Address
+	DeploymentID  [32]byte
+	RegisteredAt  *big.Int
+	ExpiresAt     *big.Int
+	ReservedUntil *big.Int
+	Referrer      common.Address
+}, error) {
+	return _BunkerRegistry.Contract.Subdomains(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// Subdomains is a free data retrieval call binding the contract method 0x9d79d081.
+//
+// Solidity: function subdomains(bytes32 ) view returns(address owner, bytes32 deploymentID, uint48 registeredAt, uint48 expiresAt, uint48 reservedUntil, address referrer)
+func (_BunkerRegistry *BunkerRegistryCallerSession) Subdomains(arg0 [32]byte) (struct {
+	Owner         common.Address
+	DeploymentID  [32]byte
+	RegisteredAt  *big.Int
+	ExpiresAt     *big.Int
+	ReservedUntil *big.Int
+	Referrer      common.Address
+}, error) {
+	return _BunkerRegistry.Contract.Subdomains(&_BunkerRegistry.CallOpts, arg0)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCaller) Treasury(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerRegistry.contract.Call(opts, &out, "treasury")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerRegistry *BunkerRegistrySession) Treasury() (common.Address, error) {
+	return _BunkerRegistry.Contract.Treasury(&_BunkerRegistry.CallOpts)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerRegistry *BunkerRegistryCallerSession) Treasury() (common.Address, error) {
+	return _BunkerRegistry.Contract.Treasury(&_BunkerRegistry.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerRegistry *BunkerRegistrySession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.AcceptOwnership(&_BunkerRegistry.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.AcceptOwnership(&_BunkerRegistry.TransactOpts)
+}
+
+// BatchReserveNames is a paid mutator transaction binding the contract method 0x559e6d80.
+//
+// Solidity: function batchReserveNames(string[] names) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) BatchReserveNames(opts *bind.TransactOpts, names []string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "batchReserveNames", names)
+}
+
+// BatchReserveNames is a paid mutator transaction binding the contract method 0x559e6d80.
+//
+// Solidity: function batchReserveNames(string[] names) returns()
+func (_BunkerRegistry *BunkerRegistrySession) BatchReserveNames(names []string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.BatchReserveNames(&_BunkerRegistry.TransactOpts, names)
+}
+
+// BatchReserveNames is a paid mutator transaction binding the contract method 0x559e6d80.
+//
+// Solidity: function batchReserveNames(string[] names) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) BatchReserveNames(names []string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.BatchReserveNames(&_BunkerRegistry.TransactOpts, names)
+}
+
+// BulkRegister is a paid mutator transaction binding the contract method 0xbba509b8.
+//
+// Solidity: function bulkRegister(string[] names, bytes32[] deploymentIDs) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) BulkRegister(opts *bind.TransactOpts, names []string, deploymentIDs [][32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "bulkRegister", names, deploymentIDs)
+}
+
+// BulkRegister is a paid mutator transaction binding the contract method 0xbba509b8.
+//
+// Solidity: function bulkRegister(string[] names, bytes32[] deploymentIDs) returns()
+func (_BunkerRegistry *BunkerRegistrySession) BulkRegister(names []string, deploymentIDs [][32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.BulkRegister(&_BunkerRegistry.TransactOpts, names, deploymentIDs)
+}
+
+// BulkRegister is a paid mutator transaction binding the contract method 0xbba509b8.
+//
+// Solidity: function bulkRegister(string[] names, bytes32[] deploymentIDs) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) BulkRegister(names []string, deploymentIDs [][32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.BulkRegister(&_BunkerRegistry.TransactOpts, names, deploymentIDs)
+}
+
+// BulkRenew is a paid mutator transaction binding the contract method 0x96202308.
+//
+// Solidity: function bulkRenew(string[] names) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) BulkRenew(opts *bind.TransactOpts, names []string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "bulkRenew", names)
+}
+
+// BulkRenew is a paid mutator transaction binding the contract method 0x96202308.
+//
+// Solidity: function bulkRenew(string[] names) returns()
+func (_BunkerRegistry *BunkerRegistrySession) BulkRenew(names []string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.BulkRenew(&_BunkerRegistry.TransactOpts, names)
+}
+
+// BulkRenew is a paid mutator transaction binding the contract method 0x96202308.
+//
+// Solidity: function bulkRenew(string[] names) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) BulkRenew(names []string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.BulkRenew(&_BunkerRegistry.TransactOpts, names)
+}
+
+// CancelReservation is a paid mutator transaction binding the contract method 0x99e4b8e1.
+//
+// Solidity: function cancelReservation(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) CancelReservation(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "cancelReservation", name)
+}
+
+// CancelReservation is a paid mutator transaction binding the contract method 0x99e4b8e1.
+//
+// Solidity: function cancelReservation(string name) returns()
+func (_BunkerRegistry *BunkerRegistrySession) CancelReservation(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.CancelReservation(&_BunkerRegistry.TransactOpts, name)
+}
+
+// CancelReservation is a paid mutator transaction binding the contract method 0x99e4b8e1.
+//
+// Solidity: function cancelReservation(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) CancelReservation(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.CancelReservation(&_BunkerRegistry.TransactOpts, name)
+}
+
+// ClaimReservation is a paid mutator transaction binding the contract method 0x594ae315.
+//
+// Solidity: function claimReservation(string name, bytes32 deploymentID) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) ClaimReservation(opts *bind.TransactOpts, name string, deploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "claimReservation", name, deploymentID)
+}
+
+// ClaimReservation is a paid mutator transaction binding the contract method 0x594ae315.
+//
+// Solidity: function claimReservation(string name, bytes32 deploymentID) returns()
+func (_BunkerRegistry *BunkerRegistrySession) ClaimReservation(name string, deploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.ClaimReservation(&_BunkerRegistry.TransactOpts, name, deploymentID)
+}
+
+// ClaimReservation is a paid mutator transaction binding the contract method 0x594ae315.
+//
+// Solidity: function claimReservation(string name, bytes32 deploymentID) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) ClaimReservation(name string, deploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.ClaimReservation(&_BunkerRegistry.TransactOpts, name, deploymentID)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerRegistry *BunkerRegistrySession) Pause() (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Pause(&_BunkerRegistry.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) Pause() (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Pause(&_BunkerRegistry.TransactOpts)
+}
+
+// ReclaimSquatted is a paid mutator transaction binding the contract method 0x3197770c.
+//
+// Solidity: function reclaimSquatted(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) ReclaimSquatted(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "reclaimSquatted", name)
+}
+
+// ReclaimSquatted is a paid mutator transaction binding the contract method 0x3197770c.
+//
+// Solidity: function reclaimSquatted(string name) returns()
+func (_BunkerRegistry *BunkerRegistrySession) ReclaimSquatted(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.ReclaimSquatted(&_BunkerRegistry.TransactOpts, name)
+}
+
+// ReclaimSquatted is a paid mutator transaction binding the contract method 0x3197770c.
+//
+// Solidity: function reclaimSquatted(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) ReclaimSquatted(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.ReclaimSquatted(&_BunkerRegistry.TransactOpts, name)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x656afdee.
+//
+// Solidity: function register(string name, bytes32 deploymentID) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) Register(opts *bind.TransactOpts, name string, deploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "register", name, deploymentID)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x656afdee.
+//
+// Solidity: function register(string name, bytes32 deploymentID) returns()
+func (_BunkerRegistry *BunkerRegistrySession) Register(name string, deploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Register(&_BunkerRegistry.TransactOpts, name, deploymentID)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x656afdee.
+//
+// Solidity: function register(string name, bytes32 deploymentID) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) Register(name string, deploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Register(&_BunkerRegistry.TransactOpts, name, deploymentID)
+}
+
+// RegisterWithReferral is a paid mutator transaction binding the contract method 0xe7707dba.
+//
+// Solidity: function registerWithReferral(string name, bytes32 deploymentID, address referrer) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) RegisterWithReferral(opts *bind.TransactOpts, name string, deploymentID [32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "registerWithReferral", name, deploymentID, referrer)
+}
+
+// RegisterWithReferral is a paid mutator transaction binding the contract method 0xe7707dba.
+//
+// Solidity: function registerWithReferral(string name, bytes32 deploymentID, address referrer) returns()
+func (_BunkerRegistry *BunkerRegistrySession) RegisterWithReferral(name string, deploymentID [32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.RegisterWithReferral(&_BunkerRegistry.TransactOpts, name, deploymentID, referrer)
+}
+
+// RegisterWithReferral is a paid mutator transaction binding the contract method 0xe7707dba.
+//
+// Solidity: function registerWithReferral(string name, bytes32 deploymentID, address referrer) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) RegisterWithReferral(name string, deploymentID [32]byte, referrer common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.RegisterWithReferral(&_BunkerRegistry.TransactOpts, name, deploymentID, referrer)
+}
+
+// Release is a paid mutator transaction binding the contract method 0xf34e3723.
+//
+// Solidity: function release(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) Release(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "release", name)
+}
+
+// Release is a paid mutator transaction binding the contract method 0xf34e3723.
+//
+// Solidity: function release(string name) returns()
+func (_BunkerRegistry *BunkerRegistrySession) Release(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Release(&_BunkerRegistry.TransactOpts, name)
+}
+
+// Release is a paid mutator transaction binding the contract method 0xf34e3723.
+//
+// Solidity: function release(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) Release(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Release(&_BunkerRegistry.TransactOpts, name)
+}
+
+// Renew is a paid mutator transaction binding the contract method 0xa4a9a612.
+//
+// Solidity: function renew(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) Renew(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "renew", name)
+}
+
+// Renew is a paid mutator transaction binding the contract method 0xa4a9a612.
+//
+// Solidity: function renew(string name) returns()
+func (_BunkerRegistry *BunkerRegistrySession) Renew(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Renew(&_BunkerRegistry.TransactOpts, name)
+}
+
+// Renew is a paid mutator transaction binding the contract method 0xa4a9a612.
+//
+// Solidity: function renew(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) Renew(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Renew(&_BunkerRegistry.TransactOpts, name)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerRegistry *BunkerRegistrySession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.RenounceOwnership(&_BunkerRegistry.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.RenounceOwnership(&_BunkerRegistry.TransactOpts)
+}
+
+// Reserve is a paid mutator transaction binding the contract method 0xae999ece.
+//
+// Solidity: function reserve(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) Reserve(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "reserve", name)
+}
+
+// Reserve is a paid mutator transaction binding the contract method 0xae999ece.
+//
+// Solidity: function reserve(string name) returns()
+func (_BunkerRegistry *BunkerRegistrySession) Reserve(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Reserve(&_BunkerRegistry.TransactOpts, name)
+}
+
+// Reserve is a paid mutator transaction binding the contract method 0xae999ece.
+//
+// Solidity: function reserve(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) Reserve(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Reserve(&_BunkerRegistry.TransactOpts, name)
+}
+
+// SetChangeFee is a paid mutator transaction binding the contract method 0xc108adab.
+//
+// Solidity: function setChangeFee(uint256 fee) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetChangeFee(opts *bind.TransactOpts, fee *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setChangeFee", fee)
+}
+
+// SetChangeFee is a paid mutator transaction binding the contract method 0xc108adab.
+//
+// Solidity: function setChangeFee(uint256 fee) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetChangeFee(fee *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetChangeFee(&_BunkerRegistry.TransactOpts, fee)
+}
+
+// SetChangeFee is a paid mutator transaction binding the contract method 0xc108adab.
+//
+// Solidity: function setChangeFee(uint256 fee) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetChangeFee(fee *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetChangeFee(&_BunkerRegistry.TransactOpts, fee)
+}
+
+// SetExpirationPeriod is a paid mutator transaction binding the contract method 0xf6eea098.
+//
+// Solidity: function setExpirationPeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetExpirationPeriod(opts *bind.TransactOpts, period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setExpirationPeriod", period)
+}
+
+// SetExpirationPeriod is a paid mutator transaction binding the contract method 0xf6eea098.
+//
+// Solidity: function setExpirationPeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetExpirationPeriod(period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetExpirationPeriod(&_BunkerRegistry.TransactOpts, period)
+}
+
+// SetExpirationPeriod is a paid mutator transaction binding the contract method 0xf6eea098.
+//
+// Solidity: function setExpirationPeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetExpirationPeriod(period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetExpirationPeriod(&_BunkerRegistry.TransactOpts, period)
+}
+
+// SetGracePeriod is a paid mutator transaction binding the contract method 0xf2f65960.
+//
+// Solidity: function setGracePeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetGracePeriod(opts *bind.TransactOpts, period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setGracePeriod", period)
+}
+
+// SetGracePeriod is a paid mutator transaction binding the contract method 0xf2f65960.
+//
+// Solidity: function setGracePeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetGracePeriod(period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetGracePeriod(&_BunkerRegistry.TransactOpts, period)
+}
+
+// SetGracePeriod is a paid mutator transaction binding the contract method 0xf2f65960.
+//
+// Solidity: function setGracePeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetGracePeriod(period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetGracePeriod(&_BunkerRegistry.TransactOpts, period)
+}
+
+// SetMetadata is a paid mutator transaction binding the contract method 0x0890d80c.
+//
+// Solidity: function setMetadata(string name, string description, string avatarURL) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetMetadata(opts *bind.TransactOpts, name string, description string, avatarURL string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setMetadata", name, description, avatarURL)
+}
+
+// SetMetadata is a paid mutator transaction binding the contract method 0x0890d80c.
+//
+// Solidity: function setMetadata(string name, string description, string avatarURL) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetMetadata(name string, description string, avatarURL string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetMetadata(&_BunkerRegistry.TransactOpts, name, description, avatarURL)
+}
+
+// SetMetadata is a paid mutator transaction binding the contract method 0x0890d80c.
+//
+// Solidity: function setMetadata(string name, string description, string avatarURL) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetMetadata(name string, description string, avatarURL string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetMetadata(&_BunkerRegistry.TransactOpts, name, description, avatarURL)
+}
+
+// SetPrimaryName is a paid mutator transaction binding the contract method 0xab66abd5.
+//
+// Solidity: function setPrimaryName(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetPrimaryName(opts *bind.TransactOpts, name string) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setPrimaryName", name)
+}
+
+// SetPrimaryName is a paid mutator transaction binding the contract method 0xab66abd5.
+//
+// Solidity: function setPrimaryName(string name) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetPrimaryName(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetPrimaryName(&_BunkerRegistry.TransactOpts, name)
+}
+
+// SetPrimaryName is a paid mutator transaction binding the contract method 0xab66abd5.
+//
+// Solidity: function setPrimaryName(string name) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetPrimaryName(name string) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetPrimaryName(&_BunkerRegistry.TransactOpts, name)
+}
+
+// SetReferralDiscountBps is a paid mutator transaction binding the contract method 0x98da62d5.
+//
+// Solidity: function setReferralDiscountBps(uint256 bps) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetReferralDiscountBps(opts *bind.TransactOpts, bps *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setReferralDiscountBps", bps)
+}
+
+// SetReferralDiscountBps is a paid mutator transaction binding the contract method 0x98da62d5.
+//
+// Solidity: function setReferralDiscountBps(uint256 bps) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetReferralDiscountBps(bps *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetReferralDiscountBps(&_BunkerRegistry.TransactOpts, bps)
+}
+
+// SetReferralDiscountBps is a paid mutator transaction binding the contract method 0x98da62d5.
+//
+// Solidity: function setReferralDiscountBps(uint256 bps) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetReferralDiscountBps(bps *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetReferralDiscountBps(&_BunkerRegistry.TransactOpts, bps)
+}
+
+// SetReferralRewardBps is a paid mutator transaction binding the contract method 0xb09e603f.
+//
+// Solidity: function setReferralRewardBps(uint256 bps) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetReferralRewardBps(opts *bind.TransactOpts, bps *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setReferralRewardBps", bps)
+}
+
+// SetReferralRewardBps is a paid mutator transaction binding the contract method 0xb09e603f.
+//
+// Solidity: function setReferralRewardBps(uint256 bps) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetReferralRewardBps(bps *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetReferralRewardBps(&_BunkerRegistry.TransactOpts, bps)
+}
+
+// SetReferralRewardBps is a paid mutator transaction binding the contract method 0xb09e603f.
+//
+// Solidity: function setReferralRewardBps(uint256 bps) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetReferralRewardBps(bps *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetReferralRewardBps(&_BunkerRegistry.TransactOpts, bps)
+}
+
+// SetRegistrationFee is a paid mutator transaction binding the contract method 0xc320c727.
+//
+// Solidity: function setRegistrationFee(uint256 newFee) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetRegistrationFee(opts *bind.TransactOpts, newFee *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setRegistrationFee", newFee)
+}
+
+// SetRegistrationFee is a paid mutator transaction binding the contract method 0xc320c727.
+//
+// Solidity: function setRegistrationFee(uint256 newFee) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetRegistrationFee(newFee *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetRegistrationFee(&_BunkerRegistry.TransactOpts, newFee)
+}
+
+// SetRegistrationFee is a paid mutator transaction binding the contract method 0xc320c727.
+//
+// Solidity: function setRegistrationFee(uint256 newFee) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetRegistrationFee(newFee *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetRegistrationFee(&_BunkerRegistry.TransactOpts, newFee)
+}
+
+// SetReservationPeriod is a paid mutator transaction binding the contract method 0xceb20a25.
+//
+// Solidity: function setReservationPeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetReservationPeriod(opts *bind.TransactOpts, period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setReservationPeriod", period)
+}
+
+// SetReservationPeriod is a paid mutator transaction binding the contract method 0xceb20a25.
+//
+// Solidity: function setReservationPeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetReservationPeriod(period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetReservationPeriod(&_BunkerRegistry.TransactOpts, period)
+}
+
+// SetReservationPeriod is a paid mutator transaction binding the contract method 0xceb20a25.
+//
+// Solidity: function setReservationPeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetReservationPeriod(period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetReservationPeriod(&_BunkerRegistry.TransactOpts, period)
+}
+
+// SetReservedName is a paid mutator transaction binding the contract method 0x9248cd43.
+//
+// Solidity: function setReservedName(string name, bool reserved) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetReservedName(opts *bind.TransactOpts, name string, reserved bool) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setReservedName", name, reserved)
+}
+
+// SetReservedName is a paid mutator transaction binding the contract method 0x9248cd43.
+//
+// Solidity: function setReservedName(string name, bool reserved) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetReservedName(name string, reserved bool) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetReservedName(&_BunkerRegistry.TransactOpts, name, reserved)
+}
+
+// SetReservedName is a paid mutator transaction binding the contract method 0x9248cd43.
+//
+// Solidity: function setReservedName(string name, bool reserved) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetReservedName(name string, reserved bool) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetReservedName(&_BunkerRegistry.TransactOpts, name, reserved)
+}
+
+// SetShortNamesEnabled is a paid mutator transaction binding the contract method 0x1482887f.
+//
+// Solidity: function setShortNamesEnabled(bool enabled) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetShortNamesEnabled(opts *bind.TransactOpts, enabled bool) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setShortNamesEnabled", enabled)
+}
+
+// SetShortNamesEnabled is a paid mutator transaction binding the contract method 0x1482887f.
+//
+// Solidity: function setShortNamesEnabled(bool enabled) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetShortNamesEnabled(enabled bool) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetShortNamesEnabled(&_BunkerRegistry.TransactOpts, enabled)
+}
+
+// SetShortNamesEnabled is a paid mutator transaction binding the contract method 0x1482887f.
+//
+// Solidity: function setShortNamesEnabled(bool enabled) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetShortNamesEnabled(enabled bool) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetShortNamesEnabled(&_BunkerRegistry.TransactOpts, enabled)
+}
+
+// SetSquattingGracePeriod is a paid mutator transaction binding the contract method 0x113f1bc4.
+//
+// Solidity: function setSquattingGracePeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetSquattingGracePeriod(opts *bind.TransactOpts, period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setSquattingGracePeriod", period)
+}
+
+// SetSquattingGracePeriod is a paid mutator transaction binding the contract method 0x113f1bc4.
+//
+// Solidity: function setSquattingGracePeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetSquattingGracePeriod(period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetSquattingGracePeriod(&_BunkerRegistry.TransactOpts, period)
+}
+
+// SetSquattingGracePeriod is a paid mutator transaction binding the contract method 0x113f1bc4.
+//
+// Solidity: function setSquattingGracePeriod(uint256 period) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetSquattingGracePeriod(period *big.Int) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetSquattingGracePeriod(&_BunkerRegistry.TransactOpts, period)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address addr) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetStakingContract(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setStakingContract", addr)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address addr) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetStakingContract(addr common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetStakingContract(&_BunkerRegistry.TransactOpts, addr)
+}
+
+// SetStakingContract is a paid mutator transaction binding the contract method 0x9dd373b9.
+//
+// Solidity: function setStakingContract(address addr) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetStakingContract(addr common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetStakingContract(&_BunkerRegistry.TransactOpts, addr)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) SetTreasury(opts *bind.TransactOpts, newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "setTreasury", newTreasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerRegistry *BunkerRegistrySession) SetTreasury(newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetTreasury(&_BunkerRegistry.TransactOpts, newTreasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) SetTreasury(newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.SetTreasury(&_BunkerRegistry.TransactOpts, newTreasury)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xfbf58b3e.
+//
+// Solidity: function transfer(string name, address newOwner) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) Transfer(opts *bind.TransactOpts, name string, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "transfer", name, newOwner)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xfbf58b3e.
+//
+// Solidity: function transfer(string name, address newOwner) returns()
+func (_BunkerRegistry *BunkerRegistrySession) Transfer(name string, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Transfer(&_BunkerRegistry.TransactOpts, name, newOwner)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xfbf58b3e.
+//
+// Solidity: function transfer(string name, address newOwner) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) Transfer(name string, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Transfer(&_BunkerRegistry.TransactOpts, name, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerRegistry *BunkerRegistrySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.TransferOwnership(&_BunkerRegistry.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.TransferOwnership(&_BunkerRegistry.TransactOpts, newOwner)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerRegistry *BunkerRegistrySession) Unpause() (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Unpause(&_BunkerRegistry.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) Unpause() (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.Unpause(&_BunkerRegistry.TransactOpts)
+}
+
+// UpdateDeployment is a paid mutator transaction binding the contract method 0xd572671f.
+//
+// Solidity: function updateDeployment(string name, bytes32 newDeploymentID) returns()
+func (_BunkerRegistry *BunkerRegistryTransactor) UpdateDeployment(opts *bind.TransactOpts, name string, newDeploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.contract.Transact(opts, "updateDeployment", name, newDeploymentID)
+}
+
+// UpdateDeployment is a paid mutator transaction binding the contract method 0xd572671f.
+//
+// Solidity: function updateDeployment(string name, bytes32 newDeploymentID) returns()
+func (_BunkerRegistry *BunkerRegistrySession) UpdateDeployment(name string, newDeploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.UpdateDeployment(&_BunkerRegistry.TransactOpts, name, newDeploymentID)
+}
+
+// UpdateDeployment is a paid mutator transaction binding the contract method 0xd572671f.
+//
+// Solidity: function updateDeployment(string name, bytes32 newDeploymentID) returns()
+func (_BunkerRegistry *BunkerRegistryTransactorSession) UpdateDeployment(name string, newDeploymentID [32]byte) (*types.Transaction, error) {
+	return _BunkerRegistry.Contract.UpdateDeployment(&_BunkerRegistry.TransactOpts, name, newDeploymentID)
+}
+
+// BunkerRegistryChangeFeeUpdatedIterator is returned from FilterChangeFeeUpdated and is used to iterate over the raw logs and unpacked data for ChangeFeeUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryChangeFeeUpdatedIterator struct {
+	Event *BunkerRegistryChangeFeeUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryChangeFeeUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryChangeFeeUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryChangeFeeUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryChangeFeeUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryChangeFeeUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryChangeFeeUpdated represents a ChangeFeeUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryChangeFeeUpdated struct {
+	OldFee *big.Int
+	NewFee *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterChangeFeeUpdated is a free log retrieval operation binding the contract event 0x55116a86ab3cee7c9c9b730bcda216ebe2ca2660136b7b36ca7138603a2bd698.
+//
+// Solidity: event ChangeFeeUpdated(uint256 oldFee, uint256 newFee)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterChangeFeeUpdated(opts *bind.FilterOpts) (*BunkerRegistryChangeFeeUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ChangeFeeUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryChangeFeeUpdatedIterator{contract: _BunkerRegistry.contract, event: "ChangeFeeUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchChangeFeeUpdated is a free log subscription operation binding the contract event 0x55116a86ab3cee7c9c9b730bcda216ebe2ca2660136b7b36ca7138603a2bd698.
+//
+// Solidity: event ChangeFeeUpdated(uint256 oldFee, uint256 newFee)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchChangeFeeUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryChangeFeeUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ChangeFeeUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryChangeFeeUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ChangeFeeUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseChangeFeeUpdated is a log parse operation binding the contract event 0x55116a86ab3cee7c9c9b730bcda216ebe2ca2660136b7b36ca7138603a2bd698.
+//
+// Solidity: event ChangeFeeUpdated(uint256 oldFee, uint256 newFee)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseChangeFeeUpdated(log types.Log) (*BunkerRegistryChangeFeeUpdated, error) {
+	event := new(BunkerRegistryChangeFeeUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ChangeFeeUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryExpirationPeriodUpdatedIterator is returned from FilterExpirationPeriodUpdated and is used to iterate over the raw logs and unpacked data for ExpirationPeriodUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryExpirationPeriodUpdatedIterator struct {
+	Event *BunkerRegistryExpirationPeriodUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryExpirationPeriodUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryExpirationPeriodUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryExpirationPeriodUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryExpirationPeriodUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryExpirationPeriodUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryExpirationPeriodUpdated represents a ExpirationPeriodUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryExpirationPeriodUpdated struct {
+	OldPeriod *big.Int
+	NewPeriod *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterExpirationPeriodUpdated is a free log retrieval operation binding the contract event 0x4a8ef160cb5b411fb018f9d68556ec33f8e7901166d29bc96fc5ca7d5eac0980.
+//
+// Solidity: event ExpirationPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterExpirationPeriodUpdated(opts *bind.FilterOpts) (*BunkerRegistryExpirationPeriodUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ExpirationPeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryExpirationPeriodUpdatedIterator{contract: _BunkerRegistry.contract, event: "ExpirationPeriodUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchExpirationPeriodUpdated is a free log subscription operation binding the contract event 0x4a8ef160cb5b411fb018f9d68556ec33f8e7901166d29bc96fc5ca7d5eac0980.
+//
+// Solidity: event ExpirationPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchExpirationPeriodUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryExpirationPeriodUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ExpirationPeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryExpirationPeriodUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ExpirationPeriodUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExpirationPeriodUpdated is a log parse operation binding the contract event 0x4a8ef160cb5b411fb018f9d68556ec33f8e7901166d29bc96fc5ca7d5eac0980.
+//
+// Solidity: event ExpirationPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseExpirationPeriodUpdated(log types.Log) (*BunkerRegistryExpirationPeriodUpdated, error) {
+	event := new(BunkerRegistryExpirationPeriodUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ExpirationPeriodUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryGracePeriodUpdatedIterator is returned from FilterGracePeriodUpdated and is used to iterate over the raw logs and unpacked data for GracePeriodUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryGracePeriodUpdatedIterator struct {
+	Event *BunkerRegistryGracePeriodUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryGracePeriodUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryGracePeriodUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryGracePeriodUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryGracePeriodUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryGracePeriodUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryGracePeriodUpdated represents a GracePeriodUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryGracePeriodUpdated struct {
+	OldPeriod *big.Int
+	NewPeriod *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterGracePeriodUpdated is a free log retrieval operation binding the contract event 0x55c7a79c45e9a972909cd640f9336a14a84adbaf756211f16267001854110191.
+//
+// Solidity: event GracePeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterGracePeriodUpdated(opts *bind.FilterOpts) (*BunkerRegistryGracePeriodUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "GracePeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryGracePeriodUpdatedIterator{contract: _BunkerRegistry.contract, event: "GracePeriodUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchGracePeriodUpdated is a free log subscription operation binding the contract event 0x55c7a79c45e9a972909cd640f9336a14a84adbaf756211f16267001854110191.
+//
+// Solidity: event GracePeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchGracePeriodUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryGracePeriodUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "GracePeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryGracePeriodUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "GracePeriodUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseGracePeriodUpdated is a log parse operation binding the contract event 0x55c7a79c45e9a972909cd640f9336a14a84adbaf756211f16267001854110191.
+//
+// Solidity: event GracePeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseGracePeriodUpdated(log types.Log) (*BunkerRegistryGracePeriodUpdated, error) {
+	event := new(BunkerRegistryGracePeriodUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "GracePeriodUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryMetadataUpdatedIterator is returned from FilterMetadataUpdated and is used to iterate over the raw logs and unpacked data for MetadataUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryMetadataUpdatedIterator struct {
+	Event *BunkerRegistryMetadataUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryMetadataUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryMetadataUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryMetadataUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryMetadataUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryMetadataUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryMetadataUpdated represents a MetadataUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryMetadataUpdated struct {
+	NameIndexed common.Hash
+	Name        string
+	Owner       common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterMetadataUpdated is a free log retrieval operation binding the contract event 0x216811aefb54a27978bda071ef6a3fac1ab61bbf27fe10ade3a8fe021f445dd7.
+//
+// Solidity: event MetadataUpdated(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterMetadataUpdated(opts *bind.FilterOpts, nameIndexed []string, owner []common.Address) (*BunkerRegistryMetadataUpdatedIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "MetadataUpdated", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryMetadataUpdatedIterator{contract: _BunkerRegistry.contract, event: "MetadataUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMetadataUpdated is a free log subscription operation binding the contract event 0x216811aefb54a27978bda071ef6a3fac1ab61bbf27fe10ade3a8fe021f445dd7.
+//
+// Solidity: event MetadataUpdated(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchMetadataUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryMetadataUpdated, nameIndexed []string, owner []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "MetadataUpdated", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryMetadataUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "MetadataUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMetadataUpdated is a log parse operation binding the contract event 0x216811aefb54a27978bda071ef6a3fac1ab61bbf27fe10ade3a8fe021f445dd7.
+//
+// Solidity: event MetadataUpdated(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseMetadataUpdated(log types.Log) (*BunkerRegistryMetadataUpdated, error) {
+	event := new(BunkerRegistryMetadataUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "MetadataUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the BunkerRegistry contract.
+type BunkerRegistryOwnershipTransferStartedIterator struct {
+	Event *BunkerRegistryOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the BunkerRegistry contract.
+type BunkerRegistryOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerRegistryOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryOwnershipTransferStartedIterator{contract: _BunkerRegistry.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BunkerRegistryOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryOwnershipTransferStarted)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseOwnershipTransferStarted(log types.Log) (*BunkerRegistryOwnershipTransferStarted, error) {
+	event := new(BunkerRegistryOwnershipTransferStarted)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BunkerRegistry contract.
+type BunkerRegistryOwnershipTransferredIterator struct {
+	Event *BunkerRegistryOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryOwnershipTransferred represents a OwnershipTransferred event raised by the BunkerRegistry contract.
+type BunkerRegistryOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerRegistryOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryOwnershipTransferredIterator{contract: _BunkerRegistry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BunkerRegistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryOwnershipTransferred)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseOwnershipTransferred(log types.Log) (*BunkerRegistryOwnershipTransferred, error) {
+	event := new(BunkerRegistryOwnershipTransferred)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the BunkerRegistry contract.
+type BunkerRegistryPausedIterator struct {
+	Event *BunkerRegistryPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryPaused represents a Paused event raised by the BunkerRegistry contract.
+type BunkerRegistryPaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterPaused(opts *bind.FilterOpts) (*BunkerRegistryPausedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryPausedIterator{contract: _BunkerRegistry.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *BunkerRegistryPaused) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryPaused)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParsePaused(log types.Log) (*BunkerRegistryPaused, error) {
+	event := new(BunkerRegistryPaused)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryPrimaryNameSetIterator is returned from FilterPrimaryNameSet and is used to iterate over the raw logs and unpacked data for PrimaryNameSet events raised by the BunkerRegistry contract.
+type BunkerRegistryPrimaryNameSetIterator struct {
+	Event *BunkerRegistryPrimaryNameSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryPrimaryNameSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryPrimaryNameSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryPrimaryNameSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryPrimaryNameSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryPrimaryNameSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryPrimaryNameSet represents a PrimaryNameSet event raised by the BunkerRegistry contract.
+type BunkerRegistryPrimaryNameSet struct {
+	DeploymentID [32]byte
+	Name         string
+	Owner        common.Address
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterPrimaryNameSet is a free log retrieval operation binding the contract event 0x7a8ce68d980cbfc1310c4a07d785ecdb27cb0fbcbd8eaf27d76f7dd7d1b0d7f9.
+//
+// Solidity: event PrimaryNameSet(bytes32 indexed deploymentID, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterPrimaryNameSet(opts *bind.FilterOpts, deploymentID [][32]byte, owner []common.Address) (*BunkerRegistryPrimaryNameSetIterator, error) {
+
+	var deploymentIDRule []interface{}
+	for _, deploymentIDItem := range deploymentID {
+		deploymentIDRule = append(deploymentIDRule, deploymentIDItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "PrimaryNameSet", deploymentIDRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryPrimaryNameSetIterator{contract: _BunkerRegistry.contract, event: "PrimaryNameSet", logs: logs, sub: sub}, nil
+}
+
+// WatchPrimaryNameSet is a free log subscription operation binding the contract event 0x7a8ce68d980cbfc1310c4a07d785ecdb27cb0fbcbd8eaf27d76f7dd7d1b0d7f9.
+//
+// Solidity: event PrimaryNameSet(bytes32 indexed deploymentID, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchPrimaryNameSet(opts *bind.WatchOpts, sink chan<- *BunkerRegistryPrimaryNameSet, deploymentID [][32]byte, owner []common.Address) (event.Subscription, error) {
+
+	var deploymentIDRule []interface{}
+	for _, deploymentIDItem := range deploymentID {
+		deploymentIDRule = append(deploymentIDRule, deploymentIDItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "PrimaryNameSet", deploymentIDRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryPrimaryNameSet)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "PrimaryNameSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePrimaryNameSet is a log parse operation binding the contract event 0x7a8ce68d980cbfc1310c4a07d785ecdb27cb0fbcbd8eaf27d76f7dd7d1b0d7f9.
+//
+// Solidity: event PrimaryNameSet(bytes32 indexed deploymentID, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParsePrimaryNameSet(log types.Log) (*BunkerRegistryPrimaryNameSet, error) {
+	event := new(BunkerRegistryPrimaryNameSet)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "PrimaryNameSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryReferralDiscountUpdatedIterator is returned from FilterReferralDiscountUpdated and is used to iterate over the raw logs and unpacked data for ReferralDiscountUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryReferralDiscountUpdatedIterator struct {
+	Event *BunkerRegistryReferralDiscountUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryReferralDiscountUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryReferralDiscountUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryReferralDiscountUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryReferralDiscountUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryReferralDiscountUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryReferralDiscountUpdated represents a ReferralDiscountUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryReferralDiscountUpdated struct {
+	OldBps *big.Int
+	NewBps *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterReferralDiscountUpdated is a free log retrieval operation binding the contract event 0x062059aa293a11d5474590143d5f595371302263fea1cd1bb4627d7c9d242fd0.
+//
+// Solidity: event ReferralDiscountUpdated(uint256 oldBps, uint256 newBps)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterReferralDiscountUpdated(opts *bind.FilterOpts) (*BunkerRegistryReferralDiscountUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ReferralDiscountUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryReferralDiscountUpdatedIterator{contract: _BunkerRegistry.contract, event: "ReferralDiscountUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchReferralDiscountUpdated is a free log subscription operation binding the contract event 0x062059aa293a11d5474590143d5f595371302263fea1cd1bb4627d7c9d242fd0.
+//
+// Solidity: event ReferralDiscountUpdated(uint256 oldBps, uint256 newBps)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchReferralDiscountUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryReferralDiscountUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ReferralDiscountUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryReferralDiscountUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ReferralDiscountUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReferralDiscountUpdated is a log parse operation binding the contract event 0x062059aa293a11d5474590143d5f595371302263fea1cd1bb4627d7c9d242fd0.
+//
+// Solidity: event ReferralDiscountUpdated(uint256 oldBps, uint256 newBps)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseReferralDiscountUpdated(log types.Log) (*BunkerRegistryReferralDiscountUpdated, error) {
+	event := new(BunkerRegistryReferralDiscountUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ReferralDiscountUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryReferralRewardUpdatedIterator is returned from FilterReferralRewardUpdated and is used to iterate over the raw logs and unpacked data for ReferralRewardUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryReferralRewardUpdatedIterator struct {
+	Event *BunkerRegistryReferralRewardUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryReferralRewardUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryReferralRewardUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryReferralRewardUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryReferralRewardUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryReferralRewardUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryReferralRewardUpdated represents a ReferralRewardUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryReferralRewardUpdated struct {
+	OldBps *big.Int
+	NewBps *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterReferralRewardUpdated is a free log retrieval operation binding the contract event 0x0ba2611e03c210377c7111f9c3f59febd751b32e081daa8d153f9e5aefc4d44a.
+//
+// Solidity: event ReferralRewardUpdated(uint256 oldBps, uint256 newBps)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterReferralRewardUpdated(opts *bind.FilterOpts) (*BunkerRegistryReferralRewardUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ReferralRewardUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryReferralRewardUpdatedIterator{contract: _BunkerRegistry.contract, event: "ReferralRewardUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchReferralRewardUpdated is a free log subscription operation binding the contract event 0x0ba2611e03c210377c7111f9c3f59febd751b32e081daa8d153f9e5aefc4d44a.
+//
+// Solidity: event ReferralRewardUpdated(uint256 oldBps, uint256 newBps)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchReferralRewardUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryReferralRewardUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ReferralRewardUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryReferralRewardUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ReferralRewardUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReferralRewardUpdated is a log parse operation binding the contract event 0x0ba2611e03c210377c7111f9c3f59febd751b32e081daa8d153f9e5aefc4d44a.
+//
+// Solidity: event ReferralRewardUpdated(uint256 oldBps, uint256 newBps)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseReferralRewardUpdated(log types.Log) (*BunkerRegistryReferralRewardUpdated, error) {
+	event := new(BunkerRegistryReferralRewardUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ReferralRewardUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryRegistrationFeeUpdatedIterator is returned from FilterRegistrationFeeUpdated and is used to iterate over the raw logs and unpacked data for RegistrationFeeUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryRegistrationFeeUpdatedIterator struct {
+	Event *BunkerRegistryRegistrationFeeUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryRegistrationFeeUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryRegistrationFeeUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryRegistrationFeeUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryRegistrationFeeUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryRegistrationFeeUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryRegistrationFeeUpdated represents a RegistrationFeeUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryRegistrationFeeUpdated struct {
+	OldFee *big.Int
+	NewFee *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterRegistrationFeeUpdated is a free log retrieval operation binding the contract event 0x50b218c5a101ad05d53ab0a964d01da639ee79525ae4b7802ed714249740a8d5.
+//
+// Solidity: event RegistrationFeeUpdated(uint256 oldFee, uint256 newFee)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterRegistrationFeeUpdated(opts *bind.FilterOpts) (*BunkerRegistryRegistrationFeeUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "RegistrationFeeUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryRegistrationFeeUpdatedIterator{contract: _BunkerRegistry.contract, event: "RegistrationFeeUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchRegistrationFeeUpdated is a free log subscription operation binding the contract event 0x50b218c5a101ad05d53ab0a964d01da639ee79525ae4b7802ed714249740a8d5.
+//
+// Solidity: event RegistrationFeeUpdated(uint256 oldFee, uint256 newFee)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchRegistrationFeeUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryRegistrationFeeUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "RegistrationFeeUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryRegistrationFeeUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "RegistrationFeeUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRegistrationFeeUpdated is a log parse operation binding the contract event 0x50b218c5a101ad05d53ab0a964d01da639ee79525ae4b7802ed714249740a8d5.
+//
+// Solidity: event RegistrationFeeUpdated(uint256 oldFee, uint256 newFee)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseRegistrationFeeUpdated(log types.Log) (*BunkerRegistryRegistrationFeeUpdated, error) {
+	event := new(BunkerRegistryRegistrationFeeUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "RegistrationFeeUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryReservationCancelledIterator is returned from FilterReservationCancelled and is used to iterate over the raw logs and unpacked data for ReservationCancelled events raised by the BunkerRegistry contract.
+type BunkerRegistryReservationCancelledIterator struct {
+	Event *BunkerRegistryReservationCancelled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryReservationCancelledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryReservationCancelled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryReservationCancelled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryReservationCancelledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryReservationCancelledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryReservationCancelled represents a ReservationCancelled event raised by the BunkerRegistry contract.
+type BunkerRegistryReservationCancelled struct {
+	NameIndexed common.Hash
+	Name        string
+	Owner       common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterReservationCancelled is a free log retrieval operation binding the contract event 0xd7ecf76eb8f3c47f70a74aeac050fdf2d18b948a777c8aa2835bc54ddeda231e.
+//
+// Solidity: event ReservationCancelled(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterReservationCancelled(opts *bind.FilterOpts, nameIndexed []string, owner []common.Address) (*BunkerRegistryReservationCancelledIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ReservationCancelled", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryReservationCancelledIterator{contract: _BunkerRegistry.contract, event: "ReservationCancelled", logs: logs, sub: sub}, nil
+}
+
+// WatchReservationCancelled is a free log subscription operation binding the contract event 0xd7ecf76eb8f3c47f70a74aeac050fdf2d18b948a777c8aa2835bc54ddeda231e.
+//
+// Solidity: event ReservationCancelled(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchReservationCancelled(opts *bind.WatchOpts, sink chan<- *BunkerRegistryReservationCancelled, nameIndexed []string, owner []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ReservationCancelled", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryReservationCancelled)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ReservationCancelled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReservationCancelled is a log parse operation binding the contract event 0xd7ecf76eb8f3c47f70a74aeac050fdf2d18b948a777c8aa2835bc54ddeda231e.
+//
+// Solidity: event ReservationCancelled(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseReservationCancelled(log types.Log) (*BunkerRegistryReservationCancelled, error) {
+	event := new(BunkerRegistryReservationCancelled)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ReservationCancelled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryReservationClaimedIterator is returned from FilterReservationClaimed and is used to iterate over the raw logs and unpacked data for ReservationClaimed events raised by the BunkerRegistry contract.
+type BunkerRegistryReservationClaimedIterator struct {
+	Event *BunkerRegistryReservationClaimed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryReservationClaimedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryReservationClaimed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryReservationClaimed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryReservationClaimedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryReservationClaimedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryReservationClaimed represents a ReservationClaimed event raised by the BunkerRegistry contract.
+type BunkerRegistryReservationClaimed struct {
+	NameIndexed  common.Hash
+	Name         string
+	Owner        common.Address
+	DeploymentID [32]byte
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterReservationClaimed is a free log retrieval operation binding the contract event 0xaf9cf492d92f51be75e0a41717d2eca55872e9c9640d946ea9276c417bafd0d3.
+//
+// Solidity: event ReservationClaimed(string indexed nameIndexed, string name, address indexed owner, bytes32 deploymentID)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterReservationClaimed(opts *bind.FilterOpts, nameIndexed []string, owner []common.Address) (*BunkerRegistryReservationClaimedIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ReservationClaimed", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryReservationClaimedIterator{contract: _BunkerRegistry.contract, event: "ReservationClaimed", logs: logs, sub: sub}, nil
+}
+
+// WatchReservationClaimed is a free log subscription operation binding the contract event 0xaf9cf492d92f51be75e0a41717d2eca55872e9c9640d946ea9276c417bafd0d3.
+//
+// Solidity: event ReservationClaimed(string indexed nameIndexed, string name, address indexed owner, bytes32 deploymentID)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchReservationClaimed(opts *bind.WatchOpts, sink chan<- *BunkerRegistryReservationClaimed, nameIndexed []string, owner []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ReservationClaimed", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryReservationClaimed)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ReservationClaimed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReservationClaimed is a log parse operation binding the contract event 0xaf9cf492d92f51be75e0a41717d2eca55872e9c9640d946ea9276c417bafd0d3.
+//
+// Solidity: event ReservationClaimed(string indexed nameIndexed, string name, address indexed owner, bytes32 deploymentID)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseReservationClaimed(log types.Log) (*BunkerRegistryReservationClaimed, error) {
+	event := new(BunkerRegistryReservationClaimed)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ReservationClaimed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryReservationPeriodUpdatedIterator is returned from FilterReservationPeriodUpdated and is used to iterate over the raw logs and unpacked data for ReservationPeriodUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryReservationPeriodUpdatedIterator struct {
+	Event *BunkerRegistryReservationPeriodUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryReservationPeriodUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryReservationPeriodUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryReservationPeriodUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryReservationPeriodUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryReservationPeriodUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryReservationPeriodUpdated represents a ReservationPeriodUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryReservationPeriodUpdated struct {
+	OldPeriod *big.Int
+	NewPeriod *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterReservationPeriodUpdated is a free log retrieval operation binding the contract event 0x1f5290971d7202a921176342fab127484a469b06550ba25e19bc5baa00b67332.
+//
+// Solidity: event ReservationPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterReservationPeriodUpdated(opts *bind.FilterOpts) (*BunkerRegistryReservationPeriodUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ReservationPeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryReservationPeriodUpdatedIterator{contract: _BunkerRegistry.contract, event: "ReservationPeriodUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchReservationPeriodUpdated is a free log subscription operation binding the contract event 0x1f5290971d7202a921176342fab127484a469b06550ba25e19bc5baa00b67332.
+//
+// Solidity: event ReservationPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchReservationPeriodUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryReservationPeriodUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ReservationPeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryReservationPeriodUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ReservationPeriodUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReservationPeriodUpdated is a log parse operation binding the contract event 0x1f5290971d7202a921176342fab127484a469b06550ba25e19bc5baa00b67332.
+//
+// Solidity: event ReservationPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseReservationPeriodUpdated(log types.Log) (*BunkerRegistryReservationPeriodUpdated, error) {
+	event := new(BunkerRegistryReservationPeriodUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ReservationPeriodUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryReservedNameUpdatedIterator is returned from FilterReservedNameUpdated and is used to iterate over the raw logs and unpacked data for ReservedNameUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryReservedNameUpdatedIterator struct {
+	Event *BunkerRegistryReservedNameUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryReservedNameUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryReservedNameUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryReservedNameUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryReservedNameUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryReservedNameUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryReservedNameUpdated represents a ReservedNameUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryReservedNameUpdated struct {
+	Name     string
+	Reserved bool
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterReservedNameUpdated is a free log retrieval operation binding the contract event 0x007b3f58008b6ebd21be6f46bb687e22a47a1e623603588c7889c4f23681d55e.
+//
+// Solidity: event ReservedNameUpdated(string name, bool reserved)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterReservedNameUpdated(opts *bind.FilterOpts) (*BunkerRegistryReservedNameUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ReservedNameUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryReservedNameUpdatedIterator{contract: _BunkerRegistry.contract, event: "ReservedNameUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchReservedNameUpdated is a free log subscription operation binding the contract event 0x007b3f58008b6ebd21be6f46bb687e22a47a1e623603588c7889c4f23681d55e.
+//
+// Solidity: event ReservedNameUpdated(string name, bool reserved)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchReservedNameUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryReservedNameUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ReservedNameUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryReservedNameUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ReservedNameUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReservedNameUpdated is a log parse operation binding the contract event 0x007b3f58008b6ebd21be6f46bb687e22a47a1e623603588c7889c4f23681d55e.
+//
+// Solidity: event ReservedNameUpdated(string name, bool reserved)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseReservedNameUpdated(log types.Log) (*BunkerRegistryReservedNameUpdated, error) {
+	event := new(BunkerRegistryReservedNameUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ReservedNameUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryShortNamesEnabledUpdatedIterator is returned from FilterShortNamesEnabledUpdated and is used to iterate over the raw logs and unpacked data for ShortNamesEnabledUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryShortNamesEnabledUpdatedIterator struct {
+	Event *BunkerRegistryShortNamesEnabledUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryShortNamesEnabledUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryShortNamesEnabledUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryShortNamesEnabledUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryShortNamesEnabledUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryShortNamesEnabledUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryShortNamesEnabledUpdated represents a ShortNamesEnabledUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryShortNamesEnabledUpdated struct {
+	Enabled bool
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterShortNamesEnabledUpdated is a free log retrieval operation binding the contract event 0xb5bd277f5de8e3ab27b8ec677e165e9b14868fb26bc569da39e21b3ed5c69ccd.
+//
+// Solidity: event ShortNamesEnabledUpdated(bool enabled)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterShortNamesEnabledUpdated(opts *bind.FilterOpts) (*BunkerRegistryShortNamesEnabledUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "ShortNamesEnabledUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryShortNamesEnabledUpdatedIterator{contract: _BunkerRegistry.contract, event: "ShortNamesEnabledUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchShortNamesEnabledUpdated is a free log subscription operation binding the contract event 0xb5bd277f5de8e3ab27b8ec677e165e9b14868fb26bc569da39e21b3ed5c69ccd.
+//
+// Solidity: event ShortNamesEnabledUpdated(bool enabled)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchShortNamesEnabledUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryShortNamesEnabledUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "ShortNamesEnabledUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryShortNamesEnabledUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "ShortNamesEnabledUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseShortNamesEnabledUpdated is a log parse operation binding the contract event 0xb5bd277f5de8e3ab27b8ec677e165e9b14868fb26bc569da39e21b3ed5c69ccd.
+//
+// Solidity: event ShortNamesEnabledUpdated(bool enabled)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseShortNamesEnabledUpdated(log types.Log) (*BunkerRegistryShortNamesEnabledUpdated, error) {
+	event := new(BunkerRegistryShortNamesEnabledUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "ShortNamesEnabledUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistrySquattedNameReclaimedIterator is returned from FilterSquattedNameReclaimed and is used to iterate over the raw logs and unpacked data for SquattedNameReclaimed events raised by the BunkerRegistry contract.
+type BunkerRegistrySquattedNameReclaimedIterator struct {
+	Event *BunkerRegistrySquattedNameReclaimed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistrySquattedNameReclaimedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistrySquattedNameReclaimed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistrySquattedNameReclaimed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistrySquattedNameReclaimedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistrySquattedNameReclaimedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistrySquattedNameReclaimed represents a SquattedNameReclaimed event raised by the BunkerRegistry contract.
+type BunkerRegistrySquattedNameReclaimed struct {
+	NameIndexed common.Hash
+	Name        string
+	Reclaimer   common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterSquattedNameReclaimed is a free log retrieval operation binding the contract event 0x5e9814c56725f590f0878c0872db7875aed61bb268867d274e4c59dae11e3923.
+//
+// Solidity: event SquattedNameReclaimed(string indexed nameIndexed, string name, address indexed reclaimer)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterSquattedNameReclaimed(opts *bind.FilterOpts, nameIndexed []string, reclaimer []common.Address) (*BunkerRegistrySquattedNameReclaimedIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var reclaimerRule []interface{}
+	for _, reclaimerItem := range reclaimer {
+		reclaimerRule = append(reclaimerRule, reclaimerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "SquattedNameReclaimed", nameIndexedRule, reclaimerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistrySquattedNameReclaimedIterator{contract: _BunkerRegistry.contract, event: "SquattedNameReclaimed", logs: logs, sub: sub}, nil
+}
+
+// WatchSquattedNameReclaimed is a free log subscription operation binding the contract event 0x5e9814c56725f590f0878c0872db7875aed61bb268867d274e4c59dae11e3923.
+//
+// Solidity: event SquattedNameReclaimed(string indexed nameIndexed, string name, address indexed reclaimer)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchSquattedNameReclaimed(opts *bind.WatchOpts, sink chan<- *BunkerRegistrySquattedNameReclaimed, nameIndexed []string, reclaimer []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var reclaimerRule []interface{}
+	for _, reclaimerItem := range reclaimer {
+		reclaimerRule = append(reclaimerRule, reclaimerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "SquattedNameReclaimed", nameIndexedRule, reclaimerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistrySquattedNameReclaimed)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "SquattedNameReclaimed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSquattedNameReclaimed is a log parse operation binding the contract event 0x5e9814c56725f590f0878c0872db7875aed61bb268867d274e4c59dae11e3923.
+//
+// Solidity: event SquattedNameReclaimed(string indexed nameIndexed, string name, address indexed reclaimer)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseSquattedNameReclaimed(log types.Log) (*BunkerRegistrySquattedNameReclaimed, error) {
+	event := new(BunkerRegistrySquattedNameReclaimed)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "SquattedNameReclaimed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistrySquattingGracePeriodUpdatedIterator is returned from FilterSquattingGracePeriodUpdated and is used to iterate over the raw logs and unpacked data for SquattingGracePeriodUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistrySquattingGracePeriodUpdatedIterator struct {
+	Event *BunkerRegistrySquattingGracePeriodUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistrySquattingGracePeriodUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistrySquattingGracePeriodUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistrySquattingGracePeriodUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistrySquattingGracePeriodUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistrySquattingGracePeriodUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistrySquattingGracePeriodUpdated represents a SquattingGracePeriodUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistrySquattingGracePeriodUpdated struct {
+	OldPeriod *big.Int
+	NewPeriod *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterSquattingGracePeriodUpdated is a free log retrieval operation binding the contract event 0x3e452c0fd86ddf6f5ade3ddcc4e4ff19a6daf5e5e0798a19ad36b85299c7c0db.
+//
+// Solidity: event SquattingGracePeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterSquattingGracePeriodUpdated(opts *bind.FilterOpts) (*BunkerRegistrySquattingGracePeriodUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "SquattingGracePeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistrySquattingGracePeriodUpdatedIterator{contract: _BunkerRegistry.contract, event: "SquattingGracePeriodUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchSquattingGracePeriodUpdated is a free log subscription operation binding the contract event 0x3e452c0fd86ddf6f5ade3ddcc4e4ff19a6daf5e5e0798a19ad36b85299c7c0db.
+//
+// Solidity: event SquattingGracePeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchSquattingGracePeriodUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistrySquattingGracePeriodUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "SquattingGracePeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistrySquattingGracePeriodUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "SquattingGracePeriodUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSquattingGracePeriodUpdated is a log parse operation binding the contract event 0x3e452c0fd86ddf6f5ade3ddcc4e4ff19a6daf5e5e0798a19ad36b85299c7c0db.
+//
+// Solidity: event SquattingGracePeriodUpdated(uint256 oldPeriod, uint256 newPeriod)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseSquattingGracePeriodUpdated(log types.Log) (*BunkerRegistrySquattingGracePeriodUpdated, error) {
+	event := new(BunkerRegistrySquattingGracePeriodUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "SquattingGracePeriodUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryStakingContractUpdatedIterator is returned from FilterStakingContractUpdated and is used to iterate over the raw logs and unpacked data for StakingContractUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryStakingContractUpdatedIterator struct {
+	Event *BunkerRegistryStakingContractUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryStakingContractUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryStakingContractUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryStakingContractUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryStakingContractUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryStakingContractUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryStakingContractUpdated represents a StakingContractUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryStakingContractUpdated struct {
+	OldAddr common.Address
+	NewAddr common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakingContractUpdated is a free log retrieval operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address oldAddr, address newAddr)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterStakingContractUpdated(opts *bind.FilterOpts) (*BunkerRegistryStakingContractUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "StakingContractUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryStakingContractUpdatedIterator{contract: _BunkerRegistry.contract, event: "StakingContractUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchStakingContractUpdated is a free log subscription operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address oldAddr, address newAddr)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchStakingContractUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryStakingContractUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "StakingContractUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryStakingContractUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "StakingContractUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakingContractUpdated is a log parse operation binding the contract event 0x7042586b23181180eb30b4798702d7a0233b7fc2551e89806770e8e5d9392e6a.
+//
+// Solidity: event StakingContractUpdated(address oldAddr, address newAddr)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseStakingContractUpdated(log types.Log) (*BunkerRegistryStakingContractUpdated, error) {
+	event := new(BunkerRegistryStakingContractUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "StakingContractUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistrySubdomainRegisteredIterator is returned from FilterSubdomainRegistered and is used to iterate over the raw logs and unpacked data for SubdomainRegistered events raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainRegisteredIterator struct {
+	Event *BunkerRegistrySubdomainRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistrySubdomainRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistrySubdomainRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistrySubdomainRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistrySubdomainRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistrySubdomainRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistrySubdomainRegistered represents a SubdomainRegistered event raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainRegistered struct {
+	NameIndexed  common.Hash
+	Name         string
+	Owner        common.Address
+	DeploymentID [32]byte
+	Fee          *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterSubdomainRegistered is a free log retrieval operation binding the contract event 0x90cdbde7f62657b2152b1e93f0ac32008757530f4d60f8292ba2e440d0015459.
+//
+// Solidity: event SubdomainRegistered(string indexed nameIndexed, string name, address indexed owner, bytes32 deploymentID, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterSubdomainRegistered(opts *bind.FilterOpts, nameIndexed []string, owner []common.Address) (*BunkerRegistrySubdomainRegisteredIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "SubdomainRegistered", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistrySubdomainRegisteredIterator{contract: _BunkerRegistry.contract, event: "SubdomainRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchSubdomainRegistered is a free log subscription operation binding the contract event 0x90cdbde7f62657b2152b1e93f0ac32008757530f4d60f8292ba2e440d0015459.
+//
+// Solidity: event SubdomainRegistered(string indexed nameIndexed, string name, address indexed owner, bytes32 deploymentID, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchSubdomainRegistered(opts *bind.WatchOpts, sink chan<- *BunkerRegistrySubdomainRegistered, nameIndexed []string, owner []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "SubdomainRegistered", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistrySubdomainRegistered)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSubdomainRegistered is a log parse operation binding the contract event 0x90cdbde7f62657b2152b1e93f0ac32008757530f4d60f8292ba2e440d0015459.
+//
+// Solidity: event SubdomainRegistered(string indexed nameIndexed, string name, address indexed owner, bytes32 deploymentID, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseSubdomainRegistered(log types.Log) (*BunkerRegistrySubdomainRegistered, error) {
+	event := new(BunkerRegistrySubdomainRegistered)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistrySubdomainReleasedIterator is returned from FilterSubdomainReleased and is used to iterate over the raw logs and unpacked data for SubdomainReleased events raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainReleasedIterator struct {
+	Event *BunkerRegistrySubdomainReleased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistrySubdomainReleasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistrySubdomainReleased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistrySubdomainReleased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistrySubdomainReleasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistrySubdomainReleasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistrySubdomainReleased represents a SubdomainReleased event raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainReleased struct {
+	NameIndexed common.Hash
+	Name        string
+	Owner       common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterSubdomainReleased is a free log retrieval operation binding the contract event 0x614e1837690e3a5f44d0508c4bfd8b1ed7c5c0712b3f73bb80bd6182ed3e0711.
+//
+// Solidity: event SubdomainReleased(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterSubdomainReleased(opts *bind.FilterOpts, nameIndexed []string, owner []common.Address) (*BunkerRegistrySubdomainReleasedIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "SubdomainReleased", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistrySubdomainReleasedIterator{contract: _BunkerRegistry.contract, event: "SubdomainReleased", logs: logs, sub: sub}, nil
+}
+
+// WatchSubdomainReleased is a free log subscription operation binding the contract event 0x614e1837690e3a5f44d0508c4bfd8b1ed7c5c0712b3f73bb80bd6182ed3e0711.
+//
+// Solidity: event SubdomainReleased(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchSubdomainReleased(opts *bind.WatchOpts, sink chan<- *BunkerRegistrySubdomainReleased, nameIndexed []string, owner []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "SubdomainReleased", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistrySubdomainReleased)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainReleased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSubdomainReleased is a log parse operation binding the contract event 0x614e1837690e3a5f44d0508c4bfd8b1ed7c5c0712b3f73bb80bd6182ed3e0711.
+//
+// Solidity: event SubdomainReleased(string indexed nameIndexed, string name, address indexed owner)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseSubdomainReleased(log types.Log) (*BunkerRegistrySubdomainReleased, error) {
+	event := new(BunkerRegistrySubdomainReleased)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainReleased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistrySubdomainRenewedIterator is returned from FilterSubdomainRenewed and is used to iterate over the raw logs and unpacked data for SubdomainRenewed events raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainRenewedIterator struct {
+	Event *BunkerRegistrySubdomainRenewed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistrySubdomainRenewedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistrySubdomainRenewed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistrySubdomainRenewed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistrySubdomainRenewedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistrySubdomainRenewedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistrySubdomainRenewed represents a SubdomainRenewed event raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainRenewed struct {
+	NameIndexed common.Hash
+	Name        string
+	Owner       common.Address
+	NewExpiry   *big.Int
+	Fee         *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterSubdomainRenewed is a free log retrieval operation binding the contract event 0x2e98e19c2a8c2ce70e2441a77a2770df5db240889d406093fd58187d6e1e23df.
+//
+// Solidity: event SubdomainRenewed(string indexed nameIndexed, string name, address indexed owner, uint48 newExpiry, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterSubdomainRenewed(opts *bind.FilterOpts, nameIndexed []string, owner []common.Address) (*BunkerRegistrySubdomainRenewedIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "SubdomainRenewed", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistrySubdomainRenewedIterator{contract: _BunkerRegistry.contract, event: "SubdomainRenewed", logs: logs, sub: sub}, nil
+}
+
+// WatchSubdomainRenewed is a free log subscription operation binding the contract event 0x2e98e19c2a8c2ce70e2441a77a2770df5db240889d406093fd58187d6e1e23df.
+//
+// Solidity: event SubdomainRenewed(string indexed nameIndexed, string name, address indexed owner, uint48 newExpiry, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchSubdomainRenewed(opts *bind.WatchOpts, sink chan<- *BunkerRegistrySubdomainRenewed, nameIndexed []string, owner []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "SubdomainRenewed", nameIndexedRule, ownerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistrySubdomainRenewed)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainRenewed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSubdomainRenewed is a log parse operation binding the contract event 0x2e98e19c2a8c2ce70e2441a77a2770df5db240889d406093fd58187d6e1e23df.
+//
+// Solidity: event SubdomainRenewed(string indexed nameIndexed, string name, address indexed owner, uint48 newExpiry, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseSubdomainRenewed(log types.Log) (*BunkerRegistrySubdomainRenewed, error) {
+	event := new(BunkerRegistrySubdomainRenewed)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainRenewed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistrySubdomainReservedIterator is returned from FilterSubdomainReserved and is used to iterate over the raw logs and unpacked data for SubdomainReserved events raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainReservedIterator struct {
+	Event *BunkerRegistrySubdomainReserved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistrySubdomainReservedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistrySubdomainReserved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistrySubdomainReserved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistrySubdomainReservedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistrySubdomainReservedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistrySubdomainReserved represents a SubdomainReserved event raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainReserved struct {
+	NameIndexed   common.Hash
+	Name          string
+	Reserver      common.Address
+	ReservedUntil *big.Int
+	Fee           *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterSubdomainReserved is a free log retrieval operation binding the contract event 0xeff1b6ffacd6e50cc00d5a112fdfccf13d7871b360f51c34018056f13aec8406.
+//
+// Solidity: event SubdomainReserved(string indexed nameIndexed, string name, address indexed reserver, uint48 reservedUntil, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterSubdomainReserved(opts *bind.FilterOpts, nameIndexed []string, reserver []common.Address) (*BunkerRegistrySubdomainReservedIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var reserverRule []interface{}
+	for _, reserverItem := range reserver {
+		reserverRule = append(reserverRule, reserverItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "SubdomainReserved", nameIndexedRule, reserverRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistrySubdomainReservedIterator{contract: _BunkerRegistry.contract, event: "SubdomainReserved", logs: logs, sub: sub}, nil
+}
+
+// WatchSubdomainReserved is a free log subscription operation binding the contract event 0xeff1b6ffacd6e50cc00d5a112fdfccf13d7871b360f51c34018056f13aec8406.
+//
+// Solidity: event SubdomainReserved(string indexed nameIndexed, string name, address indexed reserver, uint48 reservedUntil, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchSubdomainReserved(opts *bind.WatchOpts, sink chan<- *BunkerRegistrySubdomainReserved, nameIndexed []string, reserver []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var reserverRule []interface{}
+	for _, reserverItem := range reserver {
+		reserverRule = append(reserverRule, reserverItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "SubdomainReserved", nameIndexedRule, reserverRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistrySubdomainReserved)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainReserved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSubdomainReserved is a log parse operation binding the contract event 0xeff1b6ffacd6e50cc00d5a112fdfccf13d7871b360f51c34018056f13aec8406.
+//
+// Solidity: event SubdomainReserved(string indexed nameIndexed, string name, address indexed reserver, uint48 reservedUntil, uint256 fee)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseSubdomainReserved(log types.Log) (*BunkerRegistrySubdomainReserved, error) {
+	event := new(BunkerRegistrySubdomainReserved)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainReserved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistrySubdomainTransferredIterator is returned from FilterSubdomainTransferred and is used to iterate over the raw logs and unpacked data for SubdomainTransferred events raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainTransferredIterator struct {
+	Event *BunkerRegistrySubdomainTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistrySubdomainTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistrySubdomainTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistrySubdomainTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistrySubdomainTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistrySubdomainTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistrySubdomainTransferred represents a SubdomainTransferred event raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainTransferred struct {
+	NameIndexed common.Hash
+	Name        string
+	From        common.Address
+	To          common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterSubdomainTransferred is a free log retrieval operation binding the contract event 0xff6d4da279e86476cdb01668762ba2693d53c1d0169b50ca4c6bb52c1c72f7a1.
+//
+// Solidity: event SubdomainTransferred(string indexed nameIndexed, string name, address indexed from, address indexed to)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterSubdomainTransferred(opts *bind.FilterOpts, nameIndexed []string, from []common.Address, to []common.Address) (*BunkerRegistrySubdomainTransferredIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "SubdomainTransferred", nameIndexedRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistrySubdomainTransferredIterator{contract: _BunkerRegistry.contract, event: "SubdomainTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchSubdomainTransferred is a free log subscription operation binding the contract event 0xff6d4da279e86476cdb01668762ba2693d53c1d0169b50ca4c6bb52c1c72f7a1.
+//
+// Solidity: event SubdomainTransferred(string indexed nameIndexed, string name, address indexed from, address indexed to)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchSubdomainTransferred(opts *bind.WatchOpts, sink chan<- *BunkerRegistrySubdomainTransferred, nameIndexed []string, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "SubdomainTransferred", nameIndexedRule, fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistrySubdomainTransferred)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSubdomainTransferred is a log parse operation binding the contract event 0xff6d4da279e86476cdb01668762ba2693d53c1d0169b50ca4c6bb52c1c72f7a1.
+//
+// Solidity: event SubdomainTransferred(string indexed nameIndexed, string name, address indexed from, address indexed to)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseSubdomainTransferred(log types.Log) (*BunkerRegistrySubdomainTransferred, error) {
+	event := new(BunkerRegistrySubdomainTransferred)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistrySubdomainUpdatedIterator is returned from FilterSubdomainUpdated and is used to iterate over the raw logs and unpacked data for SubdomainUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainUpdatedIterator struct {
+	Event *BunkerRegistrySubdomainUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistrySubdomainUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistrySubdomainUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistrySubdomainUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistrySubdomainUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistrySubdomainUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistrySubdomainUpdated represents a SubdomainUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistrySubdomainUpdated struct {
+	NameIndexed     common.Hash
+	Name            string
+	OldDeploymentID [32]byte
+	NewDeploymentID [32]byte
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterSubdomainUpdated is a free log retrieval operation binding the contract event 0xed824acc29caa90335a2426c549a404f7cf5863b73983c53b8b03493870d1fd8.
+//
+// Solidity: event SubdomainUpdated(string indexed nameIndexed, string name, bytes32 oldDeploymentID, bytes32 newDeploymentID)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterSubdomainUpdated(opts *bind.FilterOpts, nameIndexed []string) (*BunkerRegistrySubdomainUpdatedIterator, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "SubdomainUpdated", nameIndexedRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistrySubdomainUpdatedIterator{contract: _BunkerRegistry.contract, event: "SubdomainUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchSubdomainUpdated is a free log subscription operation binding the contract event 0xed824acc29caa90335a2426c549a404f7cf5863b73983c53b8b03493870d1fd8.
+//
+// Solidity: event SubdomainUpdated(string indexed nameIndexed, string name, bytes32 oldDeploymentID, bytes32 newDeploymentID)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchSubdomainUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistrySubdomainUpdated, nameIndexed []string) (event.Subscription, error) {
+
+	var nameIndexedRule []interface{}
+	for _, nameIndexedItem := range nameIndexed {
+		nameIndexedRule = append(nameIndexedRule, nameIndexedItem)
+	}
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "SubdomainUpdated", nameIndexedRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistrySubdomainUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSubdomainUpdated is a log parse operation binding the contract event 0xed824acc29caa90335a2426c549a404f7cf5863b73983c53b8b03493870d1fd8.
+//
+// Solidity: event SubdomainUpdated(string indexed nameIndexed, string name, bytes32 oldDeploymentID, bytes32 newDeploymentID)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseSubdomainUpdated(log types.Log) (*BunkerRegistrySubdomainUpdated, error) {
+	event := new(BunkerRegistrySubdomainUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "SubdomainUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryTreasuryUpdatedIterator is returned from FilterTreasuryUpdated and is used to iterate over the raw logs and unpacked data for TreasuryUpdated events raised by the BunkerRegistry contract.
+type BunkerRegistryTreasuryUpdatedIterator struct {
+	Event *BunkerRegistryTreasuryUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryTreasuryUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryTreasuryUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryTreasuryUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryTreasuryUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryTreasuryUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryTreasuryUpdated represents a TreasuryUpdated event raised by the BunkerRegistry contract.
+type BunkerRegistryTreasuryUpdated struct {
+	OldTreasury common.Address
+	NewTreasury common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterTreasuryUpdated is a free log retrieval operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address oldTreasury, address newTreasury)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterTreasuryUpdated(opts *bind.FilterOpts) (*BunkerRegistryTreasuryUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "TreasuryUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryTreasuryUpdatedIterator{contract: _BunkerRegistry.contract, event: "TreasuryUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchTreasuryUpdated is a free log subscription operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address oldTreasury, address newTreasury)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchTreasuryUpdated(opts *bind.WatchOpts, sink chan<- *BunkerRegistryTreasuryUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "TreasuryUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryTreasuryUpdated)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "TreasuryUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTreasuryUpdated is a log parse operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address oldTreasury, address newTreasury)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseTreasuryUpdated(log types.Log) (*BunkerRegistryTreasuryUpdated, error) {
+	event := new(BunkerRegistryTreasuryUpdated)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "TreasuryUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerRegistryUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the BunkerRegistry contract.
+type BunkerRegistryUnpausedIterator struct {
+	Event *BunkerRegistryUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerRegistryUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerRegistryUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerRegistryUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerRegistryUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerRegistryUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerRegistryUnpaused represents a Unpaused event raised by the BunkerRegistry contract.
+type BunkerRegistryUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerRegistry *BunkerRegistryFilterer) FilterUnpaused(opts *bind.FilterOpts) (*BunkerRegistryUnpausedIterator, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerRegistryUnpausedIterator{contract: _BunkerRegistry.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerRegistry *BunkerRegistryFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *BunkerRegistryUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerRegistry.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerRegistryUnpaused)
+				if err := _BunkerRegistry.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerRegistry *BunkerRegistryFilterer) ParseUnpaused(log types.Log) (*BunkerRegistryUnpaused, error) {
+	event := new(BunkerRegistryUnpaused)
+	if err := _BunkerRegistry.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/payment/bindings/bunkerreputation.go
+++ b/internal/payment/bindings/bunkerreputation.go
@@ -1,0 +1,3361 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BunkerReputationReputationData is an auto generated low-level Go binding around an user-defined struct.
+type BunkerReputationReputationData struct {
+	Score         uint32
+	JobsCompleted uint32
+	JobsFailed    uint32
+	SlashCount    uint32
+	LastUpdated   *big.Int
+	RegisteredAt  *big.Int
+}
+
+// BunkerReputationMetaData contains all meta data concerning the BunkerReputation contract.
+var BunkerReputationMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_initialOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"INITIAL_SCORE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_SCORE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"REPORTER_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"WEEK\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"applyDecay\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"decayFloor\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"decayRate\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getReputation\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"data\",\"type\":\"tuple\",\"internalType\":\"structBunkerReputation.ReputationData\",\"components\":[{\"name\":\"score\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"jobsCompleted\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"jobsFailed\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"slashCount\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"lastUpdated\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"registeredAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getScore\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getTier\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"enumBunkerReputation.ReputationTier\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"healthFailDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isEligibleForJobs\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"eligible\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"jobCompletedDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"jobEarlyDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"jobTimeoutDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"maxCustomDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"minCustomDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"minScoreForJobs\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"perfectUptimeDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"recordEvent\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"delta\",\"type\":\"int16\",\"internalType\":\"int16\"},{\"name\":\"reason\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"recordJobCompleted\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"recordJobFailed\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"recordSlashEvent\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerProvider\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"replicaMismatchDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"reputations\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"score\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"jobsCompleted\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"jobsFailed\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"slashCount\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"lastUpdated\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"registeredAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"securityViolationDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setDecayParams\",\"inputs\":[{\"name\":\"rate\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"floor\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setDeltaParameters\",\"inputs\":[{\"name\":\"_jobCompletedDelta\",\"type\":\"int16\",\"internalType\":\"int16\"},{\"name\":\"_jobEarlyDelta\",\"type\":\"int16\",\"internalType\":\"int16\"},{\"name\":\"_perfectUptimeDelta\",\"type\":\"int16\",\"internalType\":\"int16\"},{\"name\":\"_jobTimeoutDelta\",\"type\":\"int16\",\"internalType\":\"int16\"},{\"name\":\"_healthFailDelta\",\"type\":\"int16\",\"internalType\":\"int16\"},{\"name\":\"_replicaMismatchDelta\",\"type\":\"int16\",\"internalType\":\"int16\"},{\"name\":\"_slashEventDelta\",\"type\":\"int16\",\"internalType\":\"int16\"},{\"name\":\"_securityViolationDelta\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMaxCustomDelta\",\"inputs\":[{\"name\":\"maxDelta\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMinScoreForJobs\",\"inputs\":[{\"name\":\"_minScore\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTierThresholds\",\"inputs\":[{\"name\":\"probation\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"standard\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"trusted\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"elite\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"slashEventDelta\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"int16\",\"internalType\":\"int16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"tierElite\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"tierProbation\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"tierStandard\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"tierTrusted\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"DecayParamsUpdated\",\"inputs\":[{\"name\":\"rate\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"floor\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DeltaParametersUpdated\",\"inputs\":[],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MaxCustomDeltaUpdated\",\"inputs\":[{\"name\":\"maxDelta\",\"type\":\"int16\",\"indexed\":false,\"internalType\":\"int16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MinScoreForJobsUpdated\",\"inputs\":[{\"name\":\"minScore\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderRegistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ScoreUpdated\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"oldScore\",\"type\":\"uint32\",\"indexed\":false,\"internalType\":\"uint32\"},{\"name\":\"newScore\",\"type\":\"uint32\",\"indexed\":false,\"internalType\":\"uint32\"},{\"name\":\"reason\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TierThresholdsUpdated\",\"inputs\":[{\"name\":\"probation\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"},{\"name\":\"standard\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"},{\"name\":\"trusted\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"},{\"name\":\"elite\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"DeltaOutOfBounds\",\"inputs\":[{\"name\":\"delta\",\"type\":\"int16\",\"internalType\":\"int16\"}]},{\"type\":\"error\",\"name\":\"FloorTooHigh\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidDelta\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NegativeDeltaRequired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"PositiveDeltaRequired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ProviderAlreadyRegistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProviderNotRegistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ScoreExceedsMax\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ScoreOverflow\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ThresholdExceedsMax\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ThresholdsNotAscending\",\"inputs\":[]}]",
+}
+
+// BunkerReputationABI is the input ABI used to generate the binding from.
+// Deprecated: Use BunkerReputationMetaData.ABI instead.
+var BunkerReputationABI = BunkerReputationMetaData.ABI
+
+// BunkerReputation is an auto generated Go binding around an Ethereum contract.
+type BunkerReputation struct {
+	BunkerReputationCaller     // Read-only binding to the contract
+	BunkerReputationTransactor // Write-only binding to the contract
+	BunkerReputationFilterer   // Log filterer for contract events
+}
+
+// BunkerReputationCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BunkerReputationCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerReputationTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BunkerReputationTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerReputationFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BunkerReputationFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerReputationSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BunkerReputationSession struct {
+	Contract     *BunkerReputation // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BunkerReputationCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BunkerReputationCallerSession struct {
+	Contract *BunkerReputationCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// BunkerReputationTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BunkerReputationTransactorSession struct {
+	Contract     *BunkerReputationTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// BunkerReputationRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BunkerReputationRaw struct {
+	Contract *BunkerReputation // Generic contract binding to access the raw methods on
+}
+
+// BunkerReputationCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BunkerReputationCallerRaw struct {
+	Contract *BunkerReputationCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BunkerReputationTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BunkerReputationTransactorRaw struct {
+	Contract *BunkerReputationTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBunkerReputation creates a new instance of BunkerReputation, bound to a specific deployed contract.
+func NewBunkerReputation(address common.Address, backend bind.ContractBackend) (*BunkerReputation, error) {
+	contract, err := bindBunkerReputation(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputation{BunkerReputationCaller: BunkerReputationCaller{contract: contract}, BunkerReputationTransactor: BunkerReputationTransactor{contract: contract}, BunkerReputationFilterer: BunkerReputationFilterer{contract: contract}}, nil
+}
+
+// NewBunkerReputationCaller creates a new read-only instance of BunkerReputation, bound to a specific deployed contract.
+func NewBunkerReputationCaller(address common.Address, caller bind.ContractCaller) (*BunkerReputationCaller, error) {
+	contract, err := bindBunkerReputation(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationCaller{contract: contract}, nil
+}
+
+// NewBunkerReputationTransactor creates a new write-only instance of BunkerReputation, bound to a specific deployed contract.
+func NewBunkerReputationTransactor(address common.Address, transactor bind.ContractTransactor) (*BunkerReputationTransactor, error) {
+	contract, err := bindBunkerReputation(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationTransactor{contract: contract}, nil
+}
+
+// NewBunkerReputationFilterer creates a new log filterer instance of BunkerReputation, bound to a specific deployed contract.
+func NewBunkerReputationFilterer(address common.Address, filterer bind.ContractFilterer) (*BunkerReputationFilterer, error) {
+	contract, err := bindBunkerReputation(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationFilterer{contract: contract}, nil
+}
+
+// bindBunkerReputation binds a generic wrapper to an already deployed contract.
+func bindBunkerReputation(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BunkerReputationMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerReputation *BunkerReputationRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerReputation.Contract.BunkerReputationCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerReputation *BunkerReputationRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.BunkerReputationTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerReputation *BunkerReputationRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.BunkerReputationTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerReputation *BunkerReputationCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerReputation.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerReputation *BunkerReputationTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerReputation *BunkerReputationTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.contract.Transact(opts, method, params...)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerReputation *BunkerReputationCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerReputation *BunkerReputationSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BunkerReputation.Contract.DEFAULTADMINROLE(&_BunkerReputation.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerReputation *BunkerReputationCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BunkerReputation.Contract.DEFAULTADMINROLE(&_BunkerReputation.CallOpts)
+}
+
+// INITIALSCORE is a free data retrieval call binding the contract method 0xde330373.
+//
+// Solidity: function INITIAL_SCORE() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCaller) INITIALSCORE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "INITIAL_SCORE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// INITIALSCORE is a free data retrieval call binding the contract method 0xde330373.
+//
+// Solidity: function INITIAL_SCORE() view returns(uint256)
+func (_BunkerReputation *BunkerReputationSession) INITIALSCORE() (*big.Int, error) {
+	return _BunkerReputation.Contract.INITIALSCORE(&_BunkerReputation.CallOpts)
+}
+
+// INITIALSCORE is a free data retrieval call binding the contract method 0xde330373.
+//
+// Solidity: function INITIAL_SCORE() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCallerSession) INITIALSCORE() (*big.Int, error) {
+	return _BunkerReputation.Contract.INITIALSCORE(&_BunkerReputation.CallOpts)
+}
+
+// MAXSCORE is a free data retrieval call binding the contract method 0x27ff6223.
+//
+// Solidity: function MAX_SCORE() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCaller) MAXSCORE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "MAX_SCORE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXSCORE is a free data retrieval call binding the contract method 0x27ff6223.
+//
+// Solidity: function MAX_SCORE() view returns(uint256)
+func (_BunkerReputation *BunkerReputationSession) MAXSCORE() (*big.Int, error) {
+	return _BunkerReputation.Contract.MAXSCORE(&_BunkerReputation.CallOpts)
+}
+
+// MAXSCORE is a free data retrieval call binding the contract method 0x27ff6223.
+//
+// Solidity: function MAX_SCORE() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCallerSession) MAXSCORE() (*big.Int, error) {
+	return _BunkerReputation.Contract.MAXSCORE(&_BunkerReputation.CallOpts)
+}
+
+// REPORTERROLE is a free data retrieval call binding the contract method 0x3f60d799.
+//
+// Solidity: function REPORTER_ROLE() view returns(bytes32)
+func (_BunkerReputation *BunkerReputationCaller) REPORTERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "REPORTER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// REPORTERROLE is a free data retrieval call binding the contract method 0x3f60d799.
+//
+// Solidity: function REPORTER_ROLE() view returns(bytes32)
+func (_BunkerReputation *BunkerReputationSession) REPORTERROLE() ([32]byte, error) {
+	return _BunkerReputation.Contract.REPORTERROLE(&_BunkerReputation.CallOpts)
+}
+
+// REPORTERROLE is a free data retrieval call binding the contract method 0x3f60d799.
+//
+// Solidity: function REPORTER_ROLE() view returns(bytes32)
+func (_BunkerReputation *BunkerReputationCallerSession) REPORTERROLE() ([32]byte, error) {
+	return _BunkerReputation.Contract.REPORTERROLE(&_BunkerReputation.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerReputation *BunkerReputationCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerReputation *BunkerReputationSession) VERSION() (string, error) {
+	return _BunkerReputation.Contract.VERSION(&_BunkerReputation.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerReputation *BunkerReputationCallerSession) VERSION() (string, error) {
+	return _BunkerReputation.Contract.VERSION(&_BunkerReputation.CallOpts)
+}
+
+// WEEK is a free data retrieval call binding the contract method 0xf4359ce5.
+//
+// Solidity: function WEEK() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCaller) WEEK(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "WEEK")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// WEEK is a free data retrieval call binding the contract method 0xf4359ce5.
+//
+// Solidity: function WEEK() view returns(uint256)
+func (_BunkerReputation *BunkerReputationSession) WEEK() (*big.Int, error) {
+	return _BunkerReputation.Contract.WEEK(&_BunkerReputation.CallOpts)
+}
+
+// WEEK is a free data retrieval call binding the contract method 0xf4359ce5.
+//
+// Solidity: function WEEK() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCallerSession) WEEK() (*big.Int, error) {
+	return _BunkerReputation.Contract.WEEK(&_BunkerReputation.CallOpts)
+}
+
+// DecayFloor is a free data retrieval call binding the contract method 0x9861f58c.
+//
+// Solidity: function decayFloor() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCaller) DecayFloor(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "decayFloor")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// DecayFloor is a free data retrieval call binding the contract method 0x9861f58c.
+//
+// Solidity: function decayFloor() view returns(uint256)
+func (_BunkerReputation *BunkerReputationSession) DecayFloor() (*big.Int, error) {
+	return _BunkerReputation.Contract.DecayFloor(&_BunkerReputation.CallOpts)
+}
+
+// DecayFloor is a free data retrieval call binding the contract method 0x9861f58c.
+//
+// Solidity: function decayFloor() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCallerSession) DecayFloor() (*big.Int, error) {
+	return _BunkerReputation.Contract.DecayFloor(&_BunkerReputation.CallOpts)
+}
+
+// DecayRate is a free data retrieval call binding the contract method 0xa9c1f2f1.
+//
+// Solidity: function decayRate() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCaller) DecayRate(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "decayRate")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// DecayRate is a free data retrieval call binding the contract method 0xa9c1f2f1.
+//
+// Solidity: function decayRate() view returns(uint256)
+func (_BunkerReputation *BunkerReputationSession) DecayRate() (*big.Int, error) {
+	return _BunkerReputation.Contract.DecayRate(&_BunkerReputation.CallOpts)
+}
+
+// DecayRate is a free data retrieval call binding the contract method 0xa9c1f2f1.
+//
+// Solidity: function decayRate() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCallerSession) DecayRate() (*big.Int, error) {
+	return _BunkerReputation.Contract.DecayRate(&_BunkerReputation.CallOpts)
+}
+
+// GetReputation is a free data retrieval call binding the contract method 0x9c89a0e2.
+//
+// Solidity: function getReputation(address provider) view returns((uint32,uint32,uint32,uint32,uint48,uint48) data)
+func (_BunkerReputation *BunkerReputationCaller) GetReputation(opts *bind.CallOpts, provider common.Address) (BunkerReputationReputationData, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "getReputation", provider)
+
+	if err != nil {
+		return *new(BunkerReputationReputationData), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerReputationReputationData)).(*BunkerReputationReputationData)
+
+	return out0, err
+
+}
+
+// GetReputation is a free data retrieval call binding the contract method 0x9c89a0e2.
+//
+// Solidity: function getReputation(address provider) view returns((uint32,uint32,uint32,uint32,uint48,uint48) data)
+func (_BunkerReputation *BunkerReputationSession) GetReputation(provider common.Address) (BunkerReputationReputationData, error) {
+	return _BunkerReputation.Contract.GetReputation(&_BunkerReputation.CallOpts, provider)
+}
+
+// GetReputation is a free data retrieval call binding the contract method 0x9c89a0e2.
+//
+// Solidity: function getReputation(address provider) view returns((uint32,uint32,uint32,uint32,uint48,uint48) data)
+func (_BunkerReputation *BunkerReputationCallerSession) GetReputation(provider common.Address) (BunkerReputationReputationData, error) {
+	return _BunkerReputation.Contract.GetReputation(&_BunkerReputation.CallOpts, provider)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerReputation *BunkerReputationCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerReputation *BunkerReputationSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BunkerReputation.Contract.GetRoleAdmin(&_BunkerReputation.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerReputation *BunkerReputationCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BunkerReputation.Contract.GetRoleAdmin(&_BunkerReputation.CallOpts, role)
+}
+
+// GetScore is a free data retrieval call binding the contract method 0xd47875d0.
+//
+// Solidity: function getScore(address provider) view returns(uint32)
+func (_BunkerReputation *BunkerReputationCaller) GetScore(opts *bind.CallOpts, provider common.Address) (uint32, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "getScore", provider)
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// GetScore is a free data retrieval call binding the contract method 0xd47875d0.
+//
+// Solidity: function getScore(address provider) view returns(uint32)
+func (_BunkerReputation *BunkerReputationSession) GetScore(provider common.Address) (uint32, error) {
+	return _BunkerReputation.Contract.GetScore(&_BunkerReputation.CallOpts, provider)
+}
+
+// GetScore is a free data retrieval call binding the contract method 0xd47875d0.
+//
+// Solidity: function getScore(address provider) view returns(uint32)
+func (_BunkerReputation *BunkerReputationCallerSession) GetScore(provider common.Address) (uint32, error) {
+	return _BunkerReputation.Contract.GetScore(&_BunkerReputation.CallOpts, provider)
+}
+
+// GetTier is a free data retrieval call binding the contract method 0xb45aae52.
+//
+// Solidity: function getTier(address provider) view returns(uint8)
+func (_BunkerReputation *BunkerReputationCaller) GetTier(opts *bind.CallOpts, provider common.Address) (uint8, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "getTier", provider)
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// GetTier is a free data retrieval call binding the contract method 0xb45aae52.
+//
+// Solidity: function getTier(address provider) view returns(uint8)
+func (_BunkerReputation *BunkerReputationSession) GetTier(provider common.Address) (uint8, error) {
+	return _BunkerReputation.Contract.GetTier(&_BunkerReputation.CallOpts, provider)
+}
+
+// GetTier is a free data retrieval call binding the contract method 0xb45aae52.
+//
+// Solidity: function getTier(address provider) view returns(uint8)
+func (_BunkerReputation *BunkerReputationCallerSession) GetTier(provider common.Address) (uint8, error) {
+	return _BunkerReputation.Contract.GetTier(&_BunkerReputation.CallOpts, provider)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerReputation *BunkerReputationCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerReputation *BunkerReputationSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BunkerReputation.Contract.HasRole(&_BunkerReputation.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerReputation *BunkerReputationCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BunkerReputation.Contract.HasRole(&_BunkerReputation.CallOpts, role, account)
+}
+
+// HealthFailDelta is a free data retrieval call binding the contract method 0x364c3b63.
+//
+// Solidity: function healthFailDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) HealthFailDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "healthFailDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// HealthFailDelta is a free data retrieval call binding the contract method 0x364c3b63.
+//
+// Solidity: function healthFailDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) HealthFailDelta() (int16, error) {
+	return _BunkerReputation.Contract.HealthFailDelta(&_BunkerReputation.CallOpts)
+}
+
+// HealthFailDelta is a free data retrieval call binding the contract method 0x364c3b63.
+//
+// Solidity: function healthFailDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) HealthFailDelta() (int16, error) {
+	return _BunkerReputation.Contract.HealthFailDelta(&_BunkerReputation.CallOpts)
+}
+
+// IsEligibleForJobs is a free data retrieval call binding the contract method 0x9d9718fe.
+//
+// Solidity: function isEligibleForJobs(address provider) view returns(bool eligible)
+func (_BunkerReputation *BunkerReputationCaller) IsEligibleForJobs(opts *bind.CallOpts, provider common.Address) (bool, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "isEligibleForJobs", provider)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsEligibleForJobs is a free data retrieval call binding the contract method 0x9d9718fe.
+//
+// Solidity: function isEligibleForJobs(address provider) view returns(bool eligible)
+func (_BunkerReputation *BunkerReputationSession) IsEligibleForJobs(provider common.Address) (bool, error) {
+	return _BunkerReputation.Contract.IsEligibleForJobs(&_BunkerReputation.CallOpts, provider)
+}
+
+// IsEligibleForJobs is a free data retrieval call binding the contract method 0x9d9718fe.
+//
+// Solidity: function isEligibleForJobs(address provider) view returns(bool eligible)
+func (_BunkerReputation *BunkerReputationCallerSession) IsEligibleForJobs(provider common.Address) (bool, error) {
+	return _BunkerReputation.Contract.IsEligibleForJobs(&_BunkerReputation.CallOpts, provider)
+}
+
+// JobCompletedDelta is a free data retrieval call binding the contract method 0x0b67ca75.
+//
+// Solidity: function jobCompletedDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) JobCompletedDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "jobCompletedDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// JobCompletedDelta is a free data retrieval call binding the contract method 0x0b67ca75.
+//
+// Solidity: function jobCompletedDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) JobCompletedDelta() (int16, error) {
+	return _BunkerReputation.Contract.JobCompletedDelta(&_BunkerReputation.CallOpts)
+}
+
+// JobCompletedDelta is a free data retrieval call binding the contract method 0x0b67ca75.
+//
+// Solidity: function jobCompletedDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) JobCompletedDelta() (int16, error) {
+	return _BunkerReputation.Contract.JobCompletedDelta(&_BunkerReputation.CallOpts)
+}
+
+// JobEarlyDelta is a free data retrieval call binding the contract method 0xc3ae1c30.
+//
+// Solidity: function jobEarlyDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) JobEarlyDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "jobEarlyDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// JobEarlyDelta is a free data retrieval call binding the contract method 0xc3ae1c30.
+//
+// Solidity: function jobEarlyDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) JobEarlyDelta() (int16, error) {
+	return _BunkerReputation.Contract.JobEarlyDelta(&_BunkerReputation.CallOpts)
+}
+
+// JobEarlyDelta is a free data retrieval call binding the contract method 0xc3ae1c30.
+//
+// Solidity: function jobEarlyDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) JobEarlyDelta() (int16, error) {
+	return _BunkerReputation.Contract.JobEarlyDelta(&_BunkerReputation.CallOpts)
+}
+
+// JobTimeoutDelta is a free data retrieval call binding the contract method 0xacb5fe0f.
+//
+// Solidity: function jobTimeoutDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) JobTimeoutDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "jobTimeoutDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// JobTimeoutDelta is a free data retrieval call binding the contract method 0xacb5fe0f.
+//
+// Solidity: function jobTimeoutDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) JobTimeoutDelta() (int16, error) {
+	return _BunkerReputation.Contract.JobTimeoutDelta(&_BunkerReputation.CallOpts)
+}
+
+// JobTimeoutDelta is a free data retrieval call binding the contract method 0xacb5fe0f.
+//
+// Solidity: function jobTimeoutDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) JobTimeoutDelta() (int16, error) {
+	return _BunkerReputation.Contract.JobTimeoutDelta(&_BunkerReputation.CallOpts)
+}
+
+// MaxCustomDelta is a free data retrieval call binding the contract method 0xaaee8cfd.
+//
+// Solidity: function maxCustomDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) MaxCustomDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "maxCustomDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// MaxCustomDelta is a free data retrieval call binding the contract method 0xaaee8cfd.
+//
+// Solidity: function maxCustomDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) MaxCustomDelta() (int16, error) {
+	return _BunkerReputation.Contract.MaxCustomDelta(&_BunkerReputation.CallOpts)
+}
+
+// MaxCustomDelta is a free data retrieval call binding the contract method 0xaaee8cfd.
+//
+// Solidity: function maxCustomDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) MaxCustomDelta() (int16, error) {
+	return _BunkerReputation.Contract.MaxCustomDelta(&_BunkerReputation.CallOpts)
+}
+
+// MinCustomDelta is a free data retrieval call binding the contract method 0xc7b71111.
+//
+// Solidity: function minCustomDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) MinCustomDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "minCustomDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// MinCustomDelta is a free data retrieval call binding the contract method 0xc7b71111.
+//
+// Solidity: function minCustomDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) MinCustomDelta() (int16, error) {
+	return _BunkerReputation.Contract.MinCustomDelta(&_BunkerReputation.CallOpts)
+}
+
+// MinCustomDelta is a free data retrieval call binding the contract method 0xc7b71111.
+//
+// Solidity: function minCustomDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) MinCustomDelta() (int16, error) {
+	return _BunkerReputation.Contract.MinCustomDelta(&_BunkerReputation.CallOpts)
+}
+
+// MinScoreForJobs is a free data retrieval call binding the contract method 0x95519b96.
+//
+// Solidity: function minScoreForJobs() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCaller) MinScoreForJobs(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "minScoreForJobs")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MinScoreForJobs is a free data retrieval call binding the contract method 0x95519b96.
+//
+// Solidity: function minScoreForJobs() view returns(uint256)
+func (_BunkerReputation *BunkerReputationSession) MinScoreForJobs() (*big.Int, error) {
+	return _BunkerReputation.Contract.MinScoreForJobs(&_BunkerReputation.CallOpts)
+}
+
+// MinScoreForJobs is a free data retrieval call binding the contract method 0x95519b96.
+//
+// Solidity: function minScoreForJobs() view returns(uint256)
+func (_BunkerReputation *BunkerReputationCallerSession) MinScoreForJobs() (*big.Int, error) {
+	return _BunkerReputation.Contract.MinScoreForJobs(&_BunkerReputation.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerReputation *BunkerReputationCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerReputation *BunkerReputationSession) Owner() (common.Address, error) {
+	return _BunkerReputation.Contract.Owner(&_BunkerReputation.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerReputation *BunkerReputationCallerSession) Owner() (common.Address, error) {
+	return _BunkerReputation.Contract.Owner(&_BunkerReputation.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerReputation *BunkerReputationCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerReputation *BunkerReputationSession) PendingOwner() (common.Address, error) {
+	return _BunkerReputation.Contract.PendingOwner(&_BunkerReputation.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerReputation *BunkerReputationCallerSession) PendingOwner() (common.Address, error) {
+	return _BunkerReputation.Contract.PendingOwner(&_BunkerReputation.CallOpts)
+}
+
+// PerfectUptimeDelta is a free data retrieval call binding the contract method 0x684e30fd.
+//
+// Solidity: function perfectUptimeDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) PerfectUptimeDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "perfectUptimeDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// PerfectUptimeDelta is a free data retrieval call binding the contract method 0x684e30fd.
+//
+// Solidity: function perfectUptimeDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) PerfectUptimeDelta() (int16, error) {
+	return _BunkerReputation.Contract.PerfectUptimeDelta(&_BunkerReputation.CallOpts)
+}
+
+// PerfectUptimeDelta is a free data retrieval call binding the contract method 0x684e30fd.
+//
+// Solidity: function perfectUptimeDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) PerfectUptimeDelta() (int16, error) {
+	return _BunkerReputation.Contract.PerfectUptimeDelta(&_BunkerReputation.CallOpts)
+}
+
+// ReplicaMismatchDelta is a free data retrieval call binding the contract method 0xfade295d.
+//
+// Solidity: function replicaMismatchDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) ReplicaMismatchDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "replicaMismatchDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// ReplicaMismatchDelta is a free data retrieval call binding the contract method 0xfade295d.
+//
+// Solidity: function replicaMismatchDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) ReplicaMismatchDelta() (int16, error) {
+	return _BunkerReputation.Contract.ReplicaMismatchDelta(&_BunkerReputation.CallOpts)
+}
+
+// ReplicaMismatchDelta is a free data retrieval call binding the contract method 0xfade295d.
+//
+// Solidity: function replicaMismatchDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) ReplicaMismatchDelta() (int16, error) {
+	return _BunkerReputation.Contract.ReplicaMismatchDelta(&_BunkerReputation.CallOpts)
+}
+
+// Reputations is a free data retrieval call binding the contract method 0x06fa15a7.
+//
+// Solidity: function reputations(address ) view returns(uint32 score, uint32 jobsCompleted, uint32 jobsFailed, uint32 slashCount, uint48 lastUpdated, uint48 registeredAt)
+func (_BunkerReputation *BunkerReputationCaller) Reputations(opts *bind.CallOpts, arg0 common.Address) (struct {
+	Score         uint32
+	JobsCompleted uint32
+	JobsFailed    uint32
+	SlashCount    uint32
+	LastUpdated   *big.Int
+	RegisteredAt  *big.Int
+}, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "reputations", arg0)
+
+	outstruct := new(struct {
+		Score         uint32
+		JobsCompleted uint32
+		JobsFailed    uint32
+		SlashCount    uint32
+		LastUpdated   *big.Int
+		RegisteredAt  *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Score = *abi.ConvertType(out[0], new(uint32)).(*uint32)
+	outstruct.JobsCompleted = *abi.ConvertType(out[1], new(uint32)).(*uint32)
+	outstruct.JobsFailed = *abi.ConvertType(out[2], new(uint32)).(*uint32)
+	outstruct.SlashCount = *abi.ConvertType(out[3], new(uint32)).(*uint32)
+	outstruct.LastUpdated = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+	outstruct.RegisteredAt = *abi.ConvertType(out[5], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// Reputations is a free data retrieval call binding the contract method 0x06fa15a7.
+//
+// Solidity: function reputations(address ) view returns(uint32 score, uint32 jobsCompleted, uint32 jobsFailed, uint32 slashCount, uint48 lastUpdated, uint48 registeredAt)
+func (_BunkerReputation *BunkerReputationSession) Reputations(arg0 common.Address) (struct {
+	Score         uint32
+	JobsCompleted uint32
+	JobsFailed    uint32
+	SlashCount    uint32
+	LastUpdated   *big.Int
+	RegisteredAt  *big.Int
+}, error) {
+	return _BunkerReputation.Contract.Reputations(&_BunkerReputation.CallOpts, arg0)
+}
+
+// Reputations is a free data retrieval call binding the contract method 0x06fa15a7.
+//
+// Solidity: function reputations(address ) view returns(uint32 score, uint32 jobsCompleted, uint32 jobsFailed, uint32 slashCount, uint48 lastUpdated, uint48 registeredAt)
+func (_BunkerReputation *BunkerReputationCallerSession) Reputations(arg0 common.Address) (struct {
+	Score         uint32
+	JobsCompleted uint32
+	JobsFailed    uint32
+	SlashCount    uint32
+	LastUpdated   *big.Int
+	RegisteredAt  *big.Int
+}, error) {
+	return _BunkerReputation.Contract.Reputations(&_BunkerReputation.CallOpts, arg0)
+}
+
+// SecurityViolationDelta is a free data retrieval call binding the contract method 0xd4b378bf.
+//
+// Solidity: function securityViolationDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) SecurityViolationDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "securityViolationDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// SecurityViolationDelta is a free data retrieval call binding the contract method 0xd4b378bf.
+//
+// Solidity: function securityViolationDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) SecurityViolationDelta() (int16, error) {
+	return _BunkerReputation.Contract.SecurityViolationDelta(&_BunkerReputation.CallOpts)
+}
+
+// SecurityViolationDelta is a free data retrieval call binding the contract method 0xd4b378bf.
+//
+// Solidity: function securityViolationDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) SecurityViolationDelta() (int16, error) {
+	return _BunkerReputation.Contract.SecurityViolationDelta(&_BunkerReputation.CallOpts)
+}
+
+// SlashEventDelta is a free data retrieval call binding the contract method 0x8bf51c2c.
+//
+// Solidity: function slashEventDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCaller) SlashEventDelta(opts *bind.CallOpts) (int16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "slashEventDelta")
+
+	if err != nil {
+		return *new(int16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(int16)).(*int16)
+
+	return out0, err
+
+}
+
+// SlashEventDelta is a free data retrieval call binding the contract method 0x8bf51c2c.
+//
+// Solidity: function slashEventDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationSession) SlashEventDelta() (int16, error) {
+	return _BunkerReputation.Contract.SlashEventDelta(&_BunkerReputation.CallOpts)
+}
+
+// SlashEventDelta is a free data retrieval call binding the contract method 0x8bf51c2c.
+//
+// Solidity: function slashEventDelta() view returns(int16)
+func (_BunkerReputation *BunkerReputationCallerSession) SlashEventDelta() (int16, error) {
+	return _BunkerReputation.Contract.SlashEventDelta(&_BunkerReputation.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerReputation *BunkerReputationCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerReputation *BunkerReputationSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BunkerReputation.Contract.SupportsInterface(&_BunkerReputation.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerReputation *BunkerReputationCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BunkerReputation.Contract.SupportsInterface(&_BunkerReputation.CallOpts, interfaceId)
+}
+
+// TierElite is a free data retrieval call binding the contract method 0xa240b04f.
+//
+// Solidity: function tierElite() view returns(uint16)
+func (_BunkerReputation *BunkerReputationCaller) TierElite(opts *bind.CallOpts) (uint16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "tierElite")
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// TierElite is a free data retrieval call binding the contract method 0xa240b04f.
+//
+// Solidity: function tierElite() view returns(uint16)
+func (_BunkerReputation *BunkerReputationSession) TierElite() (uint16, error) {
+	return _BunkerReputation.Contract.TierElite(&_BunkerReputation.CallOpts)
+}
+
+// TierElite is a free data retrieval call binding the contract method 0xa240b04f.
+//
+// Solidity: function tierElite() view returns(uint16)
+func (_BunkerReputation *BunkerReputationCallerSession) TierElite() (uint16, error) {
+	return _BunkerReputation.Contract.TierElite(&_BunkerReputation.CallOpts)
+}
+
+// TierProbation is a free data retrieval call binding the contract method 0xad74b060.
+//
+// Solidity: function tierProbation() view returns(uint16)
+func (_BunkerReputation *BunkerReputationCaller) TierProbation(opts *bind.CallOpts) (uint16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "tierProbation")
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// TierProbation is a free data retrieval call binding the contract method 0xad74b060.
+//
+// Solidity: function tierProbation() view returns(uint16)
+func (_BunkerReputation *BunkerReputationSession) TierProbation() (uint16, error) {
+	return _BunkerReputation.Contract.TierProbation(&_BunkerReputation.CallOpts)
+}
+
+// TierProbation is a free data retrieval call binding the contract method 0xad74b060.
+//
+// Solidity: function tierProbation() view returns(uint16)
+func (_BunkerReputation *BunkerReputationCallerSession) TierProbation() (uint16, error) {
+	return _BunkerReputation.Contract.TierProbation(&_BunkerReputation.CallOpts)
+}
+
+// TierStandard is a free data retrieval call binding the contract method 0xc233b616.
+//
+// Solidity: function tierStandard() view returns(uint16)
+func (_BunkerReputation *BunkerReputationCaller) TierStandard(opts *bind.CallOpts) (uint16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "tierStandard")
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// TierStandard is a free data retrieval call binding the contract method 0xc233b616.
+//
+// Solidity: function tierStandard() view returns(uint16)
+func (_BunkerReputation *BunkerReputationSession) TierStandard() (uint16, error) {
+	return _BunkerReputation.Contract.TierStandard(&_BunkerReputation.CallOpts)
+}
+
+// TierStandard is a free data retrieval call binding the contract method 0xc233b616.
+//
+// Solidity: function tierStandard() view returns(uint16)
+func (_BunkerReputation *BunkerReputationCallerSession) TierStandard() (uint16, error) {
+	return _BunkerReputation.Contract.TierStandard(&_BunkerReputation.CallOpts)
+}
+
+// TierTrusted is a free data retrieval call binding the contract method 0x125f377a.
+//
+// Solidity: function tierTrusted() view returns(uint16)
+func (_BunkerReputation *BunkerReputationCaller) TierTrusted(opts *bind.CallOpts) (uint16, error) {
+	var out []interface{}
+	err := _BunkerReputation.contract.Call(opts, &out, "tierTrusted")
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// TierTrusted is a free data retrieval call binding the contract method 0x125f377a.
+//
+// Solidity: function tierTrusted() view returns(uint16)
+func (_BunkerReputation *BunkerReputationSession) TierTrusted() (uint16, error) {
+	return _BunkerReputation.Contract.TierTrusted(&_BunkerReputation.CallOpts)
+}
+
+// TierTrusted is a free data retrieval call binding the contract method 0x125f377a.
+//
+// Solidity: function tierTrusted() view returns(uint16)
+func (_BunkerReputation *BunkerReputationCallerSession) TierTrusted() (uint16, error) {
+	return _BunkerReputation.Contract.TierTrusted(&_BunkerReputation.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerReputation *BunkerReputationTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerReputation *BunkerReputationSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerReputation.Contract.AcceptOwnership(&_BunkerReputation.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerReputation.Contract.AcceptOwnership(&_BunkerReputation.TransactOpts)
+}
+
+// ApplyDecay is a paid mutator transaction binding the contract method 0xedfcc437.
+//
+// Solidity: function applyDecay(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactor) ApplyDecay(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "applyDecay", provider)
+}
+
+// ApplyDecay is a paid mutator transaction binding the contract method 0xedfcc437.
+//
+// Solidity: function applyDecay(address provider) returns()
+func (_BunkerReputation *BunkerReputationSession) ApplyDecay(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.ApplyDecay(&_BunkerReputation.TransactOpts, provider)
+}
+
+// ApplyDecay is a paid mutator transaction binding the contract method 0xedfcc437.
+//
+// Solidity: function applyDecay(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) ApplyDecay(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.ApplyDecay(&_BunkerReputation.TransactOpts, provider)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerReputation *BunkerReputationTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerReputation *BunkerReputationSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.GrantRole(&_BunkerReputation.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.GrantRole(&_BunkerReputation.TransactOpts, role, account)
+}
+
+// RecordEvent is a paid mutator transaction binding the contract method 0x68cad238.
+//
+// Solidity: function recordEvent(address provider, int16 delta, string reason) returns()
+func (_BunkerReputation *BunkerReputationTransactor) RecordEvent(opts *bind.TransactOpts, provider common.Address, delta int16, reason string) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "recordEvent", provider, delta, reason)
+}
+
+// RecordEvent is a paid mutator transaction binding the contract method 0x68cad238.
+//
+// Solidity: function recordEvent(address provider, int16 delta, string reason) returns()
+func (_BunkerReputation *BunkerReputationSession) RecordEvent(provider common.Address, delta int16, reason string) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RecordEvent(&_BunkerReputation.TransactOpts, provider, delta, reason)
+}
+
+// RecordEvent is a paid mutator transaction binding the contract method 0x68cad238.
+//
+// Solidity: function recordEvent(address provider, int16 delta, string reason) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) RecordEvent(provider common.Address, delta int16, reason string) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RecordEvent(&_BunkerReputation.TransactOpts, provider, delta, reason)
+}
+
+// RecordJobCompleted is a paid mutator transaction binding the contract method 0xc53fba6d.
+//
+// Solidity: function recordJobCompleted(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactor) RecordJobCompleted(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "recordJobCompleted", provider)
+}
+
+// RecordJobCompleted is a paid mutator transaction binding the contract method 0xc53fba6d.
+//
+// Solidity: function recordJobCompleted(address provider) returns()
+func (_BunkerReputation *BunkerReputationSession) RecordJobCompleted(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RecordJobCompleted(&_BunkerReputation.TransactOpts, provider)
+}
+
+// RecordJobCompleted is a paid mutator transaction binding the contract method 0xc53fba6d.
+//
+// Solidity: function recordJobCompleted(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) RecordJobCompleted(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RecordJobCompleted(&_BunkerReputation.TransactOpts, provider)
+}
+
+// RecordJobFailed is a paid mutator transaction binding the contract method 0x1dd98b7e.
+//
+// Solidity: function recordJobFailed(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactor) RecordJobFailed(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "recordJobFailed", provider)
+}
+
+// RecordJobFailed is a paid mutator transaction binding the contract method 0x1dd98b7e.
+//
+// Solidity: function recordJobFailed(address provider) returns()
+func (_BunkerReputation *BunkerReputationSession) RecordJobFailed(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RecordJobFailed(&_BunkerReputation.TransactOpts, provider)
+}
+
+// RecordJobFailed is a paid mutator transaction binding the contract method 0x1dd98b7e.
+//
+// Solidity: function recordJobFailed(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) RecordJobFailed(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RecordJobFailed(&_BunkerReputation.TransactOpts, provider)
+}
+
+// RecordSlashEvent is a paid mutator transaction binding the contract method 0x93198fd0.
+//
+// Solidity: function recordSlashEvent(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactor) RecordSlashEvent(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "recordSlashEvent", provider)
+}
+
+// RecordSlashEvent is a paid mutator transaction binding the contract method 0x93198fd0.
+//
+// Solidity: function recordSlashEvent(address provider) returns()
+func (_BunkerReputation *BunkerReputationSession) RecordSlashEvent(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RecordSlashEvent(&_BunkerReputation.TransactOpts, provider)
+}
+
+// RecordSlashEvent is a paid mutator transaction binding the contract method 0x93198fd0.
+//
+// Solidity: function recordSlashEvent(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) RecordSlashEvent(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RecordSlashEvent(&_BunkerReputation.TransactOpts, provider)
+}
+
+// RegisterProvider is a paid mutator transaction binding the contract method 0x0e260016.
+//
+// Solidity: function registerProvider(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactor) RegisterProvider(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "registerProvider", provider)
+}
+
+// RegisterProvider is a paid mutator transaction binding the contract method 0x0e260016.
+//
+// Solidity: function registerProvider(address provider) returns()
+func (_BunkerReputation *BunkerReputationSession) RegisterProvider(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RegisterProvider(&_BunkerReputation.TransactOpts, provider)
+}
+
+// RegisterProvider is a paid mutator transaction binding the contract method 0x0e260016.
+//
+// Solidity: function registerProvider(address provider) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) RegisterProvider(provider common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RegisterProvider(&_BunkerReputation.TransactOpts, provider)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerReputation *BunkerReputationTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerReputation *BunkerReputationSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RenounceOwnership(&_BunkerReputation.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RenounceOwnership(&_BunkerReputation.TransactOpts)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerReputation *BunkerReputationTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerReputation *BunkerReputationSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RenounceRole(&_BunkerReputation.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RenounceRole(&_BunkerReputation.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerReputation *BunkerReputationTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerReputation *BunkerReputationSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RevokeRole(&_BunkerReputation.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.RevokeRole(&_BunkerReputation.TransactOpts, role, account)
+}
+
+// SetDecayParams is a paid mutator transaction binding the contract method 0xb0b88d74.
+//
+// Solidity: function setDecayParams(uint256 rate, uint256 floor) returns()
+func (_BunkerReputation *BunkerReputationTransactor) SetDecayParams(opts *bind.TransactOpts, rate *big.Int, floor *big.Int) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "setDecayParams", rate, floor)
+}
+
+// SetDecayParams is a paid mutator transaction binding the contract method 0xb0b88d74.
+//
+// Solidity: function setDecayParams(uint256 rate, uint256 floor) returns()
+func (_BunkerReputation *BunkerReputationSession) SetDecayParams(rate *big.Int, floor *big.Int) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetDecayParams(&_BunkerReputation.TransactOpts, rate, floor)
+}
+
+// SetDecayParams is a paid mutator transaction binding the contract method 0xb0b88d74.
+//
+// Solidity: function setDecayParams(uint256 rate, uint256 floor) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) SetDecayParams(rate *big.Int, floor *big.Int) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetDecayParams(&_BunkerReputation.TransactOpts, rate, floor)
+}
+
+// SetDeltaParameters is a paid mutator transaction binding the contract method 0x579c28e6.
+//
+// Solidity: function setDeltaParameters(int16 _jobCompletedDelta, int16 _jobEarlyDelta, int16 _perfectUptimeDelta, int16 _jobTimeoutDelta, int16 _healthFailDelta, int16 _replicaMismatchDelta, int16 _slashEventDelta, int16 _securityViolationDelta) returns()
+func (_BunkerReputation *BunkerReputationTransactor) SetDeltaParameters(opts *bind.TransactOpts, _jobCompletedDelta int16, _jobEarlyDelta int16, _perfectUptimeDelta int16, _jobTimeoutDelta int16, _healthFailDelta int16, _replicaMismatchDelta int16, _slashEventDelta int16, _securityViolationDelta int16) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "setDeltaParameters", _jobCompletedDelta, _jobEarlyDelta, _perfectUptimeDelta, _jobTimeoutDelta, _healthFailDelta, _replicaMismatchDelta, _slashEventDelta, _securityViolationDelta)
+}
+
+// SetDeltaParameters is a paid mutator transaction binding the contract method 0x579c28e6.
+//
+// Solidity: function setDeltaParameters(int16 _jobCompletedDelta, int16 _jobEarlyDelta, int16 _perfectUptimeDelta, int16 _jobTimeoutDelta, int16 _healthFailDelta, int16 _replicaMismatchDelta, int16 _slashEventDelta, int16 _securityViolationDelta) returns()
+func (_BunkerReputation *BunkerReputationSession) SetDeltaParameters(_jobCompletedDelta int16, _jobEarlyDelta int16, _perfectUptimeDelta int16, _jobTimeoutDelta int16, _healthFailDelta int16, _replicaMismatchDelta int16, _slashEventDelta int16, _securityViolationDelta int16) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetDeltaParameters(&_BunkerReputation.TransactOpts, _jobCompletedDelta, _jobEarlyDelta, _perfectUptimeDelta, _jobTimeoutDelta, _healthFailDelta, _replicaMismatchDelta, _slashEventDelta, _securityViolationDelta)
+}
+
+// SetDeltaParameters is a paid mutator transaction binding the contract method 0x579c28e6.
+//
+// Solidity: function setDeltaParameters(int16 _jobCompletedDelta, int16 _jobEarlyDelta, int16 _perfectUptimeDelta, int16 _jobTimeoutDelta, int16 _healthFailDelta, int16 _replicaMismatchDelta, int16 _slashEventDelta, int16 _securityViolationDelta) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) SetDeltaParameters(_jobCompletedDelta int16, _jobEarlyDelta int16, _perfectUptimeDelta int16, _jobTimeoutDelta int16, _healthFailDelta int16, _replicaMismatchDelta int16, _slashEventDelta int16, _securityViolationDelta int16) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetDeltaParameters(&_BunkerReputation.TransactOpts, _jobCompletedDelta, _jobEarlyDelta, _perfectUptimeDelta, _jobTimeoutDelta, _healthFailDelta, _replicaMismatchDelta, _slashEventDelta, _securityViolationDelta)
+}
+
+// SetMaxCustomDelta is a paid mutator transaction binding the contract method 0x4dd3c431.
+//
+// Solidity: function setMaxCustomDelta(int16 maxDelta) returns()
+func (_BunkerReputation *BunkerReputationTransactor) SetMaxCustomDelta(opts *bind.TransactOpts, maxDelta int16) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "setMaxCustomDelta", maxDelta)
+}
+
+// SetMaxCustomDelta is a paid mutator transaction binding the contract method 0x4dd3c431.
+//
+// Solidity: function setMaxCustomDelta(int16 maxDelta) returns()
+func (_BunkerReputation *BunkerReputationSession) SetMaxCustomDelta(maxDelta int16) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetMaxCustomDelta(&_BunkerReputation.TransactOpts, maxDelta)
+}
+
+// SetMaxCustomDelta is a paid mutator transaction binding the contract method 0x4dd3c431.
+//
+// Solidity: function setMaxCustomDelta(int16 maxDelta) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) SetMaxCustomDelta(maxDelta int16) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetMaxCustomDelta(&_BunkerReputation.TransactOpts, maxDelta)
+}
+
+// SetMinScoreForJobs is a paid mutator transaction binding the contract method 0x7aa4d004.
+//
+// Solidity: function setMinScoreForJobs(uint256 _minScore) returns()
+func (_BunkerReputation *BunkerReputationTransactor) SetMinScoreForJobs(opts *bind.TransactOpts, _minScore *big.Int) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "setMinScoreForJobs", _minScore)
+}
+
+// SetMinScoreForJobs is a paid mutator transaction binding the contract method 0x7aa4d004.
+//
+// Solidity: function setMinScoreForJobs(uint256 _minScore) returns()
+func (_BunkerReputation *BunkerReputationSession) SetMinScoreForJobs(_minScore *big.Int) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetMinScoreForJobs(&_BunkerReputation.TransactOpts, _minScore)
+}
+
+// SetMinScoreForJobs is a paid mutator transaction binding the contract method 0x7aa4d004.
+//
+// Solidity: function setMinScoreForJobs(uint256 _minScore) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) SetMinScoreForJobs(_minScore *big.Int) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetMinScoreForJobs(&_BunkerReputation.TransactOpts, _minScore)
+}
+
+// SetTierThresholds is a paid mutator transaction binding the contract method 0xdcd28478.
+//
+// Solidity: function setTierThresholds(uint16 probation, uint16 standard, uint16 trusted, uint16 elite) returns()
+func (_BunkerReputation *BunkerReputationTransactor) SetTierThresholds(opts *bind.TransactOpts, probation uint16, standard uint16, trusted uint16, elite uint16) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "setTierThresholds", probation, standard, trusted, elite)
+}
+
+// SetTierThresholds is a paid mutator transaction binding the contract method 0xdcd28478.
+//
+// Solidity: function setTierThresholds(uint16 probation, uint16 standard, uint16 trusted, uint16 elite) returns()
+func (_BunkerReputation *BunkerReputationSession) SetTierThresholds(probation uint16, standard uint16, trusted uint16, elite uint16) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetTierThresholds(&_BunkerReputation.TransactOpts, probation, standard, trusted, elite)
+}
+
+// SetTierThresholds is a paid mutator transaction binding the contract method 0xdcd28478.
+//
+// Solidity: function setTierThresholds(uint16 probation, uint16 standard, uint16 trusted, uint16 elite) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) SetTierThresholds(probation uint16, standard uint16, trusted uint16, elite uint16) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.SetTierThresholds(&_BunkerReputation.TransactOpts, probation, standard, trusted, elite)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerReputation *BunkerReputationTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerReputation *BunkerReputationSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.TransferOwnership(&_BunkerReputation.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerReputation *BunkerReputationTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerReputation.Contract.TransferOwnership(&_BunkerReputation.TransactOpts, newOwner)
+}
+
+// BunkerReputationDecayParamsUpdatedIterator is returned from FilterDecayParamsUpdated and is used to iterate over the raw logs and unpacked data for DecayParamsUpdated events raised by the BunkerReputation contract.
+type BunkerReputationDecayParamsUpdatedIterator struct {
+	Event *BunkerReputationDecayParamsUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationDecayParamsUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationDecayParamsUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationDecayParamsUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationDecayParamsUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationDecayParamsUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationDecayParamsUpdated represents a DecayParamsUpdated event raised by the BunkerReputation contract.
+type BunkerReputationDecayParamsUpdated struct {
+	Rate  *big.Int
+	Floor *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterDecayParamsUpdated is a free log retrieval operation binding the contract event 0x8fc7937c0b577a9b967c8027dda6d2507bc421730a34aa1f323d475c8674ee49.
+//
+// Solidity: event DecayParamsUpdated(uint256 rate, uint256 floor)
+func (_BunkerReputation *BunkerReputationFilterer) FilterDecayParamsUpdated(opts *bind.FilterOpts) (*BunkerReputationDecayParamsUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "DecayParamsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationDecayParamsUpdatedIterator{contract: _BunkerReputation.contract, event: "DecayParamsUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchDecayParamsUpdated is a free log subscription operation binding the contract event 0x8fc7937c0b577a9b967c8027dda6d2507bc421730a34aa1f323d475c8674ee49.
+//
+// Solidity: event DecayParamsUpdated(uint256 rate, uint256 floor)
+func (_BunkerReputation *BunkerReputationFilterer) WatchDecayParamsUpdated(opts *bind.WatchOpts, sink chan<- *BunkerReputationDecayParamsUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "DecayParamsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationDecayParamsUpdated)
+				if err := _BunkerReputation.contract.UnpackLog(event, "DecayParamsUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDecayParamsUpdated is a log parse operation binding the contract event 0x8fc7937c0b577a9b967c8027dda6d2507bc421730a34aa1f323d475c8674ee49.
+//
+// Solidity: event DecayParamsUpdated(uint256 rate, uint256 floor)
+func (_BunkerReputation *BunkerReputationFilterer) ParseDecayParamsUpdated(log types.Log) (*BunkerReputationDecayParamsUpdated, error) {
+	event := new(BunkerReputationDecayParamsUpdated)
+	if err := _BunkerReputation.contract.UnpackLog(event, "DecayParamsUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationDeltaParametersUpdatedIterator is returned from FilterDeltaParametersUpdated and is used to iterate over the raw logs and unpacked data for DeltaParametersUpdated events raised by the BunkerReputation contract.
+type BunkerReputationDeltaParametersUpdatedIterator struct {
+	Event *BunkerReputationDeltaParametersUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationDeltaParametersUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationDeltaParametersUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationDeltaParametersUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationDeltaParametersUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationDeltaParametersUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationDeltaParametersUpdated represents a DeltaParametersUpdated event raised by the BunkerReputation contract.
+type BunkerReputationDeltaParametersUpdated struct {
+	Raw types.Log // Blockchain specific contextual infos
+}
+
+// FilterDeltaParametersUpdated is a free log retrieval operation binding the contract event 0xbbe3d3400bbdd1c673beee5e0de381892cf0afcab96f92e98a7ab105f9bb6deb.
+//
+// Solidity: event DeltaParametersUpdated()
+func (_BunkerReputation *BunkerReputationFilterer) FilterDeltaParametersUpdated(opts *bind.FilterOpts) (*BunkerReputationDeltaParametersUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "DeltaParametersUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationDeltaParametersUpdatedIterator{contract: _BunkerReputation.contract, event: "DeltaParametersUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchDeltaParametersUpdated is a free log subscription operation binding the contract event 0xbbe3d3400bbdd1c673beee5e0de381892cf0afcab96f92e98a7ab105f9bb6deb.
+//
+// Solidity: event DeltaParametersUpdated()
+func (_BunkerReputation *BunkerReputationFilterer) WatchDeltaParametersUpdated(opts *bind.WatchOpts, sink chan<- *BunkerReputationDeltaParametersUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "DeltaParametersUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationDeltaParametersUpdated)
+				if err := _BunkerReputation.contract.UnpackLog(event, "DeltaParametersUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDeltaParametersUpdated is a log parse operation binding the contract event 0xbbe3d3400bbdd1c673beee5e0de381892cf0afcab96f92e98a7ab105f9bb6deb.
+//
+// Solidity: event DeltaParametersUpdated()
+func (_BunkerReputation *BunkerReputationFilterer) ParseDeltaParametersUpdated(log types.Log) (*BunkerReputationDeltaParametersUpdated, error) {
+	event := new(BunkerReputationDeltaParametersUpdated)
+	if err := _BunkerReputation.contract.UnpackLog(event, "DeltaParametersUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationMaxCustomDeltaUpdatedIterator is returned from FilterMaxCustomDeltaUpdated and is used to iterate over the raw logs and unpacked data for MaxCustomDeltaUpdated events raised by the BunkerReputation contract.
+type BunkerReputationMaxCustomDeltaUpdatedIterator struct {
+	Event *BunkerReputationMaxCustomDeltaUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationMaxCustomDeltaUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationMaxCustomDeltaUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationMaxCustomDeltaUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationMaxCustomDeltaUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationMaxCustomDeltaUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationMaxCustomDeltaUpdated represents a MaxCustomDeltaUpdated event raised by the BunkerReputation contract.
+type BunkerReputationMaxCustomDeltaUpdated struct {
+	MaxDelta int16
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterMaxCustomDeltaUpdated is a free log retrieval operation binding the contract event 0x098d1be9c3c19e7a0e573dcca5929a3e9a44f7bdde2d01345335e60d5d5c564e.
+//
+// Solidity: event MaxCustomDeltaUpdated(int16 maxDelta)
+func (_BunkerReputation *BunkerReputationFilterer) FilterMaxCustomDeltaUpdated(opts *bind.FilterOpts) (*BunkerReputationMaxCustomDeltaUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "MaxCustomDeltaUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationMaxCustomDeltaUpdatedIterator{contract: _BunkerReputation.contract, event: "MaxCustomDeltaUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMaxCustomDeltaUpdated is a free log subscription operation binding the contract event 0x098d1be9c3c19e7a0e573dcca5929a3e9a44f7bdde2d01345335e60d5d5c564e.
+//
+// Solidity: event MaxCustomDeltaUpdated(int16 maxDelta)
+func (_BunkerReputation *BunkerReputationFilterer) WatchMaxCustomDeltaUpdated(opts *bind.WatchOpts, sink chan<- *BunkerReputationMaxCustomDeltaUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "MaxCustomDeltaUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationMaxCustomDeltaUpdated)
+				if err := _BunkerReputation.contract.UnpackLog(event, "MaxCustomDeltaUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMaxCustomDeltaUpdated is a log parse operation binding the contract event 0x098d1be9c3c19e7a0e573dcca5929a3e9a44f7bdde2d01345335e60d5d5c564e.
+//
+// Solidity: event MaxCustomDeltaUpdated(int16 maxDelta)
+func (_BunkerReputation *BunkerReputationFilterer) ParseMaxCustomDeltaUpdated(log types.Log) (*BunkerReputationMaxCustomDeltaUpdated, error) {
+	event := new(BunkerReputationMaxCustomDeltaUpdated)
+	if err := _BunkerReputation.contract.UnpackLog(event, "MaxCustomDeltaUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationMinScoreForJobsUpdatedIterator is returned from FilterMinScoreForJobsUpdated and is used to iterate over the raw logs and unpacked data for MinScoreForJobsUpdated events raised by the BunkerReputation contract.
+type BunkerReputationMinScoreForJobsUpdatedIterator struct {
+	Event *BunkerReputationMinScoreForJobsUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationMinScoreForJobsUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationMinScoreForJobsUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationMinScoreForJobsUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationMinScoreForJobsUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationMinScoreForJobsUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationMinScoreForJobsUpdated represents a MinScoreForJobsUpdated event raised by the BunkerReputation contract.
+type BunkerReputationMinScoreForJobsUpdated struct {
+	MinScore *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterMinScoreForJobsUpdated is a free log retrieval operation binding the contract event 0xaa35cd770c922777c44e00b6d7435031c4be4751bf9b17dd944e5d7fb116a1e6.
+//
+// Solidity: event MinScoreForJobsUpdated(uint256 minScore)
+func (_BunkerReputation *BunkerReputationFilterer) FilterMinScoreForJobsUpdated(opts *bind.FilterOpts) (*BunkerReputationMinScoreForJobsUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "MinScoreForJobsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationMinScoreForJobsUpdatedIterator{contract: _BunkerReputation.contract, event: "MinScoreForJobsUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMinScoreForJobsUpdated is a free log subscription operation binding the contract event 0xaa35cd770c922777c44e00b6d7435031c4be4751bf9b17dd944e5d7fb116a1e6.
+//
+// Solidity: event MinScoreForJobsUpdated(uint256 minScore)
+func (_BunkerReputation *BunkerReputationFilterer) WatchMinScoreForJobsUpdated(opts *bind.WatchOpts, sink chan<- *BunkerReputationMinScoreForJobsUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "MinScoreForJobsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationMinScoreForJobsUpdated)
+				if err := _BunkerReputation.contract.UnpackLog(event, "MinScoreForJobsUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMinScoreForJobsUpdated is a log parse operation binding the contract event 0xaa35cd770c922777c44e00b6d7435031c4be4751bf9b17dd944e5d7fb116a1e6.
+//
+// Solidity: event MinScoreForJobsUpdated(uint256 minScore)
+func (_BunkerReputation *BunkerReputationFilterer) ParseMinScoreForJobsUpdated(log types.Log) (*BunkerReputationMinScoreForJobsUpdated, error) {
+	event := new(BunkerReputationMinScoreForJobsUpdated)
+	if err := _BunkerReputation.contract.UnpackLog(event, "MinScoreForJobsUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the BunkerReputation contract.
+type BunkerReputationOwnershipTransferStartedIterator struct {
+	Event *BunkerReputationOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the BunkerReputation contract.
+type BunkerReputationOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerReputation *BunkerReputationFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerReputationOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationOwnershipTransferStartedIterator{contract: _BunkerReputation.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerReputation *BunkerReputationFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BunkerReputationOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationOwnershipTransferStarted)
+				if err := _BunkerReputation.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerReputation *BunkerReputationFilterer) ParseOwnershipTransferStarted(log types.Log) (*BunkerReputationOwnershipTransferStarted, error) {
+	event := new(BunkerReputationOwnershipTransferStarted)
+	if err := _BunkerReputation.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BunkerReputation contract.
+type BunkerReputationOwnershipTransferredIterator struct {
+	Event *BunkerReputationOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationOwnershipTransferred represents a OwnershipTransferred event raised by the BunkerReputation contract.
+type BunkerReputationOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerReputation *BunkerReputationFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerReputationOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationOwnershipTransferredIterator{contract: _BunkerReputation.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerReputation *BunkerReputationFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BunkerReputationOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationOwnershipTransferred)
+				if err := _BunkerReputation.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerReputation *BunkerReputationFilterer) ParseOwnershipTransferred(log types.Log) (*BunkerReputationOwnershipTransferred, error) {
+	event := new(BunkerReputationOwnershipTransferred)
+	if err := _BunkerReputation.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationProviderRegisteredIterator is returned from FilterProviderRegistered and is used to iterate over the raw logs and unpacked data for ProviderRegistered events raised by the BunkerReputation contract.
+type BunkerReputationProviderRegisteredIterator struct {
+	Event *BunkerReputationProviderRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationProviderRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationProviderRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationProviderRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationProviderRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationProviderRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationProviderRegistered represents a ProviderRegistered event raised by the BunkerReputation contract.
+type BunkerReputationProviderRegistered struct {
+	Provider common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderRegistered is a free log retrieval operation binding the contract event 0x70abce74777b3838ae60a33a6b9a87d9d25532668fe4fea548554c55868579c0.
+//
+// Solidity: event ProviderRegistered(address indexed provider)
+func (_BunkerReputation *BunkerReputationFilterer) FilterProviderRegistered(opts *bind.FilterOpts, provider []common.Address) (*BunkerReputationProviderRegisteredIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "ProviderRegistered", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationProviderRegisteredIterator{contract: _BunkerReputation.contract, event: "ProviderRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderRegistered is a free log subscription operation binding the contract event 0x70abce74777b3838ae60a33a6b9a87d9d25532668fe4fea548554c55868579c0.
+//
+// Solidity: event ProviderRegistered(address indexed provider)
+func (_BunkerReputation *BunkerReputationFilterer) WatchProviderRegistered(opts *bind.WatchOpts, sink chan<- *BunkerReputationProviderRegistered, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "ProviderRegistered", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationProviderRegistered)
+				if err := _BunkerReputation.contract.UnpackLog(event, "ProviderRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderRegistered is a log parse operation binding the contract event 0x70abce74777b3838ae60a33a6b9a87d9d25532668fe4fea548554c55868579c0.
+//
+// Solidity: event ProviderRegistered(address indexed provider)
+func (_BunkerReputation *BunkerReputationFilterer) ParseProviderRegistered(log types.Log) (*BunkerReputationProviderRegistered, error) {
+	event := new(BunkerReputationProviderRegistered)
+	if err := _BunkerReputation.contract.UnpackLog(event, "ProviderRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the BunkerReputation contract.
+type BunkerReputationRoleAdminChangedIterator struct {
+	Event *BunkerReputationRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationRoleAdminChanged represents a RoleAdminChanged event raised by the BunkerReputation contract.
+type BunkerReputationRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerReputation *BunkerReputationFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*BunkerReputationRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationRoleAdminChangedIterator{contract: _BunkerReputation.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerReputation *BunkerReputationFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *BunkerReputationRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationRoleAdminChanged)
+				if err := _BunkerReputation.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerReputation *BunkerReputationFilterer) ParseRoleAdminChanged(log types.Log) (*BunkerReputationRoleAdminChanged, error) {
+	event := new(BunkerReputationRoleAdminChanged)
+	if err := _BunkerReputation.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the BunkerReputation contract.
+type BunkerReputationRoleGrantedIterator struct {
+	Event *BunkerReputationRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationRoleGranted represents a RoleGranted event raised by the BunkerReputation contract.
+type BunkerReputationRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerReputation *BunkerReputationFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BunkerReputationRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationRoleGrantedIterator{contract: _BunkerReputation.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerReputation *BunkerReputationFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *BunkerReputationRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationRoleGranted)
+				if err := _BunkerReputation.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerReputation *BunkerReputationFilterer) ParseRoleGranted(log types.Log) (*BunkerReputationRoleGranted, error) {
+	event := new(BunkerReputationRoleGranted)
+	if err := _BunkerReputation.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the BunkerReputation contract.
+type BunkerReputationRoleRevokedIterator struct {
+	Event *BunkerReputationRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationRoleRevoked represents a RoleRevoked event raised by the BunkerReputation contract.
+type BunkerReputationRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerReputation *BunkerReputationFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BunkerReputationRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationRoleRevokedIterator{contract: _BunkerReputation.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerReputation *BunkerReputationFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *BunkerReputationRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationRoleRevoked)
+				if err := _BunkerReputation.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerReputation *BunkerReputationFilterer) ParseRoleRevoked(log types.Log) (*BunkerReputationRoleRevoked, error) {
+	event := new(BunkerReputationRoleRevoked)
+	if err := _BunkerReputation.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationScoreUpdatedIterator is returned from FilterScoreUpdated and is used to iterate over the raw logs and unpacked data for ScoreUpdated events raised by the BunkerReputation contract.
+type BunkerReputationScoreUpdatedIterator struct {
+	Event *BunkerReputationScoreUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationScoreUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationScoreUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationScoreUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationScoreUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationScoreUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationScoreUpdated represents a ScoreUpdated event raised by the BunkerReputation contract.
+type BunkerReputationScoreUpdated struct {
+	Provider common.Address
+	OldScore uint32
+	NewScore uint32
+	Reason   string
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterScoreUpdated is a free log retrieval operation binding the contract event 0xbbca41c649d7fd3213364f8d335fde7b4993be09ac1a455a7d6644cc8b3fe4bb.
+//
+// Solidity: event ScoreUpdated(address indexed provider, uint32 oldScore, uint32 newScore, string reason)
+func (_BunkerReputation *BunkerReputationFilterer) FilterScoreUpdated(opts *bind.FilterOpts, provider []common.Address) (*BunkerReputationScoreUpdatedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "ScoreUpdated", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationScoreUpdatedIterator{contract: _BunkerReputation.contract, event: "ScoreUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchScoreUpdated is a free log subscription operation binding the contract event 0xbbca41c649d7fd3213364f8d335fde7b4993be09ac1a455a7d6644cc8b3fe4bb.
+//
+// Solidity: event ScoreUpdated(address indexed provider, uint32 oldScore, uint32 newScore, string reason)
+func (_BunkerReputation *BunkerReputationFilterer) WatchScoreUpdated(opts *bind.WatchOpts, sink chan<- *BunkerReputationScoreUpdated, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "ScoreUpdated", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationScoreUpdated)
+				if err := _BunkerReputation.contract.UnpackLog(event, "ScoreUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseScoreUpdated is a log parse operation binding the contract event 0xbbca41c649d7fd3213364f8d335fde7b4993be09ac1a455a7d6644cc8b3fe4bb.
+//
+// Solidity: event ScoreUpdated(address indexed provider, uint32 oldScore, uint32 newScore, string reason)
+func (_BunkerReputation *BunkerReputationFilterer) ParseScoreUpdated(log types.Log) (*BunkerReputationScoreUpdated, error) {
+	event := new(BunkerReputationScoreUpdated)
+	if err := _BunkerReputation.contract.UnpackLog(event, "ScoreUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerReputationTierThresholdsUpdatedIterator is returned from FilterTierThresholdsUpdated and is used to iterate over the raw logs and unpacked data for TierThresholdsUpdated events raised by the BunkerReputation contract.
+type BunkerReputationTierThresholdsUpdatedIterator struct {
+	Event *BunkerReputationTierThresholdsUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerReputationTierThresholdsUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerReputationTierThresholdsUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerReputationTierThresholdsUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerReputationTierThresholdsUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerReputationTierThresholdsUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerReputationTierThresholdsUpdated represents a TierThresholdsUpdated event raised by the BunkerReputation contract.
+type BunkerReputationTierThresholdsUpdated struct {
+	Probation uint16
+	Standard  uint16
+	Trusted   uint16
+	Elite     uint16
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterTierThresholdsUpdated is a free log retrieval operation binding the contract event 0x10dda4fe76711959fec19b1e9e1ae3674fed9d64c297bea0b351c15f0fc867eb.
+//
+// Solidity: event TierThresholdsUpdated(uint16 probation, uint16 standard, uint16 trusted, uint16 elite)
+func (_BunkerReputation *BunkerReputationFilterer) FilterTierThresholdsUpdated(opts *bind.FilterOpts) (*BunkerReputationTierThresholdsUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerReputation.contract.FilterLogs(opts, "TierThresholdsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerReputationTierThresholdsUpdatedIterator{contract: _BunkerReputation.contract, event: "TierThresholdsUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchTierThresholdsUpdated is a free log subscription operation binding the contract event 0x10dda4fe76711959fec19b1e9e1ae3674fed9d64c297bea0b351c15f0fc867eb.
+//
+// Solidity: event TierThresholdsUpdated(uint16 probation, uint16 standard, uint16 trusted, uint16 elite)
+func (_BunkerReputation *BunkerReputationFilterer) WatchTierThresholdsUpdated(opts *bind.WatchOpts, sink chan<- *BunkerReputationTierThresholdsUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerReputation.contract.WatchLogs(opts, "TierThresholdsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerReputationTierThresholdsUpdated)
+				if err := _BunkerReputation.contract.UnpackLog(event, "TierThresholdsUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTierThresholdsUpdated is a log parse operation binding the contract event 0x10dda4fe76711959fec19b1e9e1ae3674fed9d64c297bea0b351c15f0fc867eb.
+//
+// Solidity: event TierThresholdsUpdated(uint16 probation, uint16 standard, uint16 trusted, uint16 elite)
+func (_BunkerReputation *BunkerReputationFilterer) ParseTierThresholdsUpdated(log types.Log) (*BunkerReputationTierThresholdsUpdated, error) {
+	event := new(BunkerReputationTierThresholdsUpdated)
+	if err := _BunkerReputation.contract.UnpackLog(event, "TierThresholdsUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/payment/bindings/bunkerstaking.go
+++ b/internal/payment/bindings/bunkerstaking.go
@@ -1,0 +1,9135 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BunkerStakingProviderInfo is an auto generated low-level Go binding around an user-defined struct.
+type BunkerStakingProviderInfo struct {
+	StakedAmount   *big.Int
+	TotalUnbonding *big.Int
+	Beneficiary    common.Address
+	RegisteredAt   *big.Int
+	Active         bool
+	NodeId         [32]byte
+	Region         [32]byte
+	Capabilities   uint64
+	Frozen         bool
+}
+
+// BunkerStakingSlashProposal is an auto generated low-level Go binding around an user-defined struct.
+type BunkerStakingSlashProposal struct {
+	Provider             common.Address
+	Amount               *big.Int
+	Reason               string
+	ProposedAt           *big.Int
+	Executed             bool
+	Appealed             bool
+	Resolved             bool
+	SlashReason          uint8
+	AppealWindowSnapshot *big.Int
+	SlashBurnBpsSnapshot uint16
+}
+
+// BunkerStakingUnstakeRequest is an auto generated low-level Go binding around an user-defined struct.
+type BunkerStakingUnstakeRequest struct {
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Completed  bool
+}
+
+// BunkerStakingMetaData contains all meta data concerning the BunkerStaking contract.
+var BunkerStakingMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_treasury\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_initialOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BENEFICIARY_TIMELOCK\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"BPS_DENOMINATOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_EMISSION_MULTIPLIER\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"SLASHER_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"appealSlash\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"appealWindow\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"claimRewards\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"claimVestedRewards\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"completeUnstake\",\"inputs\":[{\"name\":\"requestIndex\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"earned\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"emissionMultiplier\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"executeBeneficiaryChange\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"executeSlash\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"freezeProvider\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getClaimableVested\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"claimable\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderInfo\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structBunkerStaking.ProviderInfo\",\"components\":[{\"name\":\"stakedAmount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"totalUnbonding\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"beneficiary\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"registeredAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"active\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"nodeId\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"region\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"capabilities\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"frozen\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getSlashProposal\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"proposal\",\"type\":\"tuple\",\"internalType\":\"structBunkerStaking.SlashProposal\",\"components\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"reason\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"proposedAt\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"executed\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"appealed\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"resolved\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"slashReason\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.SlashReason\"},{\"name\":\"appealWindowSnapshot\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"slashBurnBpsSnapshot\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getSlashableBalance\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"total\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getTier\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"tier\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.Tier\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getTierForAmount\",\"inputs\":[{\"name\":\"stakeAmount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"tier\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.Tier\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getUnstakeQueueLength\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"count\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getUnstakeRequest\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"request\",\"type\":\"tuple\",\"internalType\":\"structBunkerStaking.UnstakeRequest\",\"components\":[{\"name\":\"amount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"unlockTime\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"completed\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getVestedRewardCount\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"count\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"immediateReleaseBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initiateBeneficiaryChange\",\"inputs\":[{\"name\":\"newBeneficiary\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isActiveProvider\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"active\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"lastTimeRewardApplicable\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"lastUpdateTime\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"maxEmissionRate\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"maxTierMultiplierBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"nodeIdToProvider\",\"inputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"notifyRewardAmount\",\"inputs\":[{\"name\":\"reward\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingBeneficiaries\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"newBeneficiary\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"effectiveTime\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"periodFinish\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proposeSlash\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"reason\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"proposeSlashByReason\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"reason\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.SlashReason\"}],\"outputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"providers\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"stakedAmount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"totalUnbonding\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"beneficiary\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"registeredAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"active\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"nodeId\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"region\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"capabilities\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"frozen\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"reportComputeHours\",\"inputs\":[{\"name\":\"hours_\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"requestUnstake\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"resolveAppeal\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"uphold\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"rewardPerToken\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"rewardPerTokenStored\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"rewardRate\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"rewards\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"rewardsDuration\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"rewardsToken\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setAppealWindow\",\"inputs\":[{\"name\":\"newWindow\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setEmissionMultiplier\",\"inputs\":[{\"name\":\"multiplierBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMaxEmissionRate\",\"inputs\":[{\"name\":\"maxRate\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMaxTierMultiplierBps\",\"inputs\":[{\"name\":\"newMax\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRewardsDuration\",\"inputs\":[{\"name\":\"_rewardsDuration\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSlashFeeSplit\",\"inputs\":[{\"name\":\"burnBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"treasuryBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSlashPercentage\",\"inputs\":[{\"name\":\"reason\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.SlashReason\"},{\"name\":\"bps\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSlashingEnabled\",\"inputs\":[{\"name\":\"enabled\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTierMinStake\",\"inputs\":[{\"name\":\"tier\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.Tier\"},{\"name\":\"minStake\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTierRewardMultiplier\",\"inputs\":[{\"name\":\"tier\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.Tier\"},{\"name\":\"multiplierBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTreasury\",\"inputs\":[{\"name\":\"newTreasury\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setUnbondingPeriod\",\"inputs\":[{\"name\":\"newPeriod\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setVestingParams\",\"inputs\":[{\"name\":\"_vestingPeriod\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_immediateReleaseBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"slash\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"slashBurnBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashImmediate\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"slashPercentageBps\",\"inputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.SlashReason\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashProposalCount\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashProposals\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"reason\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"proposedAt\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"executed\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"appealed\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"resolved\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"slashReason\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.SlashReason\"},{\"name\":\"appealWindowSnapshot\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"slashBurnBpsSnapshot\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashTreasuryBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"slashingEnabled\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"stake\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"stakeWithIdentity\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"nodeId\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"region\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"capabilities\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"tierConfigs\",\"inputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.Tier\"}],\"outputs\":[{\"name\":\"minStake\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxConcurrentJobs\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"rewardMultiplierBps\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"priorityQueue\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"governance\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"token\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalComputeHoursReported\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalStaked\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalUnbonding\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"treasury\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unbondingPeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unfreezeProvider\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unstakeQueues\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"amount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"unlockTime\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"completed\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"updateIdentity\",\"inputs\":[{\"name\":\"nodeId\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"region\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"capabilities\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"userRewardPerTokenPaid\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"vestedRewards\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"totalAmount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"releasedAmount\",\"type\":\"uint128\",\"internalType\":\"uint128\"},{\"name\":\"vestingStart\",\"type\":\"uint48\",\"internalType\":\"uint48\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"vestingPeriod\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"AppealResolved\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"upheld\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"AppealWindowUpdated\",\"inputs\":[{\"name\":\"newWindow\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BeneficiaryChangeInitiated\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newBeneficiary\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"effectiveTime\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BeneficiaryChanged\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"oldBeneficiary\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newBeneficiary\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ComputeHoursReported\",\"inputs\":[{\"name\":\"hours_\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"totalComputeHours\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"EmissionMultiplierUpdated\",\"inputs\":[{\"name\":\"multiplierBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MaxEmissionRateUpdated\",\"inputs\":[{\"name\":\"maxRate\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MaxTierMultiplierUpdated\",\"inputs\":[{\"name\":\"newMax\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderDeregistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderFrozen\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"by\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderIdentityUpdated\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"nodeId\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"region\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"capabilities\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderRegistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"stakeAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"tier\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumBunkerStaking.Tier\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderUnfrozen\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardClaimed\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardEpochStarted\",\"inputs\":[{\"name\":\"reward\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"rewardRate\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"periodFinish\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardVested\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"totalAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"immediateAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"vestedAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RewardsDurationUpdated\",\"inputs\":[{\"name\":\"newDuration\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashAppealed\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashFeeSplitUpdated\",\"inputs\":[{\"name\":\"burnBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"},{\"name\":\"treasuryBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashPercentageUpdated\",\"inputs\":[{\"name\":\"reason\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"enumBunkerStaking.SlashReason\"},{\"name\":\"bps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashProposalExecuted\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashProposed\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"reason\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashProposedByReason\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"reason\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumBunkerStaking.SlashReason\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Slashed\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"totalSlashed\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"burnedAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"treasuryAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SlashingEnabledUpdated\",\"inputs\":[{\"name\":\"enabled\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Staked\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"totalStake\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"tier\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumBunkerStaking.Tier\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TierConfigUpdated\",\"inputs\":[{\"name\":\"tier\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"enumBunkerStaking.Tier\"},{\"name\":\"minStake\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TierRewardMultiplierUpdated\",\"inputs\":[{\"name\":\"tier\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"enumBunkerStaking.Tier\"},{\"name\":\"multiplierBps\",\"type\":\"uint16\",\"indexed\":false,\"internalType\":\"uint16\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TreasuryUpdated\",\"inputs\":[{\"name\":\"oldTreasury\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newTreasury\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"UnbondingPeriodUpdated\",\"inputs\":[{\"name\":\"newPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"UnstakeCompleted\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"requestIndex\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"UnstakeRequested\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"unlockTime\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"requestIndex\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VestedRewardsClaimed\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VestedRewardsForfeited\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"VestingParamsUpdated\",\"inputs\":[{\"name\":\"vestingPeriod\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"immediateReleaseBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AlreadyRegistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"AppealWindowElapsed\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"AppealWindowNotElapsed\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"windowEnd\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"BelowMinimumStake\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minimum\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"BeneficiaryTimelockNotElapsed\",\"inputs\":[{\"name\":\"effectiveTime\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"currentTime\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"CannotConfigureNoneTier\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InsufficientSlashableBalance\",\"inputs\":[{\"name\":\"requested\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"available\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InsufficientStake\",\"inputs\":[{\"name\":\"requested\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"available\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidAppealWindow\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidEmissionMultiplier\",\"inputs\":[{\"name\":\"multiplier\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidFeeSplit\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidImmediateReleaseBps\",\"inputs\":[{\"name\":\"bps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidMultiplierCap\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidProposalId\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidSlashPercentage\",\"inputs\":[{\"name\":\"bps\",\"type\":\"uint16\",\"internalType\":\"uint16\"}]},{\"type\":\"error\",\"name\":\"InvalidSlashReason\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidUnbondingPeriod\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidUnstakeIndex\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"queueLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidVestingPeriod\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MultiplierTooHigh\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MultiplierTooLow\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoPendingBeneficiaryChange\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NoRewardsToClaimError\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NoVestedRewardsClaimable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NodeIdAlreadyClaimed\",\"inputs\":[{\"name\":\"nodeId\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"NotProposalProvider\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProposalAlreadyAppealed\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProposalAlreadyExecuted\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProposalAlreadyResolved\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProposalAppealed\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProposalNotAppealed\",\"inputs\":[{\"name\":\"proposalId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProviderIsFrozen\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProviderNotActive\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RewardDurationNotFinished\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RewardRateTooHigh\",\"inputs\":[{\"name\":\"rewardRate\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"RewardsDurationZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SlashingNotEnabled\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TierOrderViolation\",\"inputs\":[{\"name\":\"tier\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.Tier\"},{\"name\":\"minStake\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"adjacentTier\",\"type\":\"uint8\",\"internalType\":\"enumBunkerStaking.Tier\"},{\"name\":\"adjacentMinStake\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"TokenBurnFailed\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TooManyUnstakeRequests\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UnbondingNotReady\",\"inputs\":[{\"name\":\"unlockTime\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"currentTime\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UnstakeAlreadyCompleted\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UseUpdateIdentity\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// BunkerStakingABI is the input ABI used to generate the binding from.
+// Deprecated: Use BunkerStakingMetaData.ABI instead.
+var BunkerStakingABI = BunkerStakingMetaData.ABI
+
+// BunkerStaking is an auto generated Go binding around an Ethereum contract.
+type BunkerStaking struct {
+	BunkerStakingCaller     // Read-only binding to the contract
+	BunkerStakingTransactor // Write-only binding to the contract
+	BunkerStakingFilterer   // Log filterer for contract events
+}
+
+// BunkerStakingCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BunkerStakingCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerStakingTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BunkerStakingTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerStakingFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BunkerStakingFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerStakingSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BunkerStakingSession struct {
+	Contract     *BunkerStaking    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BunkerStakingCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BunkerStakingCallerSession struct {
+	Contract *BunkerStakingCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// BunkerStakingTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BunkerStakingTransactorSession struct {
+	Contract     *BunkerStakingTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// BunkerStakingRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BunkerStakingRaw struct {
+	Contract *BunkerStaking // Generic contract binding to access the raw methods on
+}
+
+// BunkerStakingCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BunkerStakingCallerRaw struct {
+	Contract *BunkerStakingCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BunkerStakingTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BunkerStakingTransactorRaw struct {
+	Contract *BunkerStakingTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBunkerStaking creates a new instance of BunkerStaking, bound to a specific deployed contract.
+func NewBunkerStaking(address common.Address, backend bind.ContractBackend) (*BunkerStaking, error) {
+	contract, err := bindBunkerStaking(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStaking{BunkerStakingCaller: BunkerStakingCaller{contract: contract}, BunkerStakingTransactor: BunkerStakingTransactor{contract: contract}, BunkerStakingFilterer: BunkerStakingFilterer{contract: contract}}, nil
+}
+
+// NewBunkerStakingCaller creates a new read-only instance of BunkerStaking, bound to a specific deployed contract.
+func NewBunkerStakingCaller(address common.Address, caller bind.ContractCaller) (*BunkerStakingCaller, error) {
+	contract, err := bindBunkerStaking(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingCaller{contract: contract}, nil
+}
+
+// NewBunkerStakingTransactor creates a new write-only instance of BunkerStaking, bound to a specific deployed contract.
+func NewBunkerStakingTransactor(address common.Address, transactor bind.ContractTransactor) (*BunkerStakingTransactor, error) {
+	contract, err := bindBunkerStaking(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingTransactor{contract: contract}, nil
+}
+
+// NewBunkerStakingFilterer creates a new log filterer instance of BunkerStaking, bound to a specific deployed contract.
+func NewBunkerStakingFilterer(address common.Address, filterer bind.ContractFilterer) (*BunkerStakingFilterer, error) {
+	contract, err := bindBunkerStaking(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingFilterer{contract: contract}, nil
+}
+
+// bindBunkerStaking binds a generic wrapper to an already deployed contract.
+func bindBunkerStaking(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BunkerStakingMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerStaking *BunkerStakingRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerStaking.Contract.BunkerStakingCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerStaking *BunkerStakingRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.BunkerStakingTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerStaking *BunkerStakingRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.BunkerStakingTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerStaking *BunkerStakingCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerStaking.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerStaking *BunkerStakingTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerStaking *BunkerStakingTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.contract.Transact(opts, method, params...)
+}
+
+// BENEFICIARYTIMELOCK is a free data retrieval call binding the contract method 0x982bd124.
+//
+// Solidity: function BENEFICIARY_TIMELOCK() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) BENEFICIARYTIMELOCK(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "BENEFICIARY_TIMELOCK")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BENEFICIARYTIMELOCK is a free data retrieval call binding the contract method 0x982bd124.
+//
+// Solidity: function BENEFICIARY_TIMELOCK() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) BENEFICIARYTIMELOCK() (*big.Int, error) {
+	return _BunkerStaking.Contract.BENEFICIARYTIMELOCK(&_BunkerStaking.CallOpts)
+}
+
+// BENEFICIARYTIMELOCK is a free data retrieval call binding the contract method 0x982bd124.
+//
+// Solidity: function BENEFICIARY_TIMELOCK() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) BENEFICIARYTIMELOCK() (*big.Int, error) {
+	return _BunkerStaking.Contract.BENEFICIARYTIMELOCK(&_BunkerStaking.CallOpts)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) BPSDENOMINATOR(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "BPS_DENOMINATOR")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerStaking.Contract.BPSDENOMINATOR(&_BunkerStaking.CallOpts)
+}
+
+// BPSDENOMINATOR is a free data retrieval call binding the contract method 0xe1a45218.
+//
+// Solidity: function BPS_DENOMINATOR() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) BPSDENOMINATOR() (*big.Int, error) {
+	return _BunkerStaking.Contract.BPSDENOMINATOR(&_BunkerStaking.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerStaking *BunkerStakingCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerStaking *BunkerStakingSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BunkerStaking.Contract.DEFAULTADMINROLE(&_BunkerStaking.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerStaking *BunkerStakingCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BunkerStaking.Contract.DEFAULTADMINROLE(&_BunkerStaking.CallOpts)
+}
+
+// MAXEMISSIONMULTIPLIER is a free data retrieval call binding the contract method 0xa452ab9f.
+//
+// Solidity: function MAX_EMISSION_MULTIPLIER() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) MAXEMISSIONMULTIPLIER(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "MAX_EMISSION_MULTIPLIER")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXEMISSIONMULTIPLIER is a free data retrieval call binding the contract method 0xa452ab9f.
+//
+// Solidity: function MAX_EMISSION_MULTIPLIER() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) MAXEMISSIONMULTIPLIER() (*big.Int, error) {
+	return _BunkerStaking.Contract.MAXEMISSIONMULTIPLIER(&_BunkerStaking.CallOpts)
+}
+
+// MAXEMISSIONMULTIPLIER is a free data retrieval call binding the contract method 0xa452ab9f.
+//
+// Solidity: function MAX_EMISSION_MULTIPLIER() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) MAXEMISSIONMULTIPLIER() (*big.Int, error) {
+	return _BunkerStaking.Contract.MAXEMISSIONMULTIPLIER(&_BunkerStaking.CallOpts)
+}
+
+// SLASHERROLE is a free data retrieval call binding the contract method 0x5095af64.
+//
+// Solidity: function SLASHER_ROLE() view returns(bytes32)
+func (_BunkerStaking *BunkerStakingCaller) SLASHERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "SLASHER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// SLASHERROLE is a free data retrieval call binding the contract method 0x5095af64.
+//
+// Solidity: function SLASHER_ROLE() view returns(bytes32)
+func (_BunkerStaking *BunkerStakingSession) SLASHERROLE() ([32]byte, error) {
+	return _BunkerStaking.Contract.SLASHERROLE(&_BunkerStaking.CallOpts)
+}
+
+// SLASHERROLE is a free data retrieval call binding the contract method 0x5095af64.
+//
+// Solidity: function SLASHER_ROLE() view returns(bytes32)
+func (_BunkerStaking *BunkerStakingCallerSession) SLASHERROLE() ([32]byte, error) {
+	return _BunkerStaking.Contract.SLASHERROLE(&_BunkerStaking.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerStaking *BunkerStakingCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerStaking *BunkerStakingSession) VERSION() (string, error) {
+	return _BunkerStaking.Contract.VERSION(&_BunkerStaking.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerStaking *BunkerStakingCallerSession) VERSION() (string, error) {
+	return _BunkerStaking.Contract.VERSION(&_BunkerStaking.CallOpts)
+}
+
+// AppealWindow is a free data retrieval call binding the contract method 0x3fd2938a.
+//
+// Solidity: function appealWindow() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) AppealWindow(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "appealWindow")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// AppealWindow is a free data retrieval call binding the contract method 0x3fd2938a.
+//
+// Solidity: function appealWindow() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) AppealWindow() (*big.Int, error) {
+	return _BunkerStaking.Contract.AppealWindow(&_BunkerStaking.CallOpts)
+}
+
+// AppealWindow is a free data retrieval call binding the contract method 0x3fd2938a.
+//
+// Solidity: function appealWindow() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) AppealWindow() (*big.Int, error) {
+	return _BunkerStaking.Contract.AppealWindow(&_BunkerStaking.CallOpts)
+}
+
+// Earned is a free data retrieval call binding the contract method 0x008cc262.
+//
+// Solidity: function earned(address provider) view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) Earned(opts *bind.CallOpts, provider common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "earned", provider)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Earned is a free data retrieval call binding the contract method 0x008cc262.
+//
+// Solidity: function earned(address provider) view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) Earned(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.Earned(&_BunkerStaking.CallOpts, provider)
+}
+
+// Earned is a free data retrieval call binding the contract method 0x008cc262.
+//
+// Solidity: function earned(address provider) view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) Earned(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.Earned(&_BunkerStaking.CallOpts, provider)
+}
+
+// EmissionMultiplier is a free data retrieval call binding the contract method 0x37de2e19.
+//
+// Solidity: function emissionMultiplier() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) EmissionMultiplier(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "emissionMultiplier")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// EmissionMultiplier is a free data retrieval call binding the contract method 0x37de2e19.
+//
+// Solidity: function emissionMultiplier() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) EmissionMultiplier() (*big.Int, error) {
+	return _BunkerStaking.Contract.EmissionMultiplier(&_BunkerStaking.CallOpts)
+}
+
+// EmissionMultiplier is a free data retrieval call binding the contract method 0x37de2e19.
+//
+// Solidity: function emissionMultiplier() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) EmissionMultiplier() (*big.Int, error) {
+	return _BunkerStaking.Contract.EmissionMultiplier(&_BunkerStaking.CallOpts)
+}
+
+// GetClaimableVested is a free data retrieval call binding the contract method 0x73522681.
+//
+// Solidity: function getClaimableVested(address provider) view returns(uint256 claimable)
+func (_BunkerStaking *BunkerStakingCaller) GetClaimableVested(opts *bind.CallOpts, provider common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getClaimableVested", provider)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetClaimableVested is a free data retrieval call binding the contract method 0x73522681.
+//
+// Solidity: function getClaimableVested(address provider) view returns(uint256 claimable)
+func (_BunkerStaking *BunkerStakingSession) GetClaimableVested(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.GetClaimableVested(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetClaimableVested is a free data retrieval call binding the contract method 0x73522681.
+//
+// Solidity: function getClaimableVested(address provider) view returns(uint256 claimable)
+func (_BunkerStaking *BunkerStakingCallerSession) GetClaimableVested(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.GetClaimableVested(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetProviderInfo is a free data retrieval call binding the contract method 0x7583902f.
+//
+// Solidity: function getProviderInfo(address provider) view returns((uint128,uint128,address,uint48,bool,bytes32,bytes32,uint64,bool) info)
+func (_BunkerStaking *BunkerStakingCaller) GetProviderInfo(opts *bind.CallOpts, provider common.Address) (BunkerStakingProviderInfo, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getProviderInfo", provider)
+
+	if err != nil {
+		return *new(BunkerStakingProviderInfo), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerStakingProviderInfo)).(*BunkerStakingProviderInfo)
+
+	return out0, err
+
+}
+
+// GetProviderInfo is a free data retrieval call binding the contract method 0x7583902f.
+//
+// Solidity: function getProviderInfo(address provider) view returns((uint128,uint128,address,uint48,bool,bytes32,bytes32,uint64,bool) info)
+func (_BunkerStaking *BunkerStakingSession) GetProviderInfo(provider common.Address) (BunkerStakingProviderInfo, error) {
+	return _BunkerStaking.Contract.GetProviderInfo(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetProviderInfo is a free data retrieval call binding the contract method 0x7583902f.
+//
+// Solidity: function getProviderInfo(address provider) view returns((uint128,uint128,address,uint48,bool,bytes32,bytes32,uint64,bool) info)
+func (_BunkerStaking *BunkerStakingCallerSession) GetProviderInfo(provider common.Address) (BunkerStakingProviderInfo, error) {
+	return _BunkerStaking.Contract.GetProviderInfo(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerStaking *BunkerStakingCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerStaking *BunkerStakingSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BunkerStaking.Contract.GetRoleAdmin(&_BunkerStaking.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerStaking *BunkerStakingCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BunkerStaking.Contract.GetRoleAdmin(&_BunkerStaking.CallOpts, role)
+}
+
+// GetSlashProposal is a free data retrieval call binding the contract method 0x97b5103c.
+//
+// Solidity: function getSlashProposal(uint256 proposalId) view returns((address,uint256,string,uint256,bool,bool,bool,uint8,uint256,uint16) proposal)
+func (_BunkerStaking *BunkerStakingCaller) GetSlashProposal(opts *bind.CallOpts, proposalId *big.Int) (BunkerStakingSlashProposal, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getSlashProposal", proposalId)
+
+	if err != nil {
+		return *new(BunkerStakingSlashProposal), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerStakingSlashProposal)).(*BunkerStakingSlashProposal)
+
+	return out0, err
+
+}
+
+// GetSlashProposal is a free data retrieval call binding the contract method 0x97b5103c.
+//
+// Solidity: function getSlashProposal(uint256 proposalId) view returns((address,uint256,string,uint256,bool,bool,bool,uint8,uint256,uint16) proposal)
+func (_BunkerStaking *BunkerStakingSession) GetSlashProposal(proposalId *big.Int) (BunkerStakingSlashProposal, error) {
+	return _BunkerStaking.Contract.GetSlashProposal(&_BunkerStaking.CallOpts, proposalId)
+}
+
+// GetSlashProposal is a free data retrieval call binding the contract method 0x97b5103c.
+//
+// Solidity: function getSlashProposal(uint256 proposalId) view returns((address,uint256,string,uint256,bool,bool,bool,uint8,uint256,uint16) proposal)
+func (_BunkerStaking *BunkerStakingCallerSession) GetSlashProposal(proposalId *big.Int) (BunkerStakingSlashProposal, error) {
+	return _BunkerStaking.Contract.GetSlashProposal(&_BunkerStaking.CallOpts, proposalId)
+}
+
+// GetSlashableBalance is a free data retrieval call binding the contract method 0x61860e4c.
+//
+// Solidity: function getSlashableBalance(address provider) view returns(uint256 total)
+func (_BunkerStaking *BunkerStakingCaller) GetSlashableBalance(opts *bind.CallOpts, provider common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getSlashableBalance", provider)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetSlashableBalance is a free data retrieval call binding the contract method 0x61860e4c.
+//
+// Solidity: function getSlashableBalance(address provider) view returns(uint256 total)
+func (_BunkerStaking *BunkerStakingSession) GetSlashableBalance(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.GetSlashableBalance(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetSlashableBalance is a free data retrieval call binding the contract method 0x61860e4c.
+//
+// Solidity: function getSlashableBalance(address provider) view returns(uint256 total)
+func (_BunkerStaking *BunkerStakingCallerSession) GetSlashableBalance(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.GetSlashableBalance(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetTier is a free data retrieval call binding the contract method 0xb45aae52.
+//
+// Solidity: function getTier(address provider) view returns(uint8 tier)
+func (_BunkerStaking *BunkerStakingCaller) GetTier(opts *bind.CallOpts, provider common.Address) (uint8, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getTier", provider)
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// GetTier is a free data retrieval call binding the contract method 0xb45aae52.
+//
+// Solidity: function getTier(address provider) view returns(uint8 tier)
+func (_BunkerStaking *BunkerStakingSession) GetTier(provider common.Address) (uint8, error) {
+	return _BunkerStaking.Contract.GetTier(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetTier is a free data retrieval call binding the contract method 0xb45aae52.
+//
+// Solidity: function getTier(address provider) view returns(uint8 tier)
+func (_BunkerStaking *BunkerStakingCallerSession) GetTier(provider common.Address) (uint8, error) {
+	return _BunkerStaking.Contract.GetTier(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetTierForAmount is a free data retrieval call binding the contract method 0x1237739b.
+//
+// Solidity: function getTierForAmount(uint256 stakeAmount) view returns(uint8 tier)
+func (_BunkerStaking *BunkerStakingCaller) GetTierForAmount(opts *bind.CallOpts, stakeAmount *big.Int) (uint8, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getTierForAmount", stakeAmount)
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// GetTierForAmount is a free data retrieval call binding the contract method 0x1237739b.
+//
+// Solidity: function getTierForAmount(uint256 stakeAmount) view returns(uint8 tier)
+func (_BunkerStaking *BunkerStakingSession) GetTierForAmount(stakeAmount *big.Int) (uint8, error) {
+	return _BunkerStaking.Contract.GetTierForAmount(&_BunkerStaking.CallOpts, stakeAmount)
+}
+
+// GetTierForAmount is a free data retrieval call binding the contract method 0x1237739b.
+//
+// Solidity: function getTierForAmount(uint256 stakeAmount) view returns(uint8 tier)
+func (_BunkerStaking *BunkerStakingCallerSession) GetTierForAmount(stakeAmount *big.Int) (uint8, error) {
+	return _BunkerStaking.Contract.GetTierForAmount(&_BunkerStaking.CallOpts, stakeAmount)
+}
+
+// GetUnstakeQueueLength is a free data retrieval call binding the contract method 0x2eb3328a.
+//
+// Solidity: function getUnstakeQueueLength(address provider) view returns(uint256 count)
+func (_BunkerStaking *BunkerStakingCaller) GetUnstakeQueueLength(opts *bind.CallOpts, provider common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getUnstakeQueueLength", provider)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetUnstakeQueueLength is a free data retrieval call binding the contract method 0x2eb3328a.
+//
+// Solidity: function getUnstakeQueueLength(address provider) view returns(uint256 count)
+func (_BunkerStaking *BunkerStakingSession) GetUnstakeQueueLength(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.GetUnstakeQueueLength(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetUnstakeQueueLength is a free data retrieval call binding the contract method 0x2eb3328a.
+//
+// Solidity: function getUnstakeQueueLength(address provider) view returns(uint256 count)
+func (_BunkerStaking *BunkerStakingCallerSession) GetUnstakeQueueLength(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.GetUnstakeQueueLength(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetUnstakeRequest is a free data retrieval call binding the contract method 0x4ae6c4ae.
+//
+// Solidity: function getUnstakeRequest(address provider, uint256 index) view returns((uint128,uint48,bool) request)
+func (_BunkerStaking *BunkerStakingCaller) GetUnstakeRequest(opts *bind.CallOpts, provider common.Address, index *big.Int) (BunkerStakingUnstakeRequest, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getUnstakeRequest", provider, index)
+
+	if err != nil {
+		return *new(BunkerStakingUnstakeRequest), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerStakingUnstakeRequest)).(*BunkerStakingUnstakeRequest)
+
+	return out0, err
+
+}
+
+// GetUnstakeRequest is a free data retrieval call binding the contract method 0x4ae6c4ae.
+//
+// Solidity: function getUnstakeRequest(address provider, uint256 index) view returns((uint128,uint48,bool) request)
+func (_BunkerStaking *BunkerStakingSession) GetUnstakeRequest(provider common.Address, index *big.Int) (BunkerStakingUnstakeRequest, error) {
+	return _BunkerStaking.Contract.GetUnstakeRequest(&_BunkerStaking.CallOpts, provider, index)
+}
+
+// GetUnstakeRequest is a free data retrieval call binding the contract method 0x4ae6c4ae.
+//
+// Solidity: function getUnstakeRequest(address provider, uint256 index) view returns((uint128,uint48,bool) request)
+func (_BunkerStaking *BunkerStakingCallerSession) GetUnstakeRequest(provider common.Address, index *big.Int) (BunkerStakingUnstakeRequest, error) {
+	return _BunkerStaking.Contract.GetUnstakeRequest(&_BunkerStaking.CallOpts, provider, index)
+}
+
+// GetVestedRewardCount is a free data retrieval call binding the contract method 0xc4a24845.
+//
+// Solidity: function getVestedRewardCount(address provider) view returns(uint256 count)
+func (_BunkerStaking *BunkerStakingCaller) GetVestedRewardCount(opts *bind.CallOpts, provider common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "getVestedRewardCount", provider)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetVestedRewardCount is a free data retrieval call binding the contract method 0xc4a24845.
+//
+// Solidity: function getVestedRewardCount(address provider) view returns(uint256 count)
+func (_BunkerStaking *BunkerStakingSession) GetVestedRewardCount(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.GetVestedRewardCount(&_BunkerStaking.CallOpts, provider)
+}
+
+// GetVestedRewardCount is a free data retrieval call binding the contract method 0xc4a24845.
+//
+// Solidity: function getVestedRewardCount(address provider) view returns(uint256 count)
+func (_BunkerStaking *BunkerStakingCallerSession) GetVestedRewardCount(provider common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.GetVestedRewardCount(&_BunkerStaking.CallOpts, provider)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerStaking *BunkerStakingCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerStaking *BunkerStakingSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BunkerStaking.Contract.HasRole(&_BunkerStaking.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerStaking *BunkerStakingCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BunkerStaking.Contract.HasRole(&_BunkerStaking.CallOpts, role, account)
+}
+
+// ImmediateReleaseBps is a free data retrieval call binding the contract method 0x193f8d93.
+//
+// Solidity: function immediateReleaseBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) ImmediateReleaseBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "immediateReleaseBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ImmediateReleaseBps is a free data retrieval call binding the contract method 0x193f8d93.
+//
+// Solidity: function immediateReleaseBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) ImmediateReleaseBps() (*big.Int, error) {
+	return _BunkerStaking.Contract.ImmediateReleaseBps(&_BunkerStaking.CallOpts)
+}
+
+// ImmediateReleaseBps is a free data retrieval call binding the contract method 0x193f8d93.
+//
+// Solidity: function immediateReleaseBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) ImmediateReleaseBps() (*big.Int, error) {
+	return _BunkerStaking.Contract.ImmediateReleaseBps(&_BunkerStaking.CallOpts)
+}
+
+// IsActiveProvider is a free data retrieval call binding the contract method 0x9b5e1a3b.
+//
+// Solidity: function isActiveProvider(address provider) view returns(bool active)
+func (_BunkerStaking *BunkerStakingCaller) IsActiveProvider(opts *bind.CallOpts, provider common.Address) (bool, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "isActiveProvider", provider)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsActiveProvider is a free data retrieval call binding the contract method 0x9b5e1a3b.
+//
+// Solidity: function isActiveProvider(address provider) view returns(bool active)
+func (_BunkerStaking *BunkerStakingSession) IsActiveProvider(provider common.Address) (bool, error) {
+	return _BunkerStaking.Contract.IsActiveProvider(&_BunkerStaking.CallOpts, provider)
+}
+
+// IsActiveProvider is a free data retrieval call binding the contract method 0x9b5e1a3b.
+//
+// Solidity: function isActiveProvider(address provider) view returns(bool active)
+func (_BunkerStaking *BunkerStakingCallerSession) IsActiveProvider(provider common.Address) (bool, error) {
+	return _BunkerStaking.Contract.IsActiveProvider(&_BunkerStaking.CallOpts, provider)
+}
+
+// LastTimeRewardApplicable is a free data retrieval call binding the contract method 0x80faa57d.
+//
+// Solidity: function lastTimeRewardApplicable() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) LastTimeRewardApplicable(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "lastTimeRewardApplicable")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LastTimeRewardApplicable is a free data retrieval call binding the contract method 0x80faa57d.
+//
+// Solidity: function lastTimeRewardApplicable() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) LastTimeRewardApplicable() (*big.Int, error) {
+	return _BunkerStaking.Contract.LastTimeRewardApplicable(&_BunkerStaking.CallOpts)
+}
+
+// LastTimeRewardApplicable is a free data retrieval call binding the contract method 0x80faa57d.
+//
+// Solidity: function lastTimeRewardApplicable() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) LastTimeRewardApplicable() (*big.Int, error) {
+	return _BunkerStaking.Contract.LastTimeRewardApplicable(&_BunkerStaking.CallOpts)
+}
+
+// LastUpdateTime is a free data retrieval call binding the contract method 0xc8f33c91.
+//
+// Solidity: function lastUpdateTime() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) LastUpdateTime(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "lastUpdateTime")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// LastUpdateTime is a free data retrieval call binding the contract method 0xc8f33c91.
+//
+// Solidity: function lastUpdateTime() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) LastUpdateTime() (*big.Int, error) {
+	return _BunkerStaking.Contract.LastUpdateTime(&_BunkerStaking.CallOpts)
+}
+
+// LastUpdateTime is a free data retrieval call binding the contract method 0xc8f33c91.
+//
+// Solidity: function lastUpdateTime() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) LastUpdateTime() (*big.Int, error) {
+	return _BunkerStaking.Contract.LastUpdateTime(&_BunkerStaking.CallOpts)
+}
+
+// MaxEmissionRate is a free data retrieval call binding the contract method 0x142fc582.
+//
+// Solidity: function maxEmissionRate() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) MaxEmissionRate(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "maxEmissionRate")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MaxEmissionRate is a free data retrieval call binding the contract method 0x142fc582.
+//
+// Solidity: function maxEmissionRate() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) MaxEmissionRate() (*big.Int, error) {
+	return _BunkerStaking.Contract.MaxEmissionRate(&_BunkerStaking.CallOpts)
+}
+
+// MaxEmissionRate is a free data retrieval call binding the contract method 0x142fc582.
+//
+// Solidity: function maxEmissionRate() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) MaxEmissionRate() (*big.Int, error) {
+	return _BunkerStaking.Contract.MaxEmissionRate(&_BunkerStaking.CallOpts)
+}
+
+// MaxTierMultiplierBps is a free data retrieval call binding the contract method 0xedb38703.
+//
+// Solidity: function maxTierMultiplierBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) MaxTierMultiplierBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "maxTierMultiplierBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MaxTierMultiplierBps is a free data retrieval call binding the contract method 0xedb38703.
+//
+// Solidity: function maxTierMultiplierBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) MaxTierMultiplierBps() (*big.Int, error) {
+	return _BunkerStaking.Contract.MaxTierMultiplierBps(&_BunkerStaking.CallOpts)
+}
+
+// MaxTierMultiplierBps is a free data retrieval call binding the contract method 0xedb38703.
+//
+// Solidity: function maxTierMultiplierBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) MaxTierMultiplierBps() (*big.Int, error) {
+	return _BunkerStaking.Contract.MaxTierMultiplierBps(&_BunkerStaking.CallOpts)
+}
+
+// NodeIdToProvider is a free data retrieval call binding the contract method 0x04e05e8c.
+//
+// Solidity: function nodeIdToProvider(bytes32 ) view returns(address)
+func (_BunkerStaking *BunkerStakingCaller) NodeIdToProvider(opts *bind.CallOpts, arg0 [32]byte) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "nodeIdToProvider", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// NodeIdToProvider is a free data retrieval call binding the contract method 0x04e05e8c.
+//
+// Solidity: function nodeIdToProvider(bytes32 ) view returns(address)
+func (_BunkerStaking *BunkerStakingSession) NodeIdToProvider(arg0 [32]byte) (common.Address, error) {
+	return _BunkerStaking.Contract.NodeIdToProvider(&_BunkerStaking.CallOpts, arg0)
+}
+
+// NodeIdToProvider is a free data retrieval call binding the contract method 0x04e05e8c.
+//
+// Solidity: function nodeIdToProvider(bytes32 ) view returns(address)
+func (_BunkerStaking *BunkerStakingCallerSession) NodeIdToProvider(arg0 [32]byte) (common.Address, error) {
+	return _BunkerStaking.Contract.NodeIdToProvider(&_BunkerStaking.CallOpts, arg0)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerStaking *BunkerStakingCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerStaking *BunkerStakingSession) Owner() (common.Address, error) {
+	return _BunkerStaking.Contract.Owner(&_BunkerStaking.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerStaking *BunkerStakingCallerSession) Owner() (common.Address, error) {
+	return _BunkerStaking.Contract.Owner(&_BunkerStaking.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerStaking *BunkerStakingCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerStaking *BunkerStakingSession) Paused() (bool, error) {
+	return _BunkerStaking.Contract.Paused(&_BunkerStaking.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_BunkerStaking *BunkerStakingCallerSession) Paused() (bool, error) {
+	return _BunkerStaking.Contract.Paused(&_BunkerStaking.CallOpts)
+}
+
+// PendingBeneficiaries is a free data retrieval call binding the contract method 0x73605e7a.
+//
+// Solidity: function pendingBeneficiaries(address ) view returns(address newBeneficiary, uint48 effectiveTime)
+func (_BunkerStaking *BunkerStakingCaller) PendingBeneficiaries(opts *bind.CallOpts, arg0 common.Address) (struct {
+	NewBeneficiary common.Address
+	EffectiveTime  *big.Int
+}, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "pendingBeneficiaries", arg0)
+
+	outstruct := new(struct {
+		NewBeneficiary common.Address
+		EffectiveTime  *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.NewBeneficiary = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.EffectiveTime = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// PendingBeneficiaries is a free data retrieval call binding the contract method 0x73605e7a.
+//
+// Solidity: function pendingBeneficiaries(address ) view returns(address newBeneficiary, uint48 effectiveTime)
+func (_BunkerStaking *BunkerStakingSession) PendingBeneficiaries(arg0 common.Address) (struct {
+	NewBeneficiary common.Address
+	EffectiveTime  *big.Int
+}, error) {
+	return _BunkerStaking.Contract.PendingBeneficiaries(&_BunkerStaking.CallOpts, arg0)
+}
+
+// PendingBeneficiaries is a free data retrieval call binding the contract method 0x73605e7a.
+//
+// Solidity: function pendingBeneficiaries(address ) view returns(address newBeneficiary, uint48 effectiveTime)
+func (_BunkerStaking *BunkerStakingCallerSession) PendingBeneficiaries(arg0 common.Address) (struct {
+	NewBeneficiary common.Address
+	EffectiveTime  *big.Int
+}, error) {
+	return _BunkerStaking.Contract.PendingBeneficiaries(&_BunkerStaking.CallOpts, arg0)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerStaking *BunkerStakingCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerStaking *BunkerStakingSession) PendingOwner() (common.Address, error) {
+	return _BunkerStaking.Contract.PendingOwner(&_BunkerStaking.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerStaking *BunkerStakingCallerSession) PendingOwner() (common.Address, error) {
+	return _BunkerStaking.Contract.PendingOwner(&_BunkerStaking.CallOpts)
+}
+
+// PeriodFinish is a free data retrieval call binding the contract method 0xebe2b12b.
+//
+// Solidity: function periodFinish() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) PeriodFinish(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "periodFinish")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// PeriodFinish is a free data retrieval call binding the contract method 0xebe2b12b.
+//
+// Solidity: function periodFinish() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) PeriodFinish() (*big.Int, error) {
+	return _BunkerStaking.Contract.PeriodFinish(&_BunkerStaking.CallOpts)
+}
+
+// PeriodFinish is a free data retrieval call binding the contract method 0xebe2b12b.
+//
+// Solidity: function periodFinish() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) PeriodFinish() (*big.Int, error) {
+	return _BunkerStaking.Contract.PeriodFinish(&_BunkerStaking.CallOpts)
+}
+
+// Providers is a free data retrieval call binding the contract method 0x0787bc27.
+//
+// Solidity: function providers(address ) view returns(uint128 stakedAmount, uint128 totalUnbonding, address beneficiary, uint48 registeredAt, bool active, bytes32 nodeId, bytes32 region, uint64 capabilities, bool frozen)
+func (_BunkerStaking *BunkerStakingCaller) Providers(opts *bind.CallOpts, arg0 common.Address) (struct {
+	StakedAmount   *big.Int
+	TotalUnbonding *big.Int
+	Beneficiary    common.Address
+	RegisteredAt   *big.Int
+	Active         bool
+	NodeId         [32]byte
+	Region         [32]byte
+	Capabilities   uint64
+	Frozen         bool
+}, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "providers", arg0)
+
+	outstruct := new(struct {
+		StakedAmount   *big.Int
+		TotalUnbonding *big.Int
+		Beneficiary    common.Address
+		RegisteredAt   *big.Int
+		Active         bool
+		NodeId         [32]byte
+		Region         [32]byte
+		Capabilities   uint64
+		Frozen         bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.StakedAmount = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.TotalUnbonding = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.Beneficiary = *abi.ConvertType(out[2], new(common.Address)).(*common.Address)
+	outstruct.RegisteredAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.Active = *abi.ConvertType(out[4], new(bool)).(*bool)
+	outstruct.NodeId = *abi.ConvertType(out[5], new([32]byte)).(*[32]byte)
+	outstruct.Region = *abi.ConvertType(out[6], new([32]byte)).(*[32]byte)
+	outstruct.Capabilities = *abi.ConvertType(out[7], new(uint64)).(*uint64)
+	outstruct.Frozen = *abi.ConvertType(out[8], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// Providers is a free data retrieval call binding the contract method 0x0787bc27.
+//
+// Solidity: function providers(address ) view returns(uint128 stakedAmount, uint128 totalUnbonding, address beneficiary, uint48 registeredAt, bool active, bytes32 nodeId, bytes32 region, uint64 capabilities, bool frozen)
+func (_BunkerStaking *BunkerStakingSession) Providers(arg0 common.Address) (struct {
+	StakedAmount   *big.Int
+	TotalUnbonding *big.Int
+	Beneficiary    common.Address
+	RegisteredAt   *big.Int
+	Active         bool
+	NodeId         [32]byte
+	Region         [32]byte
+	Capabilities   uint64
+	Frozen         bool
+}, error) {
+	return _BunkerStaking.Contract.Providers(&_BunkerStaking.CallOpts, arg0)
+}
+
+// Providers is a free data retrieval call binding the contract method 0x0787bc27.
+//
+// Solidity: function providers(address ) view returns(uint128 stakedAmount, uint128 totalUnbonding, address beneficiary, uint48 registeredAt, bool active, bytes32 nodeId, bytes32 region, uint64 capabilities, bool frozen)
+func (_BunkerStaking *BunkerStakingCallerSession) Providers(arg0 common.Address) (struct {
+	StakedAmount   *big.Int
+	TotalUnbonding *big.Int
+	Beneficiary    common.Address
+	RegisteredAt   *big.Int
+	Active         bool
+	NodeId         [32]byte
+	Region         [32]byte
+	Capabilities   uint64
+	Frozen         bool
+}, error) {
+	return _BunkerStaking.Contract.Providers(&_BunkerStaking.CallOpts, arg0)
+}
+
+// RewardPerToken is a free data retrieval call binding the contract method 0xcd3daf9d.
+//
+// Solidity: function rewardPerToken() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) RewardPerToken(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "rewardPerToken")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// RewardPerToken is a free data retrieval call binding the contract method 0xcd3daf9d.
+//
+// Solidity: function rewardPerToken() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) RewardPerToken() (*big.Int, error) {
+	return _BunkerStaking.Contract.RewardPerToken(&_BunkerStaking.CallOpts)
+}
+
+// RewardPerToken is a free data retrieval call binding the contract method 0xcd3daf9d.
+//
+// Solidity: function rewardPerToken() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) RewardPerToken() (*big.Int, error) {
+	return _BunkerStaking.Contract.RewardPerToken(&_BunkerStaking.CallOpts)
+}
+
+// RewardPerTokenStored is a free data retrieval call binding the contract method 0xdf136d65.
+//
+// Solidity: function rewardPerTokenStored() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) RewardPerTokenStored(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "rewardPerTokenStored")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// RewardPerTokenStored is a free data retrieval call binding the contract method 0xdf136d65.
+//
+// Solidity: function rewardPerTokenStored() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) RewardPerTokenStored() (*big.Int, error) {
+	return _BunkerStaking.Contract.RewardPerTokenStored(&_BunkerStaking.CallOpts)
+}
+
+// RewardPerTokenStored is a free data retrieval call binding the contract method 0xdf136d65.
+//
+// Solidity: function rewardPerTokenStored() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) RewardPerTokenStored() (*big.Int, error) {
+	return _BunkerStaking.Contract.RewardPerTokenStored(&_BunkerStaking.CallOpts)
+}
+
+// RewardRate is a free data retrieval call binding the contract method 0x7b0a47ee.
+//
+// Solidity: function rewardRate() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) RewardRate(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "rewardRate")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// RewardRate is a free data retrieval call binding the contract method 0x7b0a47ee.
+//
+// Solidity: function rewardRate() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) RewardRate() (*big.Int, error) {
+	return _BunkerStaking.Contract.RewardRate(&_BunkerStaking.CallOpts)
+}
+
+// RewardRate is a free data retrieval call binding the contract method 0x7b0a47ee.
+//
+// Solidity: function rewardRate() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) RewardRate() (*big.Int, error) {
+	return _BunkerStaking.Contract.RewardRate(&_BunkerStaking.CallOpts)
+}
+
+// Rewards is a free data retrieval call binding the contract method 0x0700037d.
+//
+// Solidity: function rewards(address ) view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) Rewards(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "rewards", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Rewards is a free data retrieval call binding the contract method 0x0700037d.
+//
+// Solidity: function rewards(address ) view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) Rewards(arg0 common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.Rewards(&_BunkerStaking.CallOpts, arg0)
+}
+
+// Rewards is a free data retrieval call binding the contract method 0x0700037d.
+//
+// Solidity: function rewards(address ) view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) Rewards(arg0 common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.Rewards(&_BunkerStaking.CallOpts, arg0)
+}
+
+// RewardsDuration is a free data retrieval call binding the contract method 0x386a9525.
+//
+// Solidity: function rewardsDuration() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) RewardsDuration(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "rewardsDuration")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// RewardsDuration is a free data retrieval call binding the contract method 0x386a9525.
+//
+// Solidity: function rewardsDuration() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) RewardsDuration() (*big.Int, error) {
+	return _BunkerStaking.Contract.RewardsDuration(&_BunkerStaking.CallOpts)
+}
+
+// RewardsDuration is a free data retrieval call binding the contract method 0x386a9525.
+//
+// Solidity: function rewardsDuration() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) RewardsDuration() (*big.Int, error) {
+	return _BunkerStaking.Contract.RewardsDuration(&_BunkerStaking.CallOpts)
+}
+
+// RewardsToken is a free data retrieval call binding the contract method 0xd1af0c7d.
+//
+// Solidity: function rewardsToken() view returns(address)
+func (_BunkerStaking *BunkerStakingCaller) RewardsToken(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "rewardsToken")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// RewardsToken is a free data retrieval call binding the contract method 0xd1af0c7d.
+//
+// Solidity: function rewardsToken() view returns(address)
+func (_BunkerStaking *BunkerStakingSession) RewardsToken() (common.Address, error) {
+	return _BunkerStaking.Contract.RewardsToken(&_BunkerStaking.CallOpts)
+}
+
+// RewardsToken is a free data retrieval call binding the contract method 0xd1af0c7d.
+//
+// Solidity: function rewardsToken() view returns(address)
+func (_BunkerStaking *BunkerStakingCallerSession) RewardsToken() (common.Address, error) {
+	return _BunkerStaking.Contract.RewardsToken(&_BunkerStaking.CallOpts)
+}
+
+// SlashBurnBps is a free data retrieval call binding the contract method 0x4a928939.
+//
+// Solidity: function slashBurnBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) SlashBurnBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "slashBurnBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SlashBurnBps is a free data retrieval call binding the contract method 0x4a928939.
+//
+// Solidity: function slashBurnBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) SlashBurnBps() (*big.Int, error) {
+	return _BunkerStaking.Contract.SlashBurnBps(&_BunkerStaking.CallOpts)
+}
+
+// SlashBurnBps is a free data retrieval call binding the contract method 0x4a928939.
+//
+// Solidity: function slashBurnBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) SlashBurnBps() (*big.Int, error) {
+	return _BunkerStaking.Contract.SlashBurnBps(&_BunkerStaking.CallOpts)
+}
+
+// SlashPercentageBps is a free data retrieval call binding the contract method 0xab53fb0b.
+//
+// Solidity: function slashPercentageBps(uint8 ) view returns(uint16)
+func (_BunkerStaking *BunkerStakingCaller) SlashPercentageBps(opts *bind.CallOpts, arg0 uint8) (uint16, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "slashPercentageBps", arg0)
+
+	if err != nil {
+		return *new(uint16), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint16)).(*uint16)
+
+	return out0, err
+
+}
+
+// SlashPercentageBps is a free data retrieval call binding the contract method 0xab53fb0b.
+//
+// Solidity: function slashPercentageBps(uint8 ) view returns(uint16)
+func (_BunkerStaking *BunkerStakingSession) SlashPercentageBps(arg0 uint8) (uint16, error) {
+	return _BunkerStaking.Contract.SlashPercentageBps(&_BunkerStaking.CallOpts, arg0)
+}
+
+// SlashPercentageBps is a free data retrieval call binding the contract method 0xab53fb0b.
+//
+// Solidity: function slashPercentageBps(uint8 ) view returns(uint16)
+func (_BunkerStaking *BunkerStakingCallerSession) SlashPercentageBps(arg0 uint8) (uint16, error) {
+	return _BunkerStaking.Contract.SlashPercentageBps(&_BunkerStaking.CallOpts, arg0)
+}
+
+// SlashProposalCount is a free data retrieval call binding the contract method 0x95bcbe6f.
+//
+// Solidity: function slashProposalCount() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) SlashProposalCount(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "slashProposalCount")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SlashProposalCount is a free data retrieval call binding the contract method 0x95bcbe6f.
+//
+// Solidity: function slashProposalCount() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) SlashProposalCount() (*big.Int, error) {
+	return _BunkerStaking.Contract.SlashProposalCount(&_BunkerStaking.CallOpts)
+}
+
+// SlashProposalCount is a free data retrieval call binding the contract method 0x95bcbe6f.
+//
+// Solidity: function slashProposalCount() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) SlashProposalCount() (*big.Int, error) {
+	return _BunkerStaking.Contract.SlashProposalCount(&_BunkerStaking.CallOpts)
+}
+
+// SlashProposals is a free data retrieval call binding the contract method 0xe7666dba.
+//
+// Solidity: function slashProposals(uint256 ) view returns(address provider, uint256 amount, string reason, uint256 proposedAt, bool executed, bool appealed, bool resolved, uint8 slashReason, uint256 appealWindowSnapshot, uint16 slashBurnBpsSnapshot)
+func (_BunkerStaking *BunkerStakingCaller) SlashProposals(opts *bind.CallOpts, arg0 *big.Int) (struct {
+	Provider             common.Address
+	Amount               *big.Int
+	Reason               string
+	ProposedAt           *big.Int
+	Executed             bool
+	Appealed             bool
+	Resolved             bool
+	SlashReason          uint8
+	AppealWindowSnapshot *big.Int
+	SlashBurnBpsSnapshot uint16
+}, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "slashProposals", arg0)
+
+	outstruct := new(struct {
+		Provider             common.Address
+		Amount               *big.Int
+		Reason               string
+		ProposedAt           *big.Int
+		Executed             bool
+		Appealed             bool
+		Resolved             bool
+		SlashReason          uint8
+		AppealWindowSnapshot *big.Int
+		SlashBurnBpsSnapshot uint16
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Provider = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.Amount = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.Reason = *abi.ConvertType(out[2], new(string)).(*string)
+	outstruct.ProposedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.Executed = *abi.ConvertType(out[4], new(bool)).(*bool)
+	outstruct.Appealed = *abi.ConvertType(out[5], new(bool)).(*bool)
+	outstruct.Resolved = *abi.ConvertType(out[6], new(bool)).(*bool)
+	outstruct.SlashReason = *abi.ConvertType(out[7], new(uint8)).(*uint8)
+	outstruct.AppealWindowSnapshot = *abi.ConvertType(out[8], new(*big.Int)).(**big.Int)
+	outstruct.SlashBurnBpsSnapshot = *abi.ConvertType(out[9], new(uint16)).(*uint16)
+
+	return *outstruct, err
+
+}
+
+// SlashProposals is a free data retrieval call binding the contract method 0xe7666dba.
+//
+// Solidity: function slashProposals(uint256 ) view returns(address provider, uint256 amount, string reason, uint256 proposedAt, bool executed, bool appealed, bool resolved, uint8 slashReason, uint256 appealWindowSnapshot, uint16 slashBurnBpsSnapshot)
+func (_BunkerStaking *BunkerStakingSession) SlashProposals(arg0 *big.Int) (struct {
+	Provider             common.Address
+	Amount               *big.Int
+	Reason               string
+	ProposedAt           *big.Int
+	Executed             bool
+	Appealed             bool
+	Resolved             bool
+	SlashReason          uint8
+	AppealWindowSnapshot *big.Int
+	SlashBurnBpsSnapshot uint16
+}, error) {
+	return _BunkerStaking.Contract.SlashProposals(&_BunkerStaking.CallOpts, arg0)
+}
+
+// SlashProposals is a free data retrieval call binding the contract method 0xe7666dba.
+//
+// Solidity: function slashProposals(uint256 ) view returns(address provider, uint256 amount, string reason, uint256 proposedAt, bool executed, bool appealed, bool resolved, uint8 slashReason, uint256 appealWindowSnapshot, uint16 slashBurnBpsSnapshot)
+func (_BunkerStaking *BunkerStakingCallerSession) SlashProposals(arg0 *big.Int) (struct {
+	Provider             common.Address
+	Amount               *big.Int
+	Reason               string
+	ProposedAt           *big.Int
+	Executed             bool
+	Appealed             bool
+	Resolved             bool
+	SlashReason          uint8
+	AppealWindowSnapshot *big.Int
+	SlashBurnBpsSnapshot uint16
+}, error) {
+	return _BunkerStaking.Contract.SlashProposals(&_BunkerStaking.CallOpts, arg0)
+}
+
+// SlashTreasuryBps is a free data retrieval call binding the contract method 0x246c7e09.
+//
+// Solidity: function slashTreasuryBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) SlashTreasuryBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "slashTreasuryBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SlashTreasuryBps is a free data retrieval call binding the contract method 0x246c7e09.
+//
+// Solidity: function slashTreasuryBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) SlashTreasuryBps() (*big.Int, error) {
+	return _BunkerStaking.Contract.SlashTreasuryBps(&_BunkerStaking.CallOpts)
+}
+
+// SlashTreasuryBps is a free data retrieval call binding the contract method 0x246c7e09.
+//
+// Solidity: function slashTreasuryBps() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) SlashTreasuryBps() (*big.Int, error) {
+	return _BunkerStaking.Contract.SlashTreasuryBps(&_BunkerStaking.CallOpts)
+}
+
+// SlashingEnabled is a free data retrieval call binding the contract method 0x321ba6fd.
+//
+// Solidity: function slashingEnabled() view returns(bool)
+func (_BunkerStaking *BunkerStakingCaller) SlashingEnabled(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "slashingEnabled")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SlashingEnabled is a free data retrieval call binding the contract method 0x321ba6fd.
+//
+// Solidity: function slashingEnabled() view returns(bool)
+func (_BunkerStaking *BunkerStakingSession) SlashingEnabled() (bool, error) {
+	return _BunkerStaking.Contract.SlashingEnabled(&_BunkerStaking.CallOpts)
+}
+
+// SlashingEnabled is a free data retrieval call binding the contract method 0x321ba6fd.
+//
+// Solidity: function slashingEnabled() view returns(bool)
+func (_BunkerStaking *BunkerStakingCallerSession) SlashingEnabled() (bool, error) {
+	return _BunkerStaking.Contract.SlashingEnabled(&_BunkerStaking.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerStaking *BunkerStakingCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerStaking *BunkerStakingSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BunkerStaking.Contract.SupportsInterface(&_BunkerStaking.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerStaking *BunkerStakingCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BunkerStaking.Contract.SupportsInterface(&_BunkerStaking.CallOpts, interfaceId)
+}
+
+// TierConfigs is a free data retrieval call binding the contract method 0x9da9db2a.
+//
+// Solidity: function tierConfigs(uint8 ) view returns(uint256 minStake, uint16 maxConcurrentJobs, uint16 rewardMultiplierBps, bool priorityQueue, bool governance)
+func (_BunkerStaking *BunkerStakingCaller) TierConfigs(opts *bind.CallOpts, arg0 uint8) (struct {
+	MinStake            *big.Int
+	MaxConcurrentJobs   uint16
+	RewardMultiplierBps uint16
+	PriorityQueue       bool
+	Governance          bool
+}, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "tierConfigs", arg0)
+
+	outstruct := new(struct {
+		MinStake            *big.Int
+		MaxConcurrentJobs   uint16
+		RewardMultiplierBps uint16
+		PriorityQueue       bool
+		Governance          bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.MinStake = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.MaxConcurrentJobs = *abi.ConvertType(out[1], new(uint16)).(*uint16)
+	outstruct.RewardMultiplierBps = *abi.ConvertType(out[2], new(uint16)).(*uint16)
+	outstruct.PriorityQueue = *abi.ConvertType(out[3], new(bool)).(*bool)
+	outstruct.Governance = *abi.ConvertType(out[4], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// TierConfigs is a free data retrieval call binding the contract method 0x9da9db2a.
+//
+// Solidity: function tierConfigs(uint8 ) view returns(uint256 minStake, uint16 maxConcurrentJobs, uint16 rewardMultiplierBps, bool priorityQueue, bool governance)
+func (_BunkerStaking *BunkerStakingSession) TierConfigs(arg0 uint8) (struct {
+	MinStake            *big.Int
+	MaxConcurrentJobs   uint16
+	RewardMultiplierBps uint16
+	PriorityQueue       bool
+	Governance          bool
+}, error) {
+	return _BunkerStaking.Contract.TierConfigs(&_BunkerStaking.CallOpts, arg0)
+}
+
+// TierConfigs is a free data retrieval call binding the contract method 0x9da9db2a.
+//
+// Solidity: function tierConfigs(uint8 ) view returns(uint256 minStake, uint16 maxConcurrentJobs, uint16 rewardMultiplierBps, bool priorityQueue, bool governance)
+func (_BunkerStaking *BunkerStakingCallerSession) TierConfigs(arg0 uint8) (struct {
+	MinStake            *big.Int
+	MaxConcurrentJobs   uint16
+	RewardMultiplierBps uint16
+	PriorityQueue       bool
+	Governance          bool
+}, error) {
+	return _BunkerStaking.Contract.TierConfigs(&_BunkerStaking.CallOpts, arg0)
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerStaking *BunkerStakingCaller) Token(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "token")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerStaking *BunkerStakingSession) Token() (common.Address, error) {
+	return _BunkerStaking.Contract.Token(&_BunkerStaking.CallOpts)
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_BunkerStaking *BunkerStakingCallerSession) Token() (common.Address, error) {
+	return _BunkerStaking.Contract.Token(&_BunkerStaking.CallOpts)
+}
+
+// TotalComputeHoursReported is a free data retrieval call binding the contract method 0xd424b7c3.
+//
+// Solidity: function totalComputeHoursReported() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) TotalComputeHoursReported(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "totalComputeHoursReported")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalComputeHoursReported is a free data retrieval call binding the contract method 0xd424b7c3.
+//
+// Solidity: function totalComputeHoursReported() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) TotalComputeHoursReported() (*big.Int, error) {
+	return _BunkerStaking.Contract.TotalComputeHoursReported(&_BunkerStaking.CallOpts)
+}
+
+// TotalComputeHoursReported is a free data retrieval call binding the contract method 0xd424b7c3.
+//
+// Solidity: function totalComputeHoursReported() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) TotalComputeHoursReported() (*big.Int, error) {
+	return _BunkerStaking.Contract.TotalComputeHoursReported(&_BunkerStaking.CallOpts)
+}
+
+// TotalStaked is a free data retrieval call binding the contract method 0x817b1cd2.
+//
+// Solidity: function totalStaked() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) TotalStaked(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "totalStaked")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalStaked is a free data retrieval call binding the contract method 0x817b1cd2.
+//
+// Solidity: function totalStaked() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) TotalStaked() (*big.Int, error) {
+	return _BunkerStaking.Contract.TotalStaked(&_BunkerStaking.CallOpts)
+}
+
+// TotalStaked is a free data retrieval call binding the contract method 0x817b1cd2.
+//
+// Solidity: function totalStaked() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) TotalStaked() (*big.Int, error) {
+	return _BunkerStaking.Contract.TotalStaked(&_BunkerStaking.CallOpts)
+}
+
+// TotalUnbonding is a free data retrieval call binding the contract method 0x350fd0be.
+//
+// Solidity: function totalUnbonding() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) TotalUnbonding(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "totalUnbonding")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalUnbonding is a free data retrieval call binding the contract method 0x350fd0be.
+//
+// Solidity: function totalUnbonding() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) TotalUnbonding() (*big.Int, error) {
+	return _BunkerStaking.Contract.TotalUnbonding(&_BunkerStaking.CallOpts)
+}
+
+// TotalUnbonding is a free data retrieval call binding the contract method 0x350fd0be.
+//
+// Solidity: function totalUnbonding() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) TotalUnbonding() (*big.Int, error) {
+	return _BunkerStaking.Contract.TotalUnbonding(&_BunkerStaking.CallOpts)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerStaking *BunkerStakingCaller) Treasury(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "treasury")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerStaking *BunkerStakingSession) Treasury() (common.Address, error) {
+	return _BunkerStaking.Contract.Treasury(&_BunkerStaking.CallOpts)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_BunkerStaking *BunkerStakingCallerSession) Treasury() (common.Address, error) {
+	return _BunkerStaking.Contract.Treasury(&_BunkerStaking.CallOpts)
+}
+
+// UnbondingPeriod is a free data retrieval call binding the contract method 0x6cf6d675.
+//
+// Solidity: function unbondingPeriod() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) UnbondingPeriod(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "unbondingPeriod")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// UnbondingPeriod is a free data retrieval call binding the contract method 0x6cf6d675.
+//
+// Solidity: function unbondingPeriod() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) UnbondingPeriod() (*big.Int, error) {
+	return _BunkerStaking.Contract.UnbondingPeriod(&_BunkerStaking.CallOpts)
+}
+
+// UnbondingPeriod is a free data retrieval call binding the contract method 0x6cf6d675.
+//
+// Solidity: function unbondingPeriod() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) UnbondingPeriod() (*big.Int, error) {
+	return _BunkerStaking.Contract.UnbondingPeriod(&_BunkerStaking.CallOpts)
+}
+
+// UnstakeQueues is a free data retrieval call binding the contract method 0xf0023200.
+//
+// Solidity: function unstakeQueues(address , uint256 ) view returns(uint128 amount, uint48 unlockTime, bool completed)
+func (_BunkerStaking *BunkerStakingCaller) UnstakeQueues(opts *bind.CallOpts, arg0 common.Address, arg1 *big.Int) (struct {
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Completed  bool
+}, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "unstakeQueues", arg0, arg1)
+
+	outstruct := new(struct {
+		Amount     *big.Int
+		UnlockTime *big.Int
+		Completed  bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Amount = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.UnlockTime = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.Completed = *abi.ConvertType(out[2], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// UnstakeQueues is a free data retrieval call binding the contract method 0xf0023200.
+//
+// Solidity: function unstakeQueues(address , uint256 ) view returns(uint128 amount, uint48 unlockTime, bool completed)
+func (_BunkerStaking *BunkerStakingSession) UnstakeQueues(arg0 common.Address, arg1 *big.Int) (struct {
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Completed  bool
+}, error) {
+	return _BunkerStaking.Contract.UnstakeQueues(&_BunkerStaking.CallOpts, arg0, arg1)
+}
+
+// UnstakeQueues is a free data retrieval call binding the contract method 0xf0023200.
+//
+// Solidity: function unstakeQueues(address , uint256 ) view returns(uint128 amount, uint48 unlockTime, bool completed)
+func (_BunkerStaking *BunkerStakingCallerSession) UnstakeQueues(arg0 common.Address, arg1 *big.Int) (struct {
+	Amount     *big.Int
+	UnlockTime *big.Int
+	Completed  bool
+}, error) {
+	return _BunkerStaking.Contract.UnstakeQueues(&_BunkerStaking.CallOpts, arg0, arg1)
+}
+
+// UserRewardPerTokenPaid is a free data retrieval call binding the contract method 0x8b876347.
+//
+// Solidity: function userRewardPerTokenPaid(address ) view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) UserRewardPerTokenPaid(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "userRewardPerTokenPaid", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// UserRewardPerTokenPaid is a free data retrieval call binding the contract method 0x8b876347.
+//
+// Solidity: function userRewardPerTokenPaid(address ) view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) UserRewardPerTokenPaid(arg0 common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.UserRewardPerTokenPaid(&_BunkerStaking.CallOpts, arg0)
+}
+
+// UserRewardPerTokenPaid is a free data retrieval call binding the contract method 0x8b876347.
+//
+// Solidity: function userRewardPerTokenPaid(address ) view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) UserRewardPerTokenPaid(arg0 common.Address) (*big.Int, error) {
+	return _BunkerStaking.Contract.UserRewardPerTokenPaid(&_BunkerStaking.CallOpts, arg0)
+}
+
+// VestedRewards is a free data retrieval call binding the contract method 0xfcab880f.
+//
+// Solidity: function vestedRewards(address , uint256 ) view returns(uint128 totalAmount, uint128 releasedAmount, uint48 vestingStart)
+func (_BunkerStaking *BunkerStakingCaller) VestedRewards(opts *bind.CallOpts, arg0 common.Address, arg1 *big.Int) (struct {
+	TotalAmount    *big.Int
+	ReleasedAmount *big.Int
+	VestingStart   *big.Int
+}, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "vestedRewards", arg0, arg1)
+
+	outstruct := new(struct {
+		TotalAmount    *big.Int
+		ReleasedAmount *big.Int
+		VestingStart   *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.TotalAmount = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.ReleasedAmount = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.VestingStart = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// VestedRewards is a free data retrieval call binding the contract method 0xfcab880f.
+//
+// Solidity: function vestedRewards(address , uint256 ) view returns(uint128 totalAmount, uint128 releasedAmount, uint48 vestingStart)
+func (_BunkerStaking *BunkerStakingSession) VestedRewards(arg0 common.Address, arg1 *big.Int) (struct {
+	TotalAmount    *big.Int
+	ReleasedAmount *big.Int
+	VestingStart   *big.Int
+}, error) {
+	return _BunkerStaking.Contract.VestedRewards(&_BunkerStaking.CallOpts, arg0, arg1)
+}
+
+// VestedRewards is a free data retrieval call binding the contract method 0xfcab880f.
+//
+// Solidity: function vestedRewards(address , uint256 ) view returns(uint128 totalAmount, uint128 releasedAmount, uint48 vestingStart)
+func (_BunkerStaking *BunkerStakingCallerSession) VestedRewards(arg0 common.Address, arg1 *big.Int) (struct {
+	TotalAmount    *big.Int
+	ReleasedAmount *big.Int
+	VestingStart   *big.Int
+}, error) {
+	return _BunkerStaking.Contract.VestedRewards(&_BunkerStaking.CallOpts, arg0, arg1)
+}
+
+// VestingPeriod is a free data retrieval call binding the contract method 0x7313ee5a.
+//
+// Solidity: function vestingPeriod() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCaller) VestingPeriod(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerStaking.contract.Call(opts, &out, "vestingPeriod")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// VestingPeriod is a free data retrieval call binding the contract method 0x7313ee5a.
+//
+// Solidity: function vestingPeriod() view returns(uint256)
+func (_BunkerStaking *BunkerStakingSession) VestingPeriod() (*big.Int, error) {
+	return _BunkerStaking.Contract.VestingPeriod(&_BunkerStaking.CallOpts)
+}
+
+// VestingPeriod is a free data retrieval call binding the contract method 0x7313ee5a.
+//
+// Solidity: function vestingPeriod() view returns(uint256)
+func (_BunkerStaking *BunkerStakingCallerSession) VestingPeriod() (*big.Int, error) {
+	return _BunkerStaking.Contract.VestingPeriod(&_BunkerStaking.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerStaking *BunkerStakingTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerStaking *BunkerStakingSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.AcceptOwnership(&_BunkerStaking.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.AcceptOwnership(&_BunkerStaking.TransactOpts)
+}
+
+// AppealSlash is a paid mutator transaction binding the contract method 0x949a218d.
+//
+// Solidity: function appealSlash(uint256 proposalId) returns()
+func (_BunkerStaking *BunkerStakingTransactor) AppealSlash(opts *bind.TransactOpts, proposalId *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "appealSlash", proposalId)
+}
+
+// AppealSlash is a paid mutator transaction binding the contract method 0x949a218d.
+//
+// Solidity: function appealSlash(uint256 proposalId) returns()
+func (_BunkerStaking *BunkerStakingSession) AppealSlash(proposalId *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.AppealSlash(&_BunkerStaking.TransactOpts, proposalId)
+}
+
+// AppealSlash is a paid mutator transaction binding the contract method 0x949a218d.
+//
+// Solidity: function appealSlash(uint256 proposalId) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) AppealSlash(proposalId *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.AppealSlash(&_BunkerStaking.TransactOpts, proposalId)
+}
+
+// ClaimRewards is a paid mutator transaction binding the contract method 0x372500ab.
+//
+// Solidity: function claimRewards() returns()
+func (_BunkerStaking *BunkerStakingTransactor) ClaimRewards(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "claimRewards")
+}
+
+// ClaimRewards is a paid mutator transaction binding the contract method 0x372500ab.
+//
+// Solidity: function claimRewards() returns()
+func (_BunkerStaking *BunkerStakingSession) ClaimRewards() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ClaimRewards(&_BunkerStaking.TransactOpts)
+}
+
+// ClaimRewards is a paid mutator transaction binding the contract method 0x372500ab.
+//
+// Solidity: function claimRewards() returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) ClaimRewards() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ClaimRewards(&_BunkerStaking.TransactOpts)
+}
+
+// ClaimVestedRewards is a paid mutator transaction binding the contract method 0xadb50861.
+//
+// Solidity: function claimVestedRewards() returns()
+func (_BunkerStaking *BunkerStakingTransactor) ClaimVestedRewards(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "claimVestedRewards")
+}
+
+// ClaimVestedRewards is a paid mutator transaction binding the contract method 0xadb50861.
+//
+// Solidity: function claimVestedRewards() returns()
+func (_BunkerStaking *BunkerStakingSession) ClaimVestedRewards() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ClaimVestedRewards(&_BunkerStaking.TransactOpts)
+}
+
+// ClaimVestedRewards is a paid mutator transaction binding the contract method 0xadb50861.
+//
+// Solidity: function claimVestedRewards() returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) ClaimVestedRewards() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ClaimVestedRewards(&_BunkerStaking.TransactOpts)
+}
+
+// CompleteUnstake is a paid mutator transaction binding the contract method 0x552b54ec.
+//
+// Solidity: function completeUnstake(uint256 requestIndex) returns()
+func (_BunkerStaking *BunkerStakingTransactor) CompleteUnstake(opts *bind.TransactOpts, requestIndex *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "completeUnstake", requestIndex)
+}
+
+// CompleteUnstake is a paid mutator transaction binding the contract method 0x552b54ec.
+//
+// Solidity: function completeUnstake(uint256 requestIndex) returns()
+func (_BunkerStaking *BunkerStakingSession) CompleteUnstake(requestIndex *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.CompleteUnstake(&_BunkerStaking.TransactOpts, requestIndex)
+}
+
+// CompleteUnstake is a paid mutator transaction binding the contract method 0x552b54ec.
+//
+// Solidity: function completeUnstake(uint256 requestIndex) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) CompleteUnstake(requestIndex *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.CompleteUnstake(&_BunkerStaking.TransactOpts, requestIndex)
+}
+
+// ExecuteBeneficiaryChange is a paid mutator transaction binding the contract method 0x78cc30ee.
+//
+// Solidity: function executeBeneficiaryChange() returns()
+func (_BunkerStaking *BunkerStakingTransactor) ExecuteBeneficiaryChange(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "executeBeneficiaryChange")
+}
+
+// ExecuteBeneficiaryChange is a paid mutator transaction binding the contract method 0x78cc30ee.
+//
+// Solidity: function executeBeneficiaryChange() returns()
+func (_BunkerStaking *BunkerStakingSession) ExecuteBeneficiaryChange() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ExecuteBeneficiaryChange(&_BunkerStaking.TransactOpts)
+}
+
+// ExecuteBeneficiaryChange is a paid mutator transaction binding the contract method 0x78cc30ee.
+//
+// Solidity: function executeBeneficiaryChange() returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) ExecuteBeneficiaryChange() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ExecuteBeneficiaryChange(&_BunkerStaking.TransactOpts)
+}
+
+// ExecuteSlash is a paid mutator transaction binding the contract method 0x69ae9af8.
+//
+// Solidity: function executeSlash(uint256 proposalId) returns()
+func (_BunkerStaking *BunkerStakingTransactor) ExecuteSlash(opts *bind.TransactOpts, proposalId *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "executeSlash", proposalId)
+}
+
+// ExecuteSlash is a paid mutator transaction binding the contract method 0x69ae9af8.
+//
+// Solidity: function executeSlash(uint256 proposalId) returns()
+func (_BunkerStaking *BunkerStakingSession) ExecuteSlash(proposalId *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ExecuteSlash(&_BunkerStaking.TransactOpts, proposalId)
+}
+
+// ExecuteSlash is a paid mutator transaction binding the contract method 0x69ae9af8.
+//
+// Solidity: function executeSlash(uint256 proposalId) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) ExecuteSlash(proposalId *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ExecuteSlash(&_BunkerStaking.TransactOpts, proposalId)
+}
+
+// FreezeProvider is a paid mutator transaction binding the contract method 0x9980a9e8.
+//
+// Solidity: function freezeProvider(address provider) returns()
+func (_BunkerStaking *BunkerStakingTransactor) FreezeProvider(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "freezeProvider", provider)
+}
+
+// FreezeProvider is a paid mutator transaction binding the contract method 0x9980a9e8.
+//
+// Solidity: function freezeProvider(address provider) returns()
+func (_BunkerStaking *BunkerStakingSession) FreezeProvider(provider common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.FreezeProvider(&_BunkerStaking.TransactOpts, provider)
+}
+
+// FreezeProvider is a paid mutator transaction binding the contract method 0x9980a9e8.
+//
+// Solidity: function freezeProvider(address provider) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) FreezeProvider(provider common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.FreezeProvider(&_BunkerStaking.TransactOpts, provider)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerStaking *BunkerStakingTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerStaking *BunkerStakingSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.GrantRole(&_BunkerStaking.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.GrantRole(&_BunkerStaking.TransactOpts, role, account)
+}
+
+// InitiateBeneficiaryChange is a paid mutator transaction binding the contract method 0x32a10dfd.
+//
+// Solidity: function initiateBeneficiaryChange(address newBeneficiary) returns()
+func (_BunkerStaking *BunkerStakingTransactor) InitiateBeneficiaryChange(opts *bind.TransactOpts, newBeneficiary common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "initiateBeneficiaryChange", newBeneficiary)
+}
+
+// InitiateBeneficiaryChange is a paid mutator transaction binding the contract method 0x32a10dfd.
+//
+// Solidity: function initiateBeneficiaryChange(address newBeneficiary) returns()
+func (_BunkerStaking *BunkerStakingSession) InitiateBeneficiaryChange(newBeneficiary common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.InitiateBeneficiaryChange(&_BunkerStaking.TransactOpts, newBeneficiary)
+}
+
+// InitiateBeneficiaryChange is a paid mutator transaction binding the contract method 0x32a10dfd.
+//
+// Solidity: function initiateBeneficiaryChange(address newBeneficiary) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) InitiateBeneficiaryChange(newBeneficiary common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.InitiateBeneficiaryChange(&_BunkerStaking.TransactOpts, newBeneficiary)
+}
+
+// NotifyRewardAmount is a paid mutator transaction binding the contract method 0x3c6b16ab.
+//
+// Solidity: function notifyRewardAmount(uint256 reward) returns()
+func (_BunkerStaking *BunkerStakingTransactor) NotifyRewardAmount(opts *bind.TransactOpts, reward *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "notifyRewardAmount", reward)
+}
+
+// NotifyRewardAmount is a paid mutator transaction binding the contract method 0x3c6b16ab.
+//
+// Solidity: function notifyRewardAmount(uint256 reward) returns()
+func (_BunkerStaking *BunkerStakingSession) NotifyRewardAmount(reward *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.NotifyRewardAmount(&_BunkerStaking.TransactOpts, reward)
+}
+
+// NotifyRewardAmount is a paid mutator transaction binding the contract method 0x3c6b16ab.
+//
+// Solidity: function notifyRewardAmount(uint256 reward) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) NotifyRewardAmount(reward *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.NotifyRewardAmount(&_BunkerStaking.TransactOpts, reward)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerStaking *BunkerStakingTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerStaking *BunkerStakingSession) Pause() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.Pause(&_BunkerStaking.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) Pause() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.Pause(&_BunkerStaking.TransactOpts)
+}
+
+// ProposeSlash is a paid mutator transaction binding the contract method 0xa7c23fec.
+//
+// Solidity: function proposeSlash(address provider, uint256 amount, string reason) returns(uint256 proposalId)
+func (_BunkerStaking *BunkerStakingTransactor) ProposeSlash(opts *bind.TransactOpts, provider common.Address, amount *big.Int, reason string) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "proposeSlash", provider, amount, reason)
+}
+
+// ProposeSlash is a paid mutator transaction binding the contract method 0xa7c23fec.
+//
+// Solidity: function proposeSlash(address provider, uint256 amount, string reason) returns(uint256 proposalId)
+func (_BunkerStaking *BunkerStakingSession) ProposeSlash(provider common.Address, amount *big.Int, reason string) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ProposeSlash(&_BunkerStaking.TransactOpts, provider, amount, reason)
+}
+
+// ProposeSlash is a paid mutator transaction binding the contract method 0xa7c23fec.
+//
+// Solidity: function proposeSlash(address provider, uint256 amount, string reason) returns(uint256 proposalId)
+func (_BunkerStaking *BunkerStakingTransactorSession) ProposeSlash(provider common.Address, amount *big.Int, reason string) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ProposeSlash(&_BunkerStaking.TransactOpts, provider, amount, reason)
+}
+
+// ProposeSlashByReason is a paid mutator transaction binding the contract method 0x340178f2.
+//
+// Solidity: function proposeSlashByReason(address provider, uint8 reason) returns(uint256 proposalId)
+func (_BunkerStaking *BunkerStakingTransactor) ProposeSlashByReason(opts *bind.TransactOpts, provider common.Address, reason uint8) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "proposeSlashByReason", provider, reason)
+}
+
+// ProposeSlashByReason is a paid mutator transaction binding the contract method 0x340178f2.
+//
+// Solidity: function proposeSlashByReason(address provider, uint8 reason) returns(uint256 proposalId)
+func (_BunkerStaking *BunkerStakingSession) ProposeSlashByReason(provider common.Address, reason uint8) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ProposeSlashByReason(&_BunkerStaking.TransactOpts, provider, reason)
+}
+
+// ProposeSlashByReason is a paid mutator transaction binding the contract method 0x340178f2.
+//
+// Solidity: function proposeSlashByReason(address provider, uint8 reason) returns(uint256 proposalId)
+func (_BunkerStaking *BunkerStakingTransactorSession) ProposeSlashByReason(provider common.Address, reason uint8) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ProposeSlashByReason(&_BunkerStaking.TransactOpts, provider, reason)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerStaking *BunkerStakingTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerStaking *BunkerStakingSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.RenounceOwnership(&_BunkerStaking.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.RenounceOwnership(&_BunkerStaking.TransactOpts)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerStaking *BunkerStakingTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerStaking *BunkerStakingSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.RenounceRole(&_BunkerStaking.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.RenounceRole(&_BunkerStaking.TransactOpts, role, callerConfirmation)
+}
+
+// ReportComputeHours is a paid mutator transaction binding the contract method 0xd85bc13f.
+//
+// Solidity: function reportComputeHours(uint256 hours_) returns()
+func (_BunkerStaking *BunkerStakingTransactor) ReportComputeHours(opts *bind.TransactOpts, hours_ *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "reportComputeHours", hours_)
+}
+
+// ReportComputeHours is a paid mutator transaction binding the contract method 0xd85bc13f.
+//
+// Solidity: function reportComputeHours(uint256 hours_) returns()
+func (_BunkerStaking *BunkerStakingSession) ReportComputeHours(hours_ *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ReportComputeHours(&_BunkerStaking.TransactOpts, hours_)
+}
+
+// ReportComputeHours is a paid mutator transaction binding the contract method 0xd85bc13f.
+//
+// Solidity: function reportComputeHours(uint256 hours_) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) ReportComputeHours(hours_ *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ReportComputeHours(&_BunkerStaking.TransactOpts, hours_)
+}
+
+// RequestUnstake is a paid mutator transaction binding the contract method 0x23095721.
+//
+// Solidity: function requestUnstake(uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingTransactor) RequestUnstake(opts *bind.TransactOpts, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "requestUnstake", amount)
+}
+
+// RequestUnstake is a paid mutator transaction binding the contract method 0x23095721.
+//
+// Solidity: function requestUnstake(uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingSession) RequestUnstake(amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.RequestUnstake(&_BunkerStaking.TransactOpts, amount)
+}
+
+// RequestUnstake is a paid mutator transaction binding the contract method 0x23095721.
+//
+// Solidity: function requestUnstake(uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) RequestUnstake(amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.RequestUnstake(&_BunkerStaking.TransactOpts, amount)
+}
+
+// ResolveAppeal is a paid mutator transaction binding the contract method 0x1c74cf1d.
+//
+// Solidity: function resolveAppeal(uint256 proposalId, bool uphold) returns()
+func (_BunkerStaking *BunkerStakingTransactor) ResolveAppeal(opts *bind.TransactOpts, proposalId *big.Int, uphold bool) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "resolveAppeal", proposalId, uphold)
+}
+
+// ResolveAppeal is a paid mutator transaction binding the contract method 0x1c74cf1d.
+//
+// Solidity: function resolveAppeal(uint256 proposalId, bool uphold) returns()
+func (_BunkerStaking *BunkerStakingSession) ResolveAppeal(proposalId *big.Int, uphold bool) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ResolveAppeal(&_BunkerStaking.TransactOpts, proposalId, uphold)
+}
+
+// ResolveAppeal is a paid mutator transaction binding the contract method 0x1c74cf1d.
+//
+// Solidity: function resolveAppeal(uint256 proposalId, bool uphold) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) ResolveAppeal(proposalId *big.Int, uphold bool) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.ResolveAppeal(&_BunkerStaking.TransactOpts, proposalId, uphold)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerStaking *BunkerStakingTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerStaking *BunkerStakingSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.RevokeRole(&_BunkerStaking.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.RevokeRole(&_BunkerStaking.TransactOpts, role, account)
+}
+
+// SetAppealWindow is a paid mutator transaction binding the contract method 0x031fc067.
+//
+// Solidity: function setAppealWindow(uint256 newWindow) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetAppealWindow(opts *bind.TransactOpts, newWindow *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setAppealWindow", newWindow)
+}
+
+// SetAppealWindow is a paid mutator transaction binding the contract method 0x031fc067.
+//
+// Solidity: function setAppealWindow(uint256 newWindow) returns()
+func (_BunkerStaking *BunkerStakingSession) SetAppealWindow(newWindow *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetAppealWindow(&_BunkerStaking.TransactOpts, newWindow)
+}
+
+// SetAppealWindow is a paid mutator transaction binding the contract method 0x031fc067.
+//
+// Solidity: function setAppealWindow(uint256 newWindow) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetAppealWindow(newWindow *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetAppealWindow(&_BunkerStaking.TransactOpts, newWindow)
+}
+
+// SetEmissionMultiplier is a paid mutator transaction binding the contract method 0x4817cfaa.
+//
+// Solidity: function setEmissionMultiplier(uint256 multiplierBps) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetEmissionMultiplier(opts *bind.TransactOpts, multiplierBps *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setEmissionMultiplier", multiplierBps)
+}
+
+// SetEmissionMultiplier is a paid mutator transaction binding the contract method 0x4817cfaa.
+//
+// Solidity: function setEmissionMultiplier(uint256 multiplierBps) returns()
+func (_BunkerStaking *BunkerStakingSession) SetEmissionMultiplier(multiplierBps *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetEmissionMultiplier(&_BunkerStaking.TransactOpts, multiplierBps)
+}
+
+// SetEmissionMultiplier is a paid mutator transaction binding the contract method 0x4817cfaa.
+//
+// Solidity: function setEmissionMultiplier(uint256 multiplierBps) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetEmissionMultiplier(multiplierBps *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetEmissionMultiplier(&_BunkerStaking.TransactOpts, multiplierBps)
+}
+
+// SetMaxEmissionRate is a paid mutator transaction binding the contract method 0x8c3aeb08.
+//
+// Solidity: function setMaxEmissionRate(uint256 maxRate) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetMaxEmissionRate(opts *bind.TransactOpts, maxRate *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setMaxEmissionRate", maxRate)
+}
+
+// SetMaxEmissionRate is a paid mutator transaction binding the contract method 0x8c3aeb08.
+//
+// Solidity: function setMaxEmissionRate(uint256 maxRate) returns()
+func (_BunkerStaking *BunkerStakingSession) SetMaxEmissionRate(maxRate *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetMaxEmissionRate(&_BunkerStaking.TransactOpts, maxRate)
+}
+
+// SetMaxEmissionRate is a paid mutator transaction binding the contract method 0x8c3aeb08.
+//
+// Solidity: function setMaxEmissionRate(uint256 maxRate) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetMaxEmissionRate(maxRate *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetMaxEmissionRate(&_BunkerStaking.TransactOpts, maxRate)
+}
+
+// SetMaxTierMultiplierBps is a paid mutator transaction binding the contract method 0x0b69caff.
+//
+// Solidity: function setMaxTierMultiplierBps(uint16 newMax) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetMaxTierMultiplierBps(opts *bind.TransactOpts, newMax uint16) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setMaxTierMultiplierBps", newMax)
+}
+
+// SetMaxTierMultiplierBps is a paid mutator transaction binding the contract method 0x0b69caff.
+//
+// Solidity: function setMaxTierMultiplierBps(uint16 newMax) returns()
+func (_BunkerStaking *BunkerStakingSession) SetMaxTierMultiplierBps(newMax uint16) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetMaxTierMultiplierBps(&_BunkerStaking.TransactOpts, newMax)
+}
+
+// SetMaxTierMultiplierBps is a paid mutator transaction binding the contract method 0x0b69caff.
+//
+// Solidity: function setMaxTierMultiplierBps(uint16 newMax) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetMaxTierMultiplierBps(newMax uint16) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetMaxTierMultiplierBps(&_BunkerStaking.TransactOpts, newMax)
+}
+
+// SetRewardsDuration is a paid mutator transaction binding the contract method 0xcc1a378f.
+//
+// Solidity: function setRewardsDuration(uint256 _rewardsDuration) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetRewardsDuration(opts *bind.TransactOpts, _rewardsDuration *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setRewardsDuration", _rewardsDuration)
+}
+
+// SetRewardsDuration is a paid mutator transaction binding the contract method 0xcc1a378f.
+//
+// Solidity: function setRewardsDuration(uint256 _rewardsDuration) returns()
+func (_BunkerStaking *BunkerStakingSession) SetRewardsDuration(_rewardsDuration *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetRewardsDuration(&_BunkerStaking.TransactOpts, _rewardsDuration)
+}
+
+// SetRewardsDuration is a paid mutator transaction binding the contract method 0xcc1a378f.
+//
+// Solidity: function setRewardsDuration(uint256 _rewardsDuration) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetRewardsDuration(_rewardsDuration *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetRewardsDuration(&_BunkerStaking.TransactOpts, _rewardsDuration)
+}
+
+// SetSlashFeeSplit is a paid mutator transaction binding the contract method 0xe6a4347d.
+//
+// Solidity: function setSlashFeeSplit(uint16 burnBps, uint16 treasuryBps) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetSlashFeeSplit(opts *bind.TransactOpts, burnBps uint16, treasuryBps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setSlashFeeSplit", burnBps, treasuryBps)
+}
+
+// SetSlashFeeSplit is a paid mutator transaction binding the contract method 0xe6a4347d.
+//
+// Solidity: function setSlashFeeSplit(uint16 burnBps, uint16 treasuryBps) returns()
+func (_BunkerStaking *BunkerStakingSession) SetSlashFeeSplit(burnBps uint16, treasuryBps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetSlashFeeSplit(&_BunkerStaking.TransactOpts, burnBps, treasuryBps)
+}
+
+// SetSlashFeeSplit is a paid mutator transaction binding the contract method 0xe6a4347d.
+//
+// Solidity: function setSlashFeeSplit(uint16 burnBps, uint16 treasuryBps) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetSlashFeeSplit(burnBps uint16, treasuryBps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetSlashFeeSplit(&_BunkerStaking.TransactOpts, burnBps, treasuryBps)
+}
+
+// SetSlashPercentage is a paid mutator transaction binding the contract method 0xc87a1ec8.
+//
+// Solidity: function setSlashPercentage(uint8 reason, uint16 bps) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetSlashPercentage(opts *bind.TransactOpts, reason uint8, bps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setSlashPercentage", reason, bps)
+}
+
+// SetSlashPercentage is a paid mutator transaction binding the contract method 0xc87a1ec8.
+//
+// Solidity: function setSlashPercentage(uint8 reason, uint16 bps) returns()
+func (_BunkerStaking *BunkerStakingSession) SetSlashPercentage(reason uint8, bps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetSlashPercentage(&_BunkerStaking.TransactOpts, reason, bps)
+}
+
+// SetSlashPercentage is a paid mutator transaction binding the contract method 0xc87a1ec8.
+//
+// Solidity: function setSlashPercentage(uint8 reason, uint16 bps) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetSlashPercentage(reason uint8, bps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetSlashPercentage(&_BunkerStaking.TransactOpts, reason, bps)
+}
+
+// SetSlashingEnabled is a paid mutator transaction binding the contract method 0x3d357473.
+//
+// Solidity: function setSlashingEnabled(bool enabled) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetSlashingEnabled(opts *bind.TransactOpts, enabled bool) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setSlashingEnabled", enabled)
+}
+
+// SetSlashingEnabled is a paid mutator transaction binding the contract method 0x3d357473.
+//
+// Solidity: function setSlashingEnabled(bool enabled) returns()
+func (_BunkerStaking *BunkerStakingSession) SetSlashingEnabled(enabled bool) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetSlashingEnabled(&_BunkerStaking.TransactOpts, enabled)
+}
+
+// SetSlashingEnabled is a paid mutator transaction binding the contract method 0x3d357473.
+//
+// Solidity: function setSlashingEnabled(bool enabled) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetSlashingEnabled(enabled bool) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetSlashingEnabled(&_BunkerStaking.TransactOpts, enabled)
+}
+
+// SetTierMinStake is a paid mutator transaction binding the contract method 0xe5ae2240.
+//
+// Solidity: function setTierMinStake(uint8 tier, uint256 minStake) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetTierMinStake(opts *bind.TransactOpts, tier uint8, minStake *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setTierMinStake", tier, minStake)
+}
+
+// SetTierMinStake is a paid mutator transaction binding the contract method 0xe5ae2240.
+//
+// Solidity: function setTierMinStake(uint8 tier, uint256 minStake) returns()
+func (_BunkerStaking *BunkerStakingSession) SetTierMinStake(tier uint8, minStake *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetTierMinStake(&_BunkerStaking.TransactOpts, tier, minStake)
+}
+
+// SetTierMinStake is a paid mutator transaction binding the contract method 0xe5ae2240.
+//
+// Solidity: function setTierMinStake(uint8 tier, uint256 minStake) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetTierMinStake(tier uint8, minStake *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetTierMinStake(&_BunkerStaking.TransactOpts, tier, minStake)
+}
+
+// SetTierRewardMultiplier is a paid mutator transaction binding the contract method 0x647b65ed.
+//
+// Solidity: function setTierRewardMultiplier(uint8 tier, uint16 multiplierBps) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetTierRewardMultiplier(opts *bind.TransactOpts, tier uint8, multiplierBps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setTierRewardMultiplier", tier, multiplierBps)
+}
+
+// SetTierRewardMultiplier is a paid mutator transaction binding the contract method 0x647b65ed.
+//
+// Solidity: function setTierRewardMultiplier(uint8 tier, uint16 multiplierBps) returns()
+func (_BunkerStaking *BunkerStakingSession) SetTierRewardMultiplier(tier uint8, multiplierBps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetTierRewardMultiplier(&_BunkerStaking.TransactOpts, tier, multiplierBps)
+}
+
+// SetTierRewardMultiplier is a paid mutator transaction binding the contract method 0x647b65ed.
+//
+// Solidity: function setTierRewardMultiplier(uint8 tier, uint16 multiplierBps) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetTierRewardMultiplier(tier uint8, multiplierBps uint16) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetTierRewardMultiplier(&_BunkerStaking.TransactOpts, tier, multiplierBps)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetTreasury(opts *bind.TransactOpts, newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setTreasury", newTreasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerStaking *BunkerStakingSession) SetTreasury(newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetTreasury(&_BunkerStaking.TransactOpts, newTreasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetTreasury(newTreasury common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetTreasury(&_BunkerStaking.TransactOpts, newTreasury)
+}
+
+// SetUnbondingPeriod is a paid mutator transaction binding the contract method 0x114eaf55.
+//
+// Solidity: function setUnbondingPeriod(uint256 newPeriod) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetUnbondingPeriod(opts *bind.TransactOpts, newPeriod *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setUnbondingPeriod", newPeriod)
+}
+
+// SetUnbondingPeriod is a paid mutator transaction binding the contract method 0x114eaf55.
+//
+// Solidity: function setUnbondingPeriod(uint256 newPeriod) returns()
+func (_BunkerStaking *BunkerStakingSession) SetUnbondingPeriod(newPeriod *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetUnbondingPeriod(&_BunkerStaking.TransactOpts, newPeriod)
+}
+
+// SetUnbondingPeriod is a paid mutator transaction binding the contract method 0x114eaf55.
+//
+// Solidity: function setUnbondingPeriod(uint256 newPeriod) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetUnbondingPeriod(newPeriod *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetUnbondingPeriod(&_BunkerStaking.TransactOpts, newPeriod)
+}
+
+// SetVestingParams is a paid mutator transaction binding the contract method 0xeb658878.
+//
+// Solidity: function setVestingParams(uint256 _vestingPeriod, uint256 _immediateReleaseBps) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SetVestingParams(opts *bind.TransactOpts, _vestingPeriod *big.Int, _immediateReleaseBps *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "setVestingParams", _vestingPeriod, _immediateReleaseBps)
+}
+
+// SetVestingParams is a paid mutator transaction binding the contract method 0xeb658878.
+//
+// Solidity: function setVestingParams(uint256 _vestingPeriod, uint256 _immediateReleaseBps) returns()
+func (_BunkerStaking *BunkerStakingSession) SetVestingParams(_vestingPeriod *big.Int, _immediateReleaseBps *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetVestingParams(&_BunkerStaking.TransactOpts, _vestingPeriod, _immediateReleaseBps)
+}
+
+// SetVestingParams is a paid mutator transaction binding the contract method 0xeb658878.
+//
+// Solidity: function setVestingParams(uint256 _vestingPeriod, uint256 _immediateReleaseBps) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SetVestingParams(_vestingPeriod *big.Int, _immediateReleaseBps *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SetVestingParams(&_BunkerStaking.TransactOpts, _vestingPeriod, _immediateReleaseBps)
+}
+
+// Slash is a paid mutator transaction binding the contract method 0x02fb4d85.
+//
+// Solidity: function slash(address provider, uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingTransactor) Slash(opts *bind.TransactOpts, provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "slash", provider, amount)
+}
+
+// Slash is a paid mutator transaction binding the contract method 0x02fb4d85.
+//
+// Solidity: function slash(address provider, uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingSession) Slash(provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.Slash(&_BunkerStaking.TransactOpts, provider, amount)
+}
+
+// Slash is a paid mutator transaction binding the contract method 0x02fb4d85.
+//
+// Solidity: function slash(address provider, uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) Slash(provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.Slash(&_BunkerStaking.TransactOpts, provider, amount)
+}
+
+// SlashImmediate is a paid mutator transaction binding the contract method 0x817b467a.
+//
+// Solidity: function slashImmediate(address provider, uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingTransactor) SlashImmediate(opts *bind.TransactOpts, provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "slashImmediate", provider, amount)
+}
+
+// SlashImmediate is a paid mutator transaction binding the contract method 0x817b467a.
+//
+// Solidity: function slashImmediate(address provider, uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingSession) SlashImmediate(provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SlashImmediate(&_BunkerStaking.TransactOpts, provider, amount)
+}
+
+// SlashImmediate is a paid mutator transaction binding the contract method 0x817b467a.
+//
+// Solidity: function slashImmediate(address provider, uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) SlashImmediate(provider common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.SlashImmediate(&_BunkerStaking.TransactOpts, provider, amount)
+}
+
+// Stake is a paid mutator transaction binding the contract method 0xa694fc3a.
+//
+// Solidity: function stake(uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingTransactor) Stake(opts *bind.TransactOpts, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "stake", amount)
+}
+
+// Stake is a paid mutator transaction binding the contract method 0xa694fc3a.
+//
+// Solidity: function stake(uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingSession) Stake(amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.Stake(&_BunkerStaking.TransactOpts, amount)
+}
+
+// Stake is a paid mutator transaction binding the contract method 0xa694fc3a.
+//
+// Solidity: function stake(uint256 amount) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) Stake(amount *big.Int) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.Stake(&_BunkerStaking.TransactOpts, amount)
+}
+
+// StakeWithIdentity is a paid mutator transaction binding the contract method 0xaf428c3b.
+//
+// Solidity: function stakeWithIdentity(uint256 amount, bytes32 nodeId, bytes32 region, uint64 capabilities) returns()
+func (_BunkerStaking *BunkerStakingTransactor) StakeWithIdentity(opts *bind.TransactOpts, amount *big.Int, nodeId [32]byte, region [32]byte, capabilities uint64) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "stakeWithIdentity", amount, nodeId, region, capabilities)
+}
+
+// StakeWithIdentity is a paid mutator transaction binding the contract method 0xaf428c3b.
+//
+// Solidity: function stakeWithIdentity(uint256 amount, bytes32 nodeId, bytes32 region, uint64 capabilities) returns()
+func (_BunkerStaking *BunkerStakingSession) StakeWithIdentity(amount *big.Int, nodeId [32]byte, region [32]byte, capabilities uint64) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.StakeWithIdentity(&_BunkerStaking.TransactOpts, amount, nodeId, region, capabilities)
+}
+
+// StakeWithIdentity is a paid mutator transaction binding the contract method 0xaf428c3b.
+//
+// Solidity: function stakeWithIdentity(uint256 amount, bytes32 nodeId, bytes32 region, uint64 capabilities) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) StakeWithIdentity(amount *big.Int, nodeId [32]byte, region [32]byte, capabilities uint64) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.StakeWithIdentity(&_BunkerStaking.TransactOpts, amount, nodeId, region, capabilities)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerStaking *BunkerStakingTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerStaking *BunkerStakingSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.TransferOwnership(&_BunkerStaking.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.TransferOwnership(&_BunkerStaking.TransactOpts, newOwner)
+}
+
+// UnfreezeProvider is a paid mutator transaction binding the contract method 0x349ec18a.
+//
+// Solidity: function unfreezeProvider(address provider) returns()
+func (_BunkerStaking *BunkerStakingTransactor) UnfreezeProvider(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "unfreezeProvider", provider)
+}
+
+// UnfreezeProvider is a paid mutator transaction binding the contract method 0x349ec18a.
+//
+// Solidity: function unfreezeProvider(address provider) returns()
+func (_BunkerStaking *BunkerStakingSession) UnfreezeProvider(provider common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.UnfreezeProvider(&_BunkerStaking.TransactOpts, provider)
+}
+
+// UnfreezeProvider is a paid mutator transaction binding the contract method 0x349ec18a.
+//
+// Solidity: function unfreezeProvider(address provider) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) UnfreezeProvider(provider common.Address) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.UnfreezeProvider(&_BunkerStaking.TransactOpts, provider)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerStaking *BunkerStakingTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerStaking *BunkerStakingSession) Unpause() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.Unpause(&_BunkerStaking.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) Unpause() (*types.Transaction, error) {
+	return _BunkerStaking.Contract.Unpause(&_BunkerStaking.TransactOpts)
+}
+
+// UpdateIdentity is a paid mutator transaction binding the contract method 0x1607da4c.
+//
+// Solidity: function updateIdentity(bytes32 nodeId, bytes32 region, uint64 capabilities) returns()
+func (_BunkerStaking *BunkerStakingTransactor) UpdateIdentity(opts *bind.TransactOpts, nodeId [32]byte, region [32]byte, capabilities uint64) (*types.Transaction, error) {
+	return _BunkerStaking.contract.Transact(opts, "updateIdentity", nodeId, region, capabilities)
+}
+
+// UpdateIdentity is a paid mutator transaction binding the contract method 0x1607da4c.
+//
+// Solidity: function updateIdentity(bytes32 nodeId, bytes32 region, uint64 capabilities) returns()
+func (_BunkerStaking *BunkerStakingSession) UpdateIdentity(nodeId [32]byte, region [32]byte, capabilities uint64) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.UpdateIdentity(&_BunkerStaking.TransactOpts, nodeId, region, capabilities)
+}
+
+// UpdateIdentity is a paid mutator transaction binding the contract method 0x1607da4c.
+//
+// Solidity: function updateIdentity(bytes32 nodeId, bytes32 region, uint64 capabilities) returns()
+func (_BunkerStaking *BunkerStakingTransactorSession) UpdateIdentity(nodeId [32]byte, region [32]byte, capabilities uint64) (*types.Transaction, error) {
+	return _BunkerStaking.Contract.UpdateIdentity(&_BunkerStaking.TransactOpts, nodeId, region, capabilities)
+}
+
+// BunkerStakingAppealResolvedIterator is returned from FilterAppealResolved and is used to iterate over the raw logs and unpacked data for AppealResolved events raised by the BunkerStaking contract.
+type BunkerStakingAppealResolvedIterator struct {
+	Event *BunkerStakingAppealResolved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingAppealResolvedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingAppealResolved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingAppealResolved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingAppealResolvedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingAppealResolvedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingAppealResolved represents a AppealResolved event raised by the BunkerStaking contract.
+type BunkerStakingAppealResolved struct {
+	ProposalId *big.Int
+	Upheld     bool
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterAppealResolved is a free log retrieval operation binding the contract event 0x89cd618842088e9ada48e481bba3a9320eba61a9329ef23ede5abd02837084a5.
+//
+// Solidity: event AppealResolved(uint256 indexed proposalId, bool upheld)
+func (_BunkerStaking *BunkerStakingFilterer) FilterAppealResolved(opts *bind.FilterOpts, proposalId []*big.Int) (*BunkerStakingAppealResolvedIterator, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "AppealResolved", proposalIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingAppealResolvedIterator{contract: _BunkerStaking.contract, event: "AppealResolved", logs: logs, sub: sub}, nil
+}
+
+// WatchAppealResolved is a free log subscription operation binding the contract event 0x89cd618842088e9ada48e481bba3a9320eba61a9329ef23ede5abd02837084a5.
+//
+// Solidity: event AppealResolved(uint256 indexed proposalId, bool upheld)
+func (_BunkerStaking *BunkerStakingFilterer) WatchAppealResolved(opts *bind.WatchOpts, sink chan<- *BunkerStakingAppealResolved, proposalId []*big.Int) (event.Subscription, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "AppealResolved", proposalIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingAppealResolved)
+				if err := _BunkerStaking.contract.UnpackLog(event, "AppealResolved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAppealResolved is a log parse operation binding the contract event 0x89cd618842088e9ada48e481bba3a9320eba61a9329ef23ede5abd02837084a5.
+//
+// Solidity: event AppealResolved(uint256 indexed proposalId, bool upheld)
+func (_BunkerStaking *BunkerStakingFilterer) ParseAppealResolved(log types.Log) (*BunkerStakingAppealResolved, error) {
+	event := new(BunkerStakingAppealResolved)
+	if err := _BunkerStaking.contract.UnpackLog(event, "AppealResolved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingAppealWindowUpdatedIterator is returned from FilterAppealWindowUpdated and is used to iterate over the raw logs and unpacked data for AppealWindowUpdated events raised by the BunkerStaking contract.
+type BunkerStakingAppealWindowUpdatedIterator struct {
+	Event *BunkerStakingAppealWindowUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingAppealWindowUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingAppealWindowUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingAppealWindowUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingAppealWindowUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingAppealWindowUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingAppealWindowUpdated represents a AppealWindowUpdated event raised by the BunkerStaking contract.
+type BunkerStakingAppealWindowUpdated struct {
+	NewWindow *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterAppealWindowUpdated is a free log retrieval operation binding the contract event 0x54413d229c766aa747f8b521ac83d355bbe788dfe3c7c6ec5595911a9fcd6a83.
+//
+// Solidity: event AppealWindowUpdated(uint256 newWindow)
+func (_BunkerStaking *BunkerStakingFilterer) FilterAppealWindowUpdated(opts *bind.FilterOpts) (*BunkerStakingAppealWindowUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "AppealWindowUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingAppealWindowUpdatedIterator{contract: _BunkerStaking.contract, event: "AppealWindowUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchAppealWindowUpdated is a free log subscription operation binding the contract event 0x54413d229c766aa747f8b521ac83d355bbe788dfe3c7c6ec5595911a9fcd6a83.
+//
+// Solidity: event AppealWindowUpdated(uint256 newWindow)
+func (_BunkerStaking *BunkerStakingFilterer) WatchAppealWindowUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingAppealWindowUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "AppealWindowUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingAppealWindowUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "AppealWindowUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAppealWindowUpdated is a log parse operation binding the contract event 0x54413d229c766aa747f8b521ac83d355bbe788dfe3c7c6ec5595911a9fcd6a83.
+//
+// Solidity: event AppealWindowUpdated(uint256 newWindow)
+func (_BunkerStaking *BunkerStakingFilterer) ParseAppealWindowUpdated(log types.Log) (*BunkerStakingAppealWindowUpdated, error) {
+	event := new(BunkerStakingAppealWindowUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "AppealWindowUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingBeneficiaryChangeInitiatedIterator is returned from FilterBeneficiaryChangeInitiated and is used to iterate over the raw logs and unpacked data for BeneficiaryChangeInitiated events raised by the BunkerStaking contract.
+type BunkerStakingBeneficiaryChangeInitiatedIterator struct {
+	Event *BunkerStakingBeneficiaryChangeInitiated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingBeneficiaryChangeInitiatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingBeneficiaryChangeInitiated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingBeneficiaryChangeInitiated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingBeneficiaryChangeInitiatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingBeneficiaryChangeInitiatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingBeneficiaryChangeInitiated represents a BeneficiaryChangeInitiated event raised by the BunkerStaking contract.
+type BunkerStakingBeneficiaryChangeInitiated struct {
+	Provider       common.Address
+	NewBeneficiary common.Address
+	EffectiveTime  *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBeneficiaryChangeInitiated is a free log retrieval operation binding the contract event 0x98da5d426da0c3b191c5600bb598cf868f68f6592e8aae0ffcc8722e050f9208.
+//
+// Solidity: event BeneficiaryChangeInitiated(address indexed provider, address indexed newBeneficiary, uint256 effectiveTime)
+func (_BunkerStaking *BunkerStakingFilterer) FilterBeneficiaryChangeInitiated(opts *bind.FilterOpts, provider []common.Address, newBeneficiary []common.Address) (*BunkerStakingBeneficiaryChangeInitiatedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var newBeneficiaryRule []interface{}
+	for _, newBeneficiaryItem := range newBeneficiary {
+		newBeneficiaryRule = append(newBeneficiaryRule, newBeneficiaryItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "BeneficiaryChangeInitiated", providerRule, newBeneficiaryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingBeneficiaryChangeInitiatedIterator{contract: _BunkerStaking.contract, event: "BeneficiaryChangeInitiated", logs: logs, sub: sub}, nil
+}
+
+// WatchBeneficiaryChangeInitiated is a free log subscription operation binding the contract event 0x98da5d426da0c3b191c5600bb598cf868f68f6592e8aae0ffcc8722e050f9208.
+//
+// Solidity: event BeneficiaryChangeInitiated(address indexed provider, address indexed newBeneficiary, uint256 effectiveTime)
+func (_BunkerStaking *BunkerStakingFilterer) WatchBeneficiaryChangeInitiated(opts *bind.WatchOpts, sink chan<- *BunkerStakingBeneficiaryChangeInitiated, provider []common.Address, newBeneficiary []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var newBeneficiaryRule []interface{}
+	for _, newBeneficiaryItem := range newBeneficiary {
+		newBeneficiaryRule = append(newBeneficiaryRule, newBeneficiaryItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "BeneficiaryChangeInitiated", providerRule, newBeneficiaryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingBeneficiaryChangeInitiated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "BeneficiaryChangeInitiated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBeneficiaryChangeInitiated is a log parse operation binding the contract event 0x98da5d426da0c3b191c5600bb598cf868f68f6592e8aae0ffcc8722e050f9208.
+//
+// Solidity: event BeneficiaryChangeInitiated(address indexed provider, address indexed newBeneficiary, uint256 effectiveTime)
+func (_BunkerStaking *BunkerStakingFilterer) ParseBeneficiaryChangeInitiated(log types.Log) (*BunkerStakingBeneficiaryChangeInitiated, error) {
+	event := new(BunkerStakingBeneficiaryChangeInitiated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "BeneficiaryChangeInitiated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingBeneficiaryChangedIterator is returned from FilterBeneficiaryChanged and is used to iterate over the raw logs and unpacked data for BeneficiaryChanged events raised by the BunkerStaking contract.
+type BunkerStakingBeneficiaryChangedIterator struct {
+	Event *BunkerStakingBeneficiaryChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingBeneficiaryChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingBeneficiaryChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingBeneficiaryChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingBeneficiaryChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingBeneficiaryChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingBeneficiaryChanged represents a BeneficiaryChanged event raised by the BunkerStaking contract.
+type BunkerStakingBeneficiaryChanged struct {
+	Provider       common.Address
+	OldBeneficiary common.Address
+	NewBeneficiary common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterBeneficiaryChanged is a free log retrieval operation binding the contract event 0xdc2fee73e6c685172c975dd7a10bdc4da20294ae742590263dfcd6a59681dcc5.
+//
+// Solidity: event BeneficiaryChanged(address indexed provider, address indexed oldBeneficiary, address indexed newBeneficiary)
+func (_BunkerStaking *BunkerStakingFilterer) FilterBeneficiaryChanged(opts *bind.FilterOpts, provider []common.Address, oldBeneficiary []common.Address, newBeneficiary []common.Address) (*BunkerStakingBeneficiaryChangedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var oldBeneficiaryRule []interface{}
+	for _, oldBeneficiaryItem := range oldBeneficiary {
+		oldBeneficiaryRule = append(oldBeneficiaryRule, oldBeneficiaryItem)
+	}
+	var newBeneficiaryRule []interface{}
+	for _, newBeneficiaryItem := range newBeneficiary {
+		newBeneficiaryRule = append(newBeneficiaryRule, newBeneficiaryItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "BeneficiaryChanged", providerRule, oldBeneficiaryRule, newBeneficiaryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingBeneficiaryChangedIterator{contract: _BunkerStaking.contract, event: "BeneficiaryChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchBeneficiaryChanged is a free log subscription operation binding the contract event 0xdc2fee73e6c685172c975dd7a10bdc4da20294ae742590263dfcd6a59681dcc5.
+//
+// Solidity: event BeneficiaryChanged(address indexed provider, address indexed oldBeneficiary, address indexed newBeneficiary)
+func (_BunkerStaking *BunkerStakingFilterer) WatchBeneficiaryChanged(opts *bind.WatchOpts, sink chan<- *BunkerStakingBeneficiaryChanged, provider []common.Address, oldBeneficiary []common.Address, newBeneficiary []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var oldBeneficiaryRule []interface{}
+	for _, oldBeneficiaryItem := range oldBeneficiary {
+		oldBeneficiaryRule = append(oldBeneficiaryRule, oldBeneficiaryItem)
+	}
+	var newBeneficiaryRule []interface{}
+	for _, newBeneficiaryItem := range newBeneficiary {
+		newBeneficiaryRule = append(newBeneficiaryRule, newBeneficiaryItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "BeneficiaryChanged", providerRule, oldBeneficiaryRule, newBeneficiaryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingBeneficiaryChanged)
+				if err := _BunkerStaking.contract.UnpackLog(event, "BeneficiaryChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBeneficiaryChanged is a log parse operation binding the contract event 0xdc2fee73e6c685172c975dd7a10bdc4da20294ae742590263dfcd6a59681dcc5.
+//
+// Solidity: event BeneficiaryChanged(address indexed provider, address indexed oldBeneficiary, address indexed newBeneficiary)
+func (_BunkerStaking *BunkerStakingFilterer) ParseBeneficiaryChanged(log types.Log) (*BunkerStakingBeneficiaryChanged, error) {
+	event := new(BunkerStakingBeneficiaryChanged)
+	if err := _BunkerStaking.contract.UnpackLog(event, "BeneficiaryChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingComputeHoursReportedIterator is returned from FilterComputeHoursReported and is used to iterate over the raw logs and unpacked data for ComputeHoursReported events raised by the BunkerStaking contract.
+type BunkerStakingComputeHoursReportedIterator struct {
+	Event *BunkerStakingComputeHoursReported // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingComputeHoursReportedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingComputeHoursReported)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingComputeHoursReported)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingComputeHoursReportedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingComputeHoursReportedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingComputeHoursReported represents a ComputeHoursReported event raised by the BunkerStaking contract.
+type BunkerStakingComputeHoursReported struct {
+	Hours             *big.Int
+	TotalComputeHours *big.Int
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterComputeHoursReported is a free log retrieval operation binding the contract event 0xcd4e5f23e306594173b24ca7f1a71b37ffb973b416d19566af45e2139dca1b30.
+//
+// Solidity: event ComputeHoursReported(uint256 hours_, uint256 totalComputeHours)
+func (_BunkerStaking *BunkerStakingFilterer) FilterComputeHoursReported(opts *bind.FilterOpts) (*BunkerStakingComputeHoursReportedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "ComputeHoursReported")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingComputeHoursReportedIterator{contract: _BunkerStaking.contract, event: "ComputeHoursReported", logs: logs, sub: sub}, nil
+}
+
+// WatchComputeHoursReported is a free log subscription operation binding the contract event 0xcd4e5f23e306594173b24ca7f1a71b37ffb973b416d19566af45e2139dca1b30.
+//
+// Solidity: event ComputeHoursReported(uint256 hours_, uint256 totalComputeHours)
+func (_BunkerStaking *BunkerStakingFilterer) WatchComputeHoursReported(opts *bind.WatchOpts, sink chan<- *BunkerStakingComputeHoursReported) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "ComputeHoursReported")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingComputeHoursReported)
+				if err := _BunkerStaking.contract.UnpackLog(event, "ComputeHoursReported", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseComputeHoursReported is a log parse operation binding the contract event 0xcd4e5f23e306594173b24ca7f1a71b37ffb973b416d19566af45e2139dca1b30.
+//
+// Solidity: event ComputeHoursReported(uint256 hours_, uint256 totalComputeHours)
+func (_BunkerStaking *BunkerStakingFilterer) ParseComputeHoursReported(log types.Log) (*BunkerStakingComputeHoursReported, error) {
+	event := new(BunkerStakingComputeHoursReported)
+	if err := _BunkerStaking.contract.UnpackLog(event, "ComputeHoursReported", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingEmissionMultiplierUpdatedIterator is returned from FilterEmissionMultiplierUpdated and is used to iterate over the raw logs and unpacked data for EmissionMultiplierUpdated events raised by the BunkerStaking contract.
+type BunkerStakingEmissionMultiplierUpdatedIterator struct {
+	Event *BunkerStakingEmissionMultiplierUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingEmissionMultiplierUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingEmissionMultiplierUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingEmissionMultiplierUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingEmissionMultiplierUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingEmissionMultiplierUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingEmissionMultiplierUpdated represents a EmissionMultiplierUpdated event raised by the BunkerStaking contract.
+type BunkerStakingEmissionMultiplierUpdated struct {
+	MultiplierBps *big.Int
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterEmissionMultiplierUpdated is a free log retrieval operation binding the contract event 0x3665e914cbbfb56f8df84838e27e44aab666f6d78acbaf60f7c541a398fd6f54.
+//
+// Solidity: event EmissionMultiplierUpdated(uint256 multiplierBps)
+func (_BunkerStaking *BunkerStakingFilterer) FilterEmissionMultiplierUpdated(opts *bind.FilterOpts) (*BunkerStakingEmissionMultiplierUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "EmissionMultiplierUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingEmissionMultiplierUpdatedIterator{contract: _BunkerStaking.contract, event: "EmissionMultiplierUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchEmissionMultiplierUpdated is a free log subscription operation binding the contract event 0x3665e914cbbfb56f8df84838e27e44aab666f6d78acbaf60f7c541a398fd6f54.
+//
+// Solidity: event EmissionMultiplierUpdated(uint256 multiplierBps)
+func (_BunkerStaking *BunkerStakingFilterer) WatchEmissionMultiplierUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingEmissionMultiplierUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "EmissionMultiplierUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingEmissionMultiplierUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "EmissionMultiplierUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEmissionMultiplierUpdated is a log parse operation binding the contract event 0x3665e914cbbfb56f8df84838e27e44aab666f6d78acbaf60f7c541a398fd6f54.
+//
+// Solidity: event EmissionMultiplierUpdated(uint256 multiplierBps)
+func (_BunkerStaking *BunkerStakingFilterer) ParseEmissionMultiplierUpdated(log types.Log) (*BunkerStakingEmissionMultiplierUpdated, error) {
+	event := new(BunkerStakingEmissionMultiplierUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "EmissionMultiplierUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingMaxEmissionRateUpdatedIterator is returned from FilterMaxEmissionRateUpdated and is used to iterate over the raw logs and unpacked data for MaxEmissionRateUpdated events raised by the BunkerStaking contract.
+type BunkerStakingMaxEmissionRateUpdatedIterator struct {
+	Event *BunkerStakingMaxEmissionRateUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingMaxEmissionRateUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingMaxEmissionRateUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingMaxEmissionRateUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingMaxEmissionRateUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingMaxEmissionRateUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingMaxEmissionRateUpdated represents a MaxEmissionRateUpdated event raised by the BunkerStaking contract.
+type BunkerStakingMaxEmissionRateUpdated struct {
+	MaxRate *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterMaxEmissionRateUpdated is a free log retrieval operation binding the contract event 0xc44e0289ac09e3f9a9c9e667e4c25e2aea77e0fc8a89677a961c423a35082e81.
+//
+// Solidity: event MaxEmissionRateUpdated(uint256 maxRate)
+func (_BunkerStaking *BunkerStakingFilterer) FilterMaxEmissionRateUpdated(opts *bind.FilterOpts) (*BunkerStakingMaxEmissionRateUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "MaxEmissionRateUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingMaxEmissionRateUpdatedIterator{contract: _BunkerStaking.contract, event: "MaxEmissionRateUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMaxEmissionRateUpdated is a free log subscription operation binding the contract event 0xc44e0289ac09e3f9a9c9e667e4c25e2aea77e0fc8a89677a961c423a35082e81.
+//
+// Solidity: event MaxEmissionRateUpdated(uint256 maxRate)
+func (_BunkerStaking *BunkerStakingFilterer) WatchMaxEmissionRateUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingMaxEmissionRateUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "MaxEmissionRateUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingMaxEmissionRateUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "MaxEmissionRateUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMaxEmissionRateUpdated is a log parse operation binding the contract event 0xc44e0289ac09e3f9a9c9e667e4c25e2aea77e0fc8a89677a961c423a35082e81.
+//
+// Solidity: event MaxEmissionRateUpdated(uint256 maxRate)
+func (_BunkerStaking *BunkerStakingFilterer) ParseMaxEmissionRateUpdated(log types.Log) (*BunkerStakingMaxEmissionRateUpdated, error) {
+	event := new(BunkerStakingMaxEmissionRateUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "MaxEmissionRateUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingMaxTierMultiplierUpdatedIterator is returned from FilterMaxTierMultiplierUpdated and is used to iterate over the raw logs and unpacked data for MaxTierMultiplierUpdated events raised by the BunkerStaking contract.
+type BunkerStakingMaxTierMultiplierUpdatedIterator struct {
+	Event *BunkerStakingMaxTierMultiplierUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingMaxTierMultiplierUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingMaxTierMultiplierUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingMaxTierMultiplierUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingMaxTierMultiplierUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingMaxTierMultiplierUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingMaxTierMultiplierUpdated represents a MaxTierMultiplierUpdated event raised by the BunkerStaking contract.
+type BunkerStakingMaxTierMultiplierUpdated struct {
+	NewMax uint16
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterMaxTierMultiplierUpdated is a free log retrieval operation binding the contract event 0x51842c09c69e9b362aa5f1861b50689dd0af1ae0111cea7050599ccb2105e31b.
+//
+// Solidity: event MaxTierMultiplierUpdated(uint16 newMax)
+func (_BunkerStaking *BunkerStakingFilterer) FilterMaxTierMultiplierUpdated(opts *bind.FilterOpts) (*BunkerStakingMaxTierMultiplierUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "MaxTierMultiplierUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingMaxTierMultiplierUpdatedIterator{contract: _BunkerStaking.contract, event: "MaxTierMultiplierUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMaxTierMultiplierUpdated is a free log subscription operation binding the contract event 0x51842c09c69e9b362aa5f1861b50689dd0af1ae0111cea7050599ccb2105e31b.
+//
+// Solidity: event MaxTierMultiplierUpdated(uint16 newMax)
+func (_BunkerStaking *BunkerStakingFilterer) WatchMaxTierMultiplierUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingMaxTierMultiplierUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "MaxTierMultiplierUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingMaxTierMultiplierUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "MaxTierMultiplierUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMaxTierMultiplierUpdated is a log parse operation binding the contract event 0x51842c09c69e9b362aa5f1861b50689dd0af1ae0111cea7050599ccb2105e31b.
+//
+// Solidity: event MaxTierMultiplierUpdated(uint16 newMax)
+func (_BunkerStaking *BunkerStakingFilterer) ParseMaxTierMultiplierUpdated(log types.Log) (*BunkerStakingMaxTierMultiplierUpdated, error) {
+	event := new(BunkerStakingMaxTierMultiplierUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "MaxTierMultiplierUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the BunkerStaking contract.
+type BunkerStakingOwnershipTransferStartedIterator struct {
+	Event *BunkerStakingOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the BunkerStaking contract.
+type BunkerStakingOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerStaking *BunkerStakingFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerStakingOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingOwnershipTransferStartedIterator{contract: _BunkerStaking.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerStaking *BunkerStakingFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BunkerStakingOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingOwnershipTransferStarted)
+				if err := _BunkerStaking.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerStaking *BunkerStakingFilterer) ParseOwnershipTransferStarted(log types.Log) (*BunkerStakingOwnershipTransferStarted, error) {
+	event := new(BunkerStakingOwnershipTransferStarted)
+	if err := _BunkerStaking.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BunkerStaking contract.
+type BunkerStakingOwnershipTransferredIterator struct {
+	Event *BunkerStakingOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingOwnershipTransferred represents a OwnershipTransferred event raised by the BunkerStaking contract.
+type BunkerStakingOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerStaking *BunkerStakingFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerStakingOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingOwnershipTransferredIterator{contract: _BunkerStaking.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerStaking *BunkerStakingFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BunkerStakingOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingOwnershipTransferred)
+				if err := _BunkerStaking.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerStaking *BunkerStakingFilterer) ParseOwnershipTransferred(log types.Log) (*BunkerStakingOwnershipTransferred, error) {
+	event := new(BunkerStakingOwnershipTransferred)
+	if err := _BunkerStaking.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the BunkerStaking contract.
+type BunkerStakingPausedIterator struct {
+	Event *BunkerStakingPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingPaused represents a Paused event raised by the BunkerStaking contract.
+type BunkerStakingPaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerStaking *BunkerStakingFilterer) FilterPaused(opts *bind.FilterOpts) (*BunkerStakingPausedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingPausedIterator{contract: _BunkerStaking.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerStaking *BunkerStakingFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *BunkerStakingPaused) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingPaused)
+				if err := _BunkerStaking.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_BunkerStaking *BunkerStakingFilterer) ParsePaused(log types.Log) (*BunkerStakingPaused, error) {
+	event := new(BunkerStakingPaused)
+	if err := _BunkerStaking.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingProviderDeregisteredIterator is returned from FilterProviderDeregistered and is used to iterate over the raw logs and unpacked data for ProviderDeregistered events raised by the BunkerStaking contract.
+type BunkerStakingProviderDeregisteredIterator struct {
+	Event *BunkerStakingProviderDeregistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingProviderDeregisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingProviderDeregistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingProviderDeregistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingProviderDeregisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingProviderDeregisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingProviderDeregistered represents a ProviderDeregistered event raised by the BunkerStaking contract.
+type BunkerStakingProviderDeregistered struct {
+	Provider common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderDeregistered is a free log retrieval operation binding the contract event 0xf04091b4a187e321a42001e46961e45b6a75b203fc6fb766b7e05505f6080abb.
+//
+// Solidity: event ProviderDeregistered(address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) FilterProviderDeregistered(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingProviderDeregisteredIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "ProviderDeregistered", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingProviderDeregisteredIterator{contract: _BunkerStaking.contract, event: "ProviderDeregistered", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderDeregistered is a free log subscription operation binding the contract event 0xf04091b4a187e321a42001e46961e45b6a75b203fc6fb766b7e05505f6080abb.
+//
+// Solidity: event ProviderDeregistered(address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) WatchProviderDeregistered(opts *bind.WatchOpts, sink chan<- *BunkerStakingProviderDeregistered, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "ProviderDeregistered", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingProviderDeregistered)
+				if err := _BunkerStaking.contract.UnpackLog(event, "ProviderDeregistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderDeregistered is a log parse operation binding the contract event 0xf04091b4a187e321a42001e46961e45b6a75b203fc6fb766b7e05505f6080abb.
+//
+// Solidity: event ProviderDeregistered(address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) ParseProviderDeregistered(log types.Log) (*BunkerStakingProviderDeregistered, error) {
+	event := new(BunkerStakingProviderDeregistered)
+	if err := _BunkerStaking.contract.UnpackLog(event, "ProviderDeregistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingProviderFrozenIterator is returned from FilterProviderFrozen and is used to iterate over the raw logs and unpacked data for ProviderFrozen events raised by the BunkerStaking contract.
+type BunkerStakingProviderFrozenIterator struct {
+	Event *BunkerStakingProviderFrozen // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingProviderFrozenIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingProviderFrozen)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingProviderFrozen)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingProviderFrozenIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingProviderFrozenIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingProviderFrozen represents a ProviderFrozen event raised by the BunkerStaking contract.
+type BunkerStakingProviderFrozen struct {
+	Provider common.Address
+	By       common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderFrozen is a free log retrieval operation binding the contract event 0x65eea5ca6f5e9a2ded541a1264e7cc2d2c3ebd7e8de01cbf48d345ea50920f75.
+//
+// Solidity: event ProviderFrozen(address indexed provider, address indexed by)
+func (_BunkerStaking *BunkerStakingFilterer) FilterProviderFrozen(opts *bind.FilterOpts, provider []common.Address, by []common.Address) (*BunkerStakingProviderFrozenIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var byRule []interface{}
+	for _, byItem := range by {
+		byRule = append(byRule, byItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "ProviderFrozen", providerRule, byRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingProviderFrozenIterator{contract: _BunkerStaking.contract, event: "ProviderFrozen", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderFrozen is a free log subscription operation binding the contract event 0x65eea5ca6f5e9a2ded541a1264e7cc2d2c3ebd7e8de01cbf48d345ea50920f75.
+//
+// Solidity: event ProviderFrozen(address indexed provider, address indexed by)
+func (_BunkerStaking *BunkerStakingFilterer) WatchProviderFrozen(opts *bind.WatchOpts, sink chan<- *BunkerStakingProviderFrozen, provider []common.Address, by []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+	var byRule []interface{}
+	for _, byItem := range by {
+		byRule = append(byRule, byItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "ProviderFrozen", providerRule, byRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingProviderFrozen)
+				if err := _BunkerStaking.contract.UnpackLog(event, "ProviderFrozen", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderFrozen is a log parse operation binding the contract event 0x65eea5ca6f5e9a2ded541a1264e7cc2d2c3ebd7e8de01cbf48d345ea50920f75.
+//
+// Solidity: event ProviderFrozen(address indexed provider, address indexed by)
+func (_BunkerStaking *BunkerStakingFilterer) ParseProviderFrozen(log types.Log) (*BunkerStakingProviderFrozen, error) {
+	event := new(BunkerStakingProviderFrozen)
+	if err := _BunkerStaking.contract.UnpackLog(event, "ProviderFrozen", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingProviderIdentityUpdatedIterator is returned from FilterProviderIdentityUpdated and is used to iterate over the raw logs and unpacked data for ProviderIdentityUpdated events raised by the BunkerStaking contract.
+type BunkerStakingProviderIdentityUpdatedIterator struct {
+	Event *BunkerStakingProviderIdentityUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingProviderIdentityUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingProviderIdentityUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingProviderIdentityUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingProviderIdentityUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingProviderIdentityUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingProviderIdentityUpdated represents a ProviderIdentityUpdated event raised by the BunkerStaking contract.
+type BunkerStakingProviderIdentityUpdated struct {
+	Provider     common.Address
+	NodeId       [32]byte
+	Region       [32]byte
+	Capabilities uint64
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderIdentityUpdated is a free log retrieval operation binding the contract event 0x1cee51a2b872997d671c1f8951c74077c6e67098f7a60021794d5ac33f597c0f.
+//
+// Solidity: event ProviderIdentityUpdated(address indexed provider, bytes32 nodeId, bytes32 region, uint64 capabilities)
+func (_BunkerStaking *BunkerStakingFilterer) FilterProviderIdentityUpdated(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingProviderIdentityUpdatedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "ProviderIdentityUpdated", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingProviderIdentityUpdatedIterator{contract: _BunkerStaking.contract, event: "ProviderIdentityUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderIdentityUpdated is a free log subscription operation binding the contract event 0x1cee51a2b872997d671c1f8951c74077c6e67098f7a60021794d5ac33f597c0f.
+//
+// Solidity: event ProviderIdentityUpdated(address indexed provider, bytes32 nodeId, bytes32 region, uint64 capabilities)
+func (_BunkerStaking *BunkerStakingFilterer) WatchProviderIdentityUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingProviderIdentityUpdated, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "ProviderIdentityUpdated", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingProviderIdentityUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "ProviderIdentityUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderIdentityUpdated is a log parse operation binding the contract event 0x1cee51a2b872997d671c1f8951c74077c6e67098f7a60021794d5ac33f597c0f.
+//
+// Solidity: event ProviderIdentityUpdated(address indexed provider, bytes32 nodeId, bytes32 region, uint64 capabilities)
+func (_BunkerStaking *BunkerStakingFilterer) ParseProviderIdentityUpdated(log types.Log) (*BunkerStakingProviderIdentityUpdated, error) {
+	event := new(BunkerStakingProviderIdentityUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "ProviderIdentityUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingProviderRegisteredIterator is returned from FilterProviderRegistered and is used to iterate over the raw logs and unpacked data for ProviderRegistered events raised by the BunkerStaking contract.
+type BunkerStakingProviderRegisteredIterator struct {
+	Event *BunkerStakingProviderRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingProviderRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingProviderRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingProviderRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingProviderRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingProviderRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingProviderRegistered represents a ProviderRegistered event raised by the BunkerStaking contract.
+type BunkerStakingProviderRegistered struct {
+	Provider    common.Address
+	StakeAmount *big.Int
+	Tier        uint8
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderRegistered is a free log retrieval operation binding the contract event 0x57d314643bba38495581cebe1f7627d299bd42671765bfd77105c4f5093a530a.
+//
+// Solidity: event ProviderRegistered(address indexed provider, uint256 stakeAmount, uint8 tier)
+func (_BunkerStaking *BunkerStakingFilterer) FilterProviderRegistered(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingProviderRegisteredIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "ProviderRegistered", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingProviderRegisteredIterator{contract: _BunkerStaking.contract, event: "ProviderRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderRegistered is a free log subscription operation binding the contract event 0x57d314643bba38495581cebe1f7627d299bd42671765bfd77105c4f5093a530a.
+//
+// Solidity: event ProviderRegistered(address indexed provider, uint256 stakeAmount, uint8 tier)
+func (_BunkerStaking *BunkerStakingFilterer) WatchProviderRegistered(opts *bind.WatchOpts, sink chan<- *BunkerStakingProviderRegistered, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "ProviderRegistered", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingProviderRegistered)
+				if err := _BunkerStaking.contract.UnpackLog(event, "ProviderRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderRegistered is a log parse operation binding the contract event 0x57d314643bba38495581cebe1f7627d299bd42671765bfd77105c4f5093a530a.
+//
+// Solidity: event ProviderRegistered(address indexed provider, uint256 stakeAmount, uint8 tier)
+func (_BunkerStaking *BunkerStakingFilterer) ParseProviderRegistered(log types.Log) (*BunkerStakingProviderRegistered, error) {
+	event := new(BunkerStakingProviderRegistered)
+	if err := _BunkerStaking.contract.UnpackLog(event, "ProviderRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingProviderUnfrozenIterator is returned from FilterProviderUnfrozen and is used to iterate over the raw logs and unpacked data for ProviderUnfrozen events raised by the BunkerStaking contract.
+type BunkerStakingProviderUnfrozenIterator struct {
+	Event *BunkerStakingProviderUnfrozen // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingProviderUnfrozenIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingProviderUnfrozen)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingProviderUnfrozen)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingProviderUnfrozenIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingProviderUnfrozenIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingProviderUnfrozen represents a ProviderUnfrozen event raised by the BunkerStaking contract.
+type BunkerStakingProviderUnfrozen struct {
+	Provider common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderUnfrozen is a free log retrieval operation binding the contract event 0x33fa283d77758f91ac312d2ad1600b5797226bb3f77ebe1b2aaad28a4713b4a1.
+//
+// Solidity: event ProviderUnfrozen(address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) FilterProviderUnfrozen(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingProviderUnfrozenIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "ProviderUnfrozen", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingProviderUnfrozenIterator{contract: _BunkerStaking.contract, event: "ProviderUnfrozen", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderUnfrozen is a free log subscription operation binding the contract event 0x33fa283d77758f91ac312d2ad1600b5797226bb3f77ebe1b2aaad28a4713b4a1.
+//
+// Solidity: event ProviderUnfrozen(address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) WatchProviderUnfrozen(opts *bind.WatchOpts, sink chan<- *BunkerStakingProviderUnfrozen, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "ProviderUnfrozen", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingProviderUnfrozen)
+				if err := _BunkerStaking.contract.UnpackLog(event, "ProviderUnfrozen", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderUnfrozen is a log parse operation binding the contract event 0x33fa283d77758f91ac312d2ad1600b5797226bb3f77ebe1b2aaad28a4713b4a1.
+//
+// Solidity: event ProviderUnfrozen(address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) ParseProviderUnfrozen(log types.Log) (*BunkerStakingProviderUnfrozen, error) {
+	event := new(BunkerStakingProviderUnfrozen)
+	if err := _BunkerStaking.contract.UnpackLog(event, "ProviderUnfrozen", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingRewardClaimedIterator is returned from FilterRewardClaimed and is used to iterate over the raw logs and unpacked data for RewardClaimed events raised by the BunkerStaking contract.
+type BunkerStakingRewardClaimedIterator struct {
+	Event *BunkerStakingRewardClaimed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingRewardClaimedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingRewardClaimed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingRewardClaimed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingRewardClaimedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingRewardClaimedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingRewardClaimed represents a RewardClaimed event raised by the BunkerStaking contract.
+type BunkerStakingRewardClaimed struct {
+	Provider common.Address
+	Amount   *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardClaimed is a free log retrieval operation binding the contract event 0x106f923f993c2149d49b4255ff723acafa1f2d94393f561d3eda32ae348f7241.
+//
+// Solidity: event RewardClaimed(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) FilterRewardClaimed(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingRewardClaimedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "RewardClaimed", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingRewardClaimedIterator{contract: _BunkerStaking.contract, event: "RewardClaimed", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardClaimed is a free log subscription operation binding the contract event 0x106f923f993c2149d49b4255ff723acafa1f2d94393f561d3eda32ae348f7241.
+//
+// Solidity: event RewardClaimed(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) WatchRewardClaimed(opts *bind.WatchOpts, sink chan<- *BunkerStakingRewardClaimed, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "RewardClaimed", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingRewardClaimed)
+				if err := _BunkerStaking.contract.UnpackLog(event, "RewardClaimed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardClaimed is a log parse operation binding the contract event 0x106f923f993c2149d49b4255ff723acafa1f2d94393f561d3eda32ae348f7241.
+//
+// Solidity: event RewardClaimed(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) ParseRewardClaimed(log types.Log) (*BunkerStakingRewardClaimed, error) {
+	event := new(BunkerStakingRewardClaimed)
+	if err := _BunkerStaking.contract.UnpackLog(event, "RewardClaimed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingRewardEpochStartedIterator is returned from FilterRewardEpochStarted and is used to iterate over the raw logs and unpacked data for RewardEpochStarted events raised by the BunkerStaking contract.
+type BunkerStakingRewardEpochStartedIterator struct {
+	Event *BunkerStakingRewardEpochStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingRewardEpochStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingRewardEpochStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingRewardEpochStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingRewardEpochStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingRewardEpochStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingRewardEpochStarted represents a RewardEpochStarted event raised by the BunkerStaking contract.
+type BunkerStakingRewardEpochStarted struct {
+	Reward       *big.Int
+	RewardRate   *big.Int
+	PeriodFinish *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardEpochStarted is a free log retrieval operation binding the contract event 0x347a584423bcd4ce3b9eef1f89febdd551066b57473a8c30c7cb7b5384defd10.
+//
+// Solidity: event RewardEpochStarted(uint256 reward, uint256 rewardRate, uint256 periodFinish)
+func (_BunkerStaking *BunkerStakingFilterer) FilterRewardEpochStarted(opts *bind.FilterOpts) (*BunkerStakingRewardEpochStartedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "RewardEpochStarted")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingRewardEpochStartedIterator{contract: _BunkerStaking.contract, event: "RewardEpochStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardEpochStarted is a free log subscription operation binding the contract event 0x347a584423bcd4ce3b9eef1f89febdd551066b57473a8c30c7cb7b5384defd10.
+//
+// Solidity: event RewardEpochStarted(uint256 reward, uint256 rewardRate, uint256 periodFinish)
+func (_BunkerStaking *BunkerStakingFilterer) WatchRewardEpochStarted(opts *bind.WatchOpts, sink chan<- *BunkerStakingRewardEpochStarted) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "RewardEpochStarted")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingRewardEpochStarted)
+				if err := _BunkerStaking.contract.UnpackLog(event, "RewardEpochStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardEpochStarted is a log parse operation binding the contract event 0x347a584423bcd4ce3b9eef1f89febdd551066b57473a8c30c7cb7b5384defd10.
+//
+// Solidity: event RewardEpochStarted(uint256 reward, uint256 rewardRate, uint256 periodFinish)
+func (_BunkerStaking *BunkerStakingFilterer) ParseRewardEpochStarted(log types.Log) (*BunkerStakingRewardEpochStarted, error) {
+	event := new(BunkerStakingRewardEpochStarted)
+	if err := _BunkerStaking.contract.UnpackLog(event, "RewardEpochStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingRewardVestedIterator is returned from FilterRewardVested and is used to iterate over the raw logs and unpacked data for RewardVested events raised by the BunkerStaking contract.
+type BunkerStakingRewardVestedIterator struct {
+	Event *BunkerStakingRewardVested // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingRewardVestedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingRewardVested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingRewardVested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingRewardVestedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingRewardVestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingRewardVested represents a RewardVested event raised by the BunkerStaking contract.
+type BunkerStakingRewardVested struct {
+	Provider        common.Address
+	TotalAmount     *big.Int
+	ImmediateAmount *big.Int
+	VestedAmount    *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardVested is a free log retrieval operation binding the contract event 0x475055cbae9aa34fd8d18d08d5012fc98dcbbcdfc5540d79b84e2a0caa7ab42d.
+//
+// Solidity: event RewardVested(address indexed provider, uint256 totalAmount, uint256 immediateAmount, uint256 vestedAmount)
+func (_BunkerStaking *BunkerStakingFilterer) FilterRewardVested(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingRewardVestedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "RewardVested", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingRewardVestedIterator{contract: _BunkerStaking.contract, event: "RewardVested", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardVested is a free log subscription operation binding the contract event 0x475055cbae9aa34fd8d18d08d5012fc98dcbbcdfc5540d79b84e2a0caa7ab42d.
+//
+// Solidity: event RewardVested(address indexed provider, uint256 totalAmount, uint256 immediateAmount, uint256 vestedAmount)
+func (_BunkerStaking *BunkerStakingFilterer) WatchRewardVested(opts *bind.WatchOpts, sink chan<- *BunkerStakingRewardVested, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "RewardVested", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingRewardVested)
+				if err := _BunkerStaking.contract.UnpackLog(event, "RewardVested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardVested is a log parse operation binding the contract event 0x475055cbae9aa34fd8d18d08d5012fc98dcbbcdfc5540d79b84e2a0caa7ab42d.
+//
+// Solidity: event RewardVested(address indexed provider, uint256 totalAmount, uint256 immediateAmount, uint256 vestedAmount)
+func (_BunkerStaking *BunkerStakingFilterer) ParseRewardVested(log types.Log) (*BunkerStakingRewardVested, error) {
+	event := new(BunkerStakingRewardVested)
+	if err := _BunkerStaking.contract.UnpackLog(event, "RewardVested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingRewardsDurationUpdatedIterator is returned from FilterRewardsDurationUpdated and is used to iterate over the raw logs and unpacked data for RewardsDurationUpdated events raised by the BunkerStaking contract.
+type BunkerStakingRewardsDurationUpdatedIterator struct {
+	Event *BunkerStakingRewardsDurationUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingRewardsDurationUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingRewardsDurationUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingRewardsDurationUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingRewardsDurationUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingRewardsDurationUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingRewardsDurationUpdated represents a RewardsDurationUpdated event raised by the BunkerStaking contract.
+type BunkerStakingRewardsDurationUpdated struct {
+	NewDuration *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardsDurationUpdated is a free log retrieval operation binding the contract event 0xfb46ca5a5e06d4540d6387b930a7c978bce0db5f449ec6b3f5d07c6e1d44f2d3.
+//
+// Solidity: event RewardsDurationUpdated(uint256 newDuration)
+func (_BunkerStaking *BunkerStakingFilterer) FilterRewardsDurationUpdated(opts *bind.FilterOpts) (*BunkerStakingRewardsDurationUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "RewardsDurationUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingRewardsDurationUpdatedIterator{contract: _BunkerStaking.contract, event: "RewardsDurationUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardsDurationUpdated is a free log subscription operation binding the contract event 0xfb46ca5a5e06d4540d6387b930a7c978bce0db5f449ec6b3f5d07c6e1d44f2d3.
+//
+// Solidity: event RewardsDurationUpdated(uint256 newDuration)
+func (_BunkerStaking *BunkerStakingFilterer) WatchRewardsDurationUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingRewardsDurationUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "RewardsDurationUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingRewardsDurationUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "RewardsDurationUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardsDurationUpdated is a log parse operation binding the contract event 0xfb46ca5a5e06d4540d6387b930a7c978bce0db5f449ec6b3f5d07c6e1d44f2d3.
+//
+// Solidity: event RewardsDurationUpdated(uint256 newDuration)
+func (_BunkerStaking *BunkerStakingFilterer) ParseRewardsDurationUpdated(log types.Log) (*BunkerStakingRewardsDurationUpdated, error) {
+	event := new(BunkerStakingRewardsDurationUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "RewardsDurationUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the BunkerStaking contract.
+type BunkerStakingRoleAdminChangedIterator struct {
+	Event *BunkerStakingRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingRoleAdminChanged represents a RoleAdminChanged event raised by the BunkerStaking contract.
+type BunkerStakingRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerStaking *BunkerStakingFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*BunkerStakingRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingRoleAdminChangedIterator{contract: _BunkerStaking.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerStaking *BunkerStakingFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *BunkerStakingRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingRoleAdminChanged)
+				if err := _BunkerStaking.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerStaking *BunkerStakingFilterer) ParseRoleAdminChanged(log types.Log) (*BunkerStakingRoleAdminChanged, error) {
+	event := new(BunkerStakingRoleAdminChanged)
+	if err := _BunkerStaking.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the BunkerStaking contract.
+type BunkerStakingRoleGrantedIterator struct {
+	Event *BunkerStakingRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingRoleGranted represents a RoleGranted event raised by the BunkerStaking contract.
+type BunkerStakingRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerStaking *BunkerStakingFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BunkerStakingRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingRoleGrantedIterator{contract: _BunkerStaking.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerStaking *BunkerStakingFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *BunkerStakingRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingRoleGranted)
+				if err := _BunkerStaking.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerStaking *BunkerStakingFilterer) ParseRoleGranted(log types.Log) (*BunkerStakingRoleGranted, error) {
+	event := new(BunkerStakingRoleGranted)
+	if err := _BunkerStaking.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the BunkerStaking contract.
+type BunkerStakingRoleRevokedIterator struct {
+	Event *BunkerStakingRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingRoleRevoked represents a RoleRevoked event raised by the BunkerStaking contract.
+type BunkerStakingRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerStaking *BunkerStakingFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BunkerStakingRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingRoleRevokedIterator{contract: _BunkerStaking.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerStaking *BunkerStakingFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *BunkerStakingRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingRoleRevoked)
+				if err := _BunkerStaking.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerStaking *BunkerStakingFilterer) ParseRoleRevoked(log types.Log) (*BunkerStakingRoleRevoked, error) {
+	event := new(BunkerStakingRoleRevoked)
+	if err := _BunkerStaking.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingSlashAppealedIterator is returned from FilterSlashAppealed and is used to iterate over the raw logs and unpacked data for SlashAppealed events raised by the BunkerStaking contract.
+type BunkerStakingSlashAppealedIterator struct {
+	Event *BunkerStakingSlashAppealed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingSlashAppealedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingSlashAppealed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingSlashAppealed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingSlashAppealedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingSlashAppealedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingSlashAppealed represents a SlashAppealed event raised by the BunkerStaking contract.
+type BunkerStakingSlashAppealed struct {
+	ProposalId *big.Int
+	Provider   common.Address
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashAppealed is a free log retrieval operation binding the contract event 0xbd0352ee5139a1b683bb023cc369fd06666afe06da9100507190d7dea2d85e6f.
+//
+// Solidity: event SlashAppealed(uint256 indexed proposalId, address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) FilterSlashAppealed(opts *bind.FilterOpts, proposalId []*big.Int, provider []common.Address) (*BunkerStakingSlashAppealedIterator, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "SlashAppealed", proposalIdRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingSlashAppealedIterator{contract: _BunkerStaking.contract, event: "SlashAppealed", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashAppealed is a free log subscription operation binding the contract event 0xbd0352ee5139a1b683bb023cc369fd06666afe06da9100507190d7dea2d85e6f.
+//
+// Solidity: event SlashAppealed(uint256 indexed proposalId, address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) WatchSlashAppealed(opts *bind.WatchOpts, sink chan<- *BunkerStakingSlashAppealed, proposalId []*big.Int, provider []common.Address) (event.Subscription, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "SlashAppealed", proposalIdRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingSlashAppealed)
+				if err := _BunkerStaking.contract.UnpackLog(event, "SlashAppealed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashAppealed is a log parse operation binding the contract event 0xbd0352ee5139a1b683bb023cc369fd06666afe06da9100507190d7dea2d85e6f.
+//
+// Solidity: event SlashAppealed(uint256 indexed proposalId, address indexed provider)
+func (_BunkerStaking *BunkerStakingFilterer) ParseSlashAppealed(log types.Log) (*BunkerStakingSlashAppealed, error) {
+	event := new(BunkerStakingSlashAppealed)
+	if err := _BunkerStaking.contract.UnpackLog(event, "SlashAppealed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingSlashFeeSplitUpdatedIterator is returned from FilterSlashFeeSplitUpdated and is used to iterate over the raw logs and unpacked data for SlashFeeSplitUpdated events raised by the BunkerStaking contract.
+type BunkerStakingSlashFeeSplitUpdatedIterator struct {
+	Event *BunkerStakingSlashFeeSplitUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingSlashFeeSplitUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingSlashFeeSplitUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingSlashFeeSplitUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingSlashFeeSplitUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingSlashFeeSplitUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingSlashFeeSplitUpdated represents a SlashFeeSplitUpdated event raised by the BunkerStaking contract.
+type BunkerStakingSlashFeeSplitUpdated struct {
+	BurnBps     uint16
+	TreasuryBps uint16
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashFeeSplitUpdated is a free log retrieval operation binding the contract event 0x15b73021de90b6b84357315508cf8ed811c03180d19a0b761081c55467dab9ea.
+//
+// Solidity: event SlashFeeSplitUpdated(uint16 burnBps, uint16 treasuryBps)
+func (_BunkerStaking *BunkerStakingFilterer) FilterSlashFeeSplitUpdated(opts *bind.FilterOpts) (*BunkerStakingSlashFeeSplitUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "SlashFeeSplitUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingSlashFeeSplitUpdatedIterator{contract: _BunkerStaking.contract, event: "SlashFeeSplitUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashFeeSplitUpdated is a free log subscription operation binding the contract event 0x15b73021de90b6b84357315508cf8ed811c03180d19a0b761081c55467dab9ea.
+//
+// Solidity: event SlashFeeSplitUpdated(uint16 burnBps, uint16 treasuryBps)
+func (_BunkerStaking *BunkerStakingFilterer) WatchSlashFeeSplitUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingSlashFeeSplitUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "SlashFeeSplitUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingSlashFeeSplitUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "SlashFeeSplitUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashFeeSplitUpdated is a log parse operation binding the contract event 0x15b73021de90b6b84357315508cf8ed811c03180d19a0b761081c55467dab9ea.
+//
+// Solidity: event SlashFeeSplitUpdated(uint16 burnBps, uint16 treasuryBps)
+func (_BunkerStaking *BunkerStakingFilterer) ParseSlashFeeSplitUpdated(log types.Log) (*BunkerStakingSlashFeeSplitUpdated, error) {
+	event := new(BunkerStakingSlashFeeSplitUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "SlashFeeSplitUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingSlashPercentageUpdatedIterator is returned from FilterSlashPercentageUpdated and is used to iterate over the raw logs and unpacked data for SlashPercentageUpdated events raised by the BunkerStaking contract.
+type BunkerStakingSlashPercentageUpdatedIterator struct {
+	Event *BunkerStakingSlashPercentageUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingSlashPercentageUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingSlashPercentageUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingSlashPercentageUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingSlashPercentageUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingSlashPercentageUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingSlashPercentageUpdated represents a SlashPercentageUpdated event raised by the BunkerStaking contract.
+type BunkerStakingSlashPercentageUpdated struct {
+	Reason uint8
+	Bps    uint16
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashPercentageUpdated is a free log retrieval operation binding the contract event 0xd9f07f2676b0b065e4321fe7215b8a66130f4a15cd8a0b9583429ad3c41cc63c.
+//
+// Solidity: event SlashPercentageUpdated(uint8 indexed reason, uint16 bps)
+func (_BunkerStaking *BunkerStakingFilterer) FilterSlashPercentageUpdated(opts *bind.FilterOpts, reason []uint8) (*BunkerStakingSlashPercentageUpdatedIterator, error) {
+
+	var reasonRule []interface{}
+	for _, reasonItem := range reason {
+		reasonRule = append(reasonRule, reasonItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "SlashPercentageUpdated", reasonRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingSlashPercentageUpdatedIterator{contract: _BunkerStaking.contract, event: "SlashPercentageUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashPercentageUpdated is a free log subscription operation binding the contract event 0xd9f07f2676b0b065e4321fe7215b8a66130f4a15cd8a0b9583429ad3c41cc63c.
+//
+// Solidity: event SlashPercentageUpdated(uint8 indexed reason, uint16 bps)
+func (_BunkerStaking *BunkerStakingFilterer) WatchSlashPercentageUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingSlashPercentageUpdated, reason []uint8) (event.Subscription, error) {
+
+	var reasonRule []interface{}
+	for _, reasonItem := range reason {
+		reasonRule = append(reasonRule, reasonItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "SlashPercentageUpdated", reasonRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingSlashPercentageUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "SlashPercentageUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashPercentageUpdated is a log parse operation binding the contract event 0xd9f07f2676b0b065e4321fe7215b8a66130f4a15cd8a0b9583429ad3c41cc63c.
+//
+// Solidity: event SlashPercentageUpdated(uint8 indexed reason, uint16 bps)
+func (_BunkerStaking *BunkerStakingFilterer) ParseSlashPercentageUpdated(log types.Log) (*BunkerStakingSlashPercentageUpdated, error) {
+	event := new(BunkerStakingSlashPercentageUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "SlashPercentageUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingSlashProposalExecutedIterator is returned from FilterSlashProposalExecuted and is used to iterate over the raw logs and unpacked data for SlashProposalExecuted events raised by the BunkerStaking contract.
+type BunkerStakingSlashProposalExecutedIterator struct {
+	Event *BunkerStakingSlashProposalExecuted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingSlashProposalExecutedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingSlashProposalExecuted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingSlashProposalExecuted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingSlashProposalExecutedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingSlashProposalExecutedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingSlashProposalExecuted represents a SlashProposalExecuted event raised by the BunkerStaking contract.
+type BunkerStakingSlashProposalExecuted struct {
+	ProposalId *big.Int
+	Provider   common.Address
+	Amount     *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashProposalExecuted is a free log retrieval operation binding the contract event 0x918b19ebaa57b40a3d5b3863d0d0d8697941812ac1e24e08f1226af6c441b0c4.
+//
+// Solidity: event SlashProposalExecuted(uint256 indexed proposalId, address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) FilterSlashProposalExecuted(opts *bind.FilterOpts, proposalId []*big.Int, provider []common.Address) (*BunkerStakingSlashProposalExecutedIterator, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "SlashProposalExecuted", proposalIdRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingSlashProposalExecutedIterator{contract: _BunkerStaking.contract, event: "SlashProposalExecuted", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashProposalExecuted is a free log subscription operation binding the contract event 0x918b19ebaa57b40a3d5b3863d0d0d8697941812ac1e24e08f1226af6c441b0c4.
+//
+// Solidity: event SlashProposalExecuted(uint256 indexed proposalId, address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) WatchSlashProposalExecuted(opts *bind.WatchOpts, sink chan<- *BunkerStakingSlashProposalExecuted, proposalId []*big.Int, provider []common.Address) (event.Subscription, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "SlashProposalExecuted", proposalIdRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingSlashProposalExecuted)
+				if err := _BunkerStaking.contract.UnpackLog(event, "SlashProposalExecuted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashProposalExecuted is a log parse operation binding the contract event 0x918b19ebaa57b40a3d5b3863d0d0d8697941812ac1e24e08f1226af6c441b0c4.
+//
+// Solidity: event SlashProposalExecuted(uint256 indexed proposalId, address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) ParseSlashProposalExecuted(log types.Log) (*BunkerStakingSlashProposalExecuted, error) {
+	event := new(BunkerStakingSlashProposalExecuted)
+	if err := _BunkerStaking.contract.UnpackLog(event, "SlashProposalExecuted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingSlashProposedIterator is returned from FilterSlashProposed and is used to iterate over the raw logs and unpacked data for SlashProposed events raised by the BunkerStaking contract.
+type BunkerStakingSlashProposedIterator struct {
+	Event *BunkerStakingSlashProposed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingSlashProposedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingSlashProposed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingSlashProposed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingSlashProposedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingSlashProposedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingSlashProposed represents a SlashProposed event raised by the BunkerStaking contract.
+type BunkerStakingSlashProposed struct {
+	ProposalId *big.Int
+	Provider   common.Address
+	Amount     *big.Int
+	Reason     string
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashProposed is a free log retrieval operation binding the contract event 0xf9a4da41e5e2e24a83fa7b480cb6c8c275cf2bac4a62d7a085a42eb5f18fdf91.
+//
+// Solidity: event SlashProposed(uint256 indexed proposalId, address indexed provider, uint256 amount, string reason)
+func (_BunkerStaking *BunkerStakingFilterer) FilterSlashProposed(opts *bind.FilterOpts, proposalId []*big.Int, provider []common.Address) (*BunkerStakingSlashProposedIterator, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "SlashProposed", proposalIdRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingSlashProposedIterator{contract: _BunkerStaking.contract, event: "SlashProposed", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashProposed is a free log subscription operation binding the contract event 0xf9a4da41e5e2e24a83fa7b480cb6c8c275cf2bac4a62d7a085a42eb5f18fdf91.
+//
+// Solidity: event SlashProposed(uint256 indexed proposalId, address indexed provider, uint256 amount, string reason)
+func (_BunkerStaking *BunkerStakingFilterer) WatchSlashProposed(opts *bind.WatchOpts, sink chan<- *BunkerStakingSlashProposed, proposalId []*big.Int, provider []common.Address) (event.Subscription, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "SlashProposed", proposalIdRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingSlashProposed)
+				if err := _BunkerStaking.contract.UnpackLog(event, "SlashProposed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashProposed is a log parse operation binding the contract event 0xf9a4da41e5e2e24a83fa7b480cb6c8c275cf2bac4a62d7a085a42eb5f18fdf91.
+//
+// Solidity: event SlashProposed(uint256 indexed proposalId, address indexed provider, uint256 amount, string reason)
+func (_BunkerStaking *BunkerStakingFilterer) ParseSlashProposed(log types.Log) (*BunkerStakingSlashProposed, error) {
+	event := new(BunkerStakingSlashProposed)
+	if err := _BunkerStaking.contract.UnpackLog(event, "SlashProposed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingSlashProposedByReasonIterator is returned from FilterSlashProposedByReason and is used to iterate over the raw logs and unpacked data for SlashProposedByReason events raised by the BunkerStaking contract.
+type BunkerStakingSlashProposedByReasonIterator struct {
+	Event *BunkerStakingSlashProposedByReason // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingSlashProposedByReasonIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingSlashProposedByReason)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingSlashProposedByReason)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingSlashProposedByReasonIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingSlashProposedByReasonIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingSlashProposedByReason represents a SlashProposedByReason event raised by the BunkerStaking contract.
+type BunkerStakingSlashProposedByReason struct {
+	ProposalId *big.Int
+	Provider   common.Address
+	Amount     *big.Int
+	Reason     uint8
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashProposedByReason is a free log retrieval operation binding the contract event 0xadfef744d6013ba990154f6243ea13ab87ec3400c8d78d9186ca1b19c376fd3f.
+//
+// Solidity: event SlashProposedByReason(uint256 indexed proposalId, address indexed provider, uint256 amount, uint8 reason)
+func (_BunkerStaking *BunkerStakingFilterer) FilterSlashProposedByReason(opts *bind.FilterOpts, proposalId []*big.Int, provider []common.Address) (*BunkerStakingSlashProposedByReasonIterator, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "SlashProposedByReason", proposalIdRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingSlashProposedByReasonIterator{contract: _BunkerStaking.contract, event: "SlashProposedByReason", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashProposedByReason is a free log subscription operation binding the contract event 0xadfef744d6013ba990154f6243ea13ab87ec3400c8d78d9186ca1b19c376fd3f.
+//
+// Solidity: event SlashProposedByReason(uint256 indexed proposalId, address indexed provider, uint256 amount, uint8 reason)
+func (_BunkerStaking *BunkerStakingFilterer) WatchSlashProposedByReason(opts *bind.WatchOpts, sink chan<- *BunkerStakingSlashProposedByReason, proposalId []*big.Int, provider []common.Address) (event.Subscription, error) {
+
+	var proposalIdRule []interface{}
+	for _, proposalIdItem := range proposalId {
+		proposalIdRule = append(proposalIdRule, proposalIdItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "SlashProposedByReason", proposalIdRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingSlashProposedByReason)
+				if err := _BunkerStaking.contract.UnpackLog(event, "SlashProposedByReason", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashProposedByReason is a log parse operation binding the contract event 0xadfef744d6013ba990154f6243ea13ab87ec3400c8d78d9186ca1b19c376fd3f.
+//
+// Solidity: event SlashProposedByReason(uint256 indexed proposalId, address indexed provider, uint256 amount, uint8 reason)
+func (_BunkerStaking *BunkerStakingFilterer) ParseSlashProposedByReason(log types.Log) (*BunkerStakingSlashProposedByReason, error) {
+	event := new(BunkerStakingSlashProposedByReason)
+	if err := _BunkerStaking.contract.UnpackLog(event, "SlashProposedByReason", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingSlashedIterator is returned from FilterSlashed and is used to iterate over the raw logs and unpacked data for Slashed events raised by the BunkerStaking contract.
+type BunkerStakingSlashedIterator struct {
+	Event *BunkerStakingSlashed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingSlashedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingSlashed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingSlashed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingSlashedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingSlashedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingSlashed represents a Slashed event raised by the BunkerStaking contract.
+type BunkerStakingSlashed struct {
+	Provider       common.Address
+	TotalSlashed   *big.Int
+	BurnedAmount   *big.Int
+	TreasuryAmount *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashed is a free log retrieval operation binding the contract event 0x23ee33e2cc85d581547d857dc227450a3e2ef8666fa2faa5b13f0a0893e4d4ad.
+//
+// Solidity: event Slashed(address indexed provider, uint256 totalSlashed, uint256 burnedAmount, uint256 treasuryAmount)
+func (_BunkerStaking *BunkerStakingFilterer) FilterSlashed(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingSlashedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "Slashed", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingSlashedIterator{contract: _BunkerStaking.contract, event: "Slashed", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashed is a free log subscription operation binding the contract event 0x23ee33e2cc85d581547d857dc227450a3e2ef8666fa2faa5b13f0a0893e4d4ad.
+//
+// Solidity: event Slashed(address indexed provider, uint256 totalSlashed, uint256 burnedAmount, uint256 treasuryAmount)
+func (_BunkerStaking *BunkerStakingFilterer) WatchSlashed(opts *bind.WatchOpts, sink chan<- *BunkerStakingSlashed, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "Slashed", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingSlashed)
+				if err := _BunkerStaking.contract.UnpackLog(event, "Slashed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashed is a log parse operation binding the contract event 0x23ee33e2cc85d581547d857dc227450a3e2ef8666fa2faa5b13f0a0893e4d4ad.
+//
+// Solidity: event Slashed(address indexed provider, uint256 totalSlashed, uint256 burnedAmount, uint256 treasuryAmount)
+func (_BunkerStaking *BunkerStakingFilterer) ParseSlashed(log types.Log) (*BunkerStakingSlashed, error) {
+	event := new(BunkerStakingSlashed)
+	if err := _BunkerStaking.contract.UnpackLog(event, "Slashed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingSlashingEnabledUpdatedIterator is returned from FilterSlashingEnabledUpdated and is used to iterate over the raw logs and unpacked data for SlashingEnabledUpdated events raised by the BunkerStaking contract.
+type BunkerStakingSlashingEnabledUpdatedIterator struct {
+	Event *BunkerStakingSlashingEnabledUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingSlashingEnabledUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingSlashingEnabledUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingSlashingEnabledUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingSlashingEnabledUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingSlashingEnabledUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingSlashingEnabledUpdated represents a SlashingEnabledUpdated event raised by the BunkerStaking contract.
+type BunkerStakingSlashingEnabledUpdated struct {
+	Enabled bool
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterSlashingEnabledUpdated is a free log retrieval operation binding the contract event 0xc3ef19d6884f0eda58a206cc3949f40500fd0e290ba63d4448dd37c491b606f8.
+//
+// Solidity: event SlashingEnabledUpdated(bool enabled)
+func (_BunkerStaking *BunkerStakingFilterer) FilterSlashingEnabledUpdated(opts *bind.FilterOpts) (*BunkerStakingSlashingEnabledUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "SlashingEnabledUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingSlashingEnabledUpdatedIterator{contract: _BunkerStaking.contract, event: "SlashingEnabledUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchSlashingEnabledUpdated is a free log subscription operation binding the contract event 0xc3ef19d6884f0eda58a206cc3949f40500fd0e290ba63d4448dd37c491b606f8.
+//
+// Solidity: event SlashingEnabledUpdated(bool enabled)
+func (_BunkerStaking *BunkerStakingFilterer) WatchSlashingEnabledUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingSlashingEnabledUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "SlashingEnabledUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingSlashingEnabledUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "SlashingEnabledUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSlashingEnabledUpdated is a log parse operation binding the contract event 0xc3ef19d6884f0eda58a206cc3949f40500fd0e290ba63d4448dd37c491b606f8.
+//
+// Solidity: event SlashingEnabledUpdated(bool enabled)
+func (_BunkerStaking *BunkerStakingFilterer) ParseSlashingEnabledUpdated(log types.Log) (*BunkerStakingSlashingEnabledUpdated, error) {
+	event := new(BunkerStakingSlashingEnabledUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "SlashingEnabledUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingStakedIterator is returned from FilterStaked and is used to iterate over the raw logs and unpacked data for Staked events raised by the BunkerStaking contract.
+type BunkerStakingStakedIterator struct {
+	Event *BunkerStakingStaked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingStakedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingStaked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingStaked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingStakedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingStakedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingStaked represents a Staked event raised by the BunkerStaking contract.
+type BunkerStakingStaked struct {
+	Provider   common.Address
+	Amount     *big.Int
+	TotalStake *big.Int
+	Tier       uint8
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterStaked is a free log retrieval operation binding the contract event 0x11046f741396910185536955c79ec22a76d04229d188bc13962f8331b81008a9.
+//
+// Solidity: event Staked(address indexed provider, uint256 amount, uint256 totalStake, uint8 tier)
+func (_BunkerStaking *BunkerStakingFilterer) FilterStaked(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingStakedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "Staked", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingStakedIterator{contract: _BunkerStaking.contract, event: "Staked", logs: logs, sub: sub}, nil
+}
+
+// WatchStaked is a free log subscription operation binding the contract event 0x11046f741396910185536955c79ec22a76d04229d188bc13962f8331b81008a9.
+//
+// Solidity: event Staked(address indexed provider, uint256 amount, uint256 totalStake, uint8 tier)
+func (_BunkerStaking *BunkerStakingFilterer) WatchStaked(opts *bind.WatchOpts, sink chan<- *BunkerStakingStaked, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "Staked", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingStaked)
+				if err := _BunkerStaking.contract.UnpackLog(event, "Staked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStaked is a log parse operation binding the contract event 0x11046f741396910185536955c79ec22a76d04229d188bc13962f8331b81008a9.
+//
+// Solidity: event Staked(address indexed provider, uint256 amount, uint256 totalStake, uint8 tier)
+func (_BunkerStaking *BunkerStakingFilterer) ParseStaked(log types.Log) (*BunkerStakingStaked, error) {
+	event := new(BunkerStakingStaked)
+	if err := _BunkerStaking.contract.UnpackLog(event, "Staked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingTierConfigUpdatedIterator is returned from FilterTierConfigUpdated and is used to iterate over the raw logs and unpacked data for TierConfigUpdated events raised by the BunkerStaking contract.
+type BunkerStakingTierConfigUpdatedIterator struct {
+	Event *BunkerStakingTierConfigUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingTierConfigUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingTierConfigUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingTierConfigUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingTierConfigUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingTierConfigUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingTierConfigUpdated represents a TierConfigUpdated event raised by the BunkerStaking contract.
+type BunkerStakingTierConfigUpdated struct {
+	Tier     uint8
+	MinStake *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterTierConfigUpdated is a free log retrieval operation binding the contract event 0x058e74ecb6b959ca816a971cf6a85ecc6cb00effd98a67f02478c7fe3d40ec67.
+//
+// Solidity: event TierConfigUpdated(uint8 indexed tier, uint256 minStake)
+func (_BunkerStaking *BunkerStakingFilterer) FilterTierConfigUpdated(opts *bind.FilterOpts, tier []uint8) (*BunkerStakingTierConfigUpdatedIterator, error) {
+
+	var tierRule []interface{}
+	for _, tierItem := range tier {
+		tierRule = append(tierRule, tierItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "TierConfigUpdated", tierRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingTierConfigUpdatedIterator{contract: _BunkerStaking.contract, event: "TierConfigUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchTierConfigUpdated is a free log subscription operation binding the contract event 0x058e74ecb6b959ca816a971cf6a85ecc6cb00effd98a67f02478c7fe3d40ec67.
+//
+// Solidity: event TierConfigUpdated(uint8 indexed tier, uint256 minStake)
+func (_BunkerStaking *BunkerStakingFilterer) WatchTierConfigUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingTierConfigUpdated, tier []uint8) (event.Subscription, error) {
+
+	var tierRule []interface{}
+	for _, tierItem := range tier {
+		tierRule = append(tierRule, tierItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "TierConfigUpdated", tierRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingTierConfigUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "TierConfigUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTierConfigUpdated is a log parse operation binding the contract event 0x058e74ecb6b959ca816a971cf6a85ecc6cb00effd98a67f02478c7fe3d40ec67.
+//
+// Solidity: event TierConfigUpdated(uint8 indexed tier, uint256 minStake)
+func (_BunkerStaking *BunkerStakingFilterer) ParseTierConfigUpdated(log types.Log) (*BunkerStakingTierConfigUpdated, error) {
+	event := new(BunkerStakingTierConfigUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "TierConfigUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingTierRewardMultiplierUpdatedIterator is returned from FilterTierRewardMultiplierUpdated and is used to iterate over the raw logs and unpacked data for TierRewardMultiplierUpdated events raised by the BunkerStaking contract.
+type BunkerStakingTierRewardMultiplierUpdatedIterator struct {
+	Event *BunkerStakingTierRewardMultiplierUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingTierRewardMultiplierUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingTierRewardMultiplierUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingTierRewardMultiplierUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingTierRewardMultiplierUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingTierRewardMultiplierUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingTierRewardMultiplierUpdated represents a TierRewardMultiplierUpdated event raised by the BunkerStaking contract.
+type BunkerStakingTierRewardMultiplierUpdated struct {
+	Tier          uint8
+	MultiplierBps uint16
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterTierRewardMultiplierUpdated is a free log retrieval operation binding the contract event 0x3ddbe19f2e67fb27e670a8e6970e56ed4fc0969de981bcfc91ef749b8a5143f8.
+//
+// Solidity: event TierRewardMultiplierUpdated(uint8 indexed tier, uint16 multiplierBps)
+func (_BunkerStaking *BunkerStakingFilterer) FilterTierRewardMultiplierUpdated(opts *bind.FilterOpts, tier []uint8) (*BunkerStakingTierRewardMultiplierUpdatedIterator, error) {
+
+	var tierRule []interface{}
+	for _, tierItem := range tier {
+		tierRule = append(tierRule, tierItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "TierRewardMultiplierUpdated", tierRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingTierRewardMultiplierUpdatedIterator{contract: _BunkerStaking.contract, event: "TierRewardMultiplierUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchTierRewardMultiplierUpdated is a free log subscription operation binding the contract event 0x3ddbe19f2e67fb27e670a8e6970e56ed4fc0969de981bcfc91ef749b8a5143f8.
+//
+// Solidity: event TierRewardMultiplierUpdated(uint8 indexed tier, uint16 multiplierBps)
+func (_BunkerStaking *BunkerStakingFilterer) WatchTierRewardMultiplierUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingTierRewardMultiplierUpdated, tier []uint8) (event.Subscription, error) {
+
+	var tierRule []interface{}
+	for _, tierItem := range tier {
+		tierRule = append(tierRule, tierItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "TierRewardMultiplierUpdated", tierRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingTierRewardMultiplierUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "TierRewardMultiplierUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTierRewardMultiplierUpdated is a log parse operation binding the contract event 0x3ddbe19f2e67fb27e670a8e6970e56ed4fc0969de981bcfc91ef749b8a5143f8.
+//
+// Solidity: event TierRewardMultiplierUpdated(uint8 indexed tier, uint16 multiplierBps)
+func (_BunkerStaking *BunkerStakingFilterer) ParseTierRewardMultiplierUpdated(log types.Log) (*BunkerStakingTierRewardMultiplierUpdated, error) {
+	event := new(BunkerStakingTierRewardMultiplierUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "TierRewardMultiplierUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingTreasuryUpdatedIterator is returned from FilterTreasuryUpdated and is used to iterate over the raw logs and unpacked data for TreasuryUpdated events raised by the BunkerStaking contract.
+type BunkerStakingTreasuryUpdatedIterator struct {
+	Event *BunkerStakingTreasuryUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingTreasuryUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingTreasuryUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingTreasuryUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingTreasuryUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingTreasuryUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingTreasuryUpdated represents a TreasuryUpdated event raised by the BunkerStaking contract.
+type BunkerStakingTreasuryUpdated struct {
+	OldTreasury common.Address
+	NewTreasury common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterTreasuryUpdated is a free log retrieval operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_BunkerStaking *BunkerStakingFilterer) FilterTreasuryUpdated(opts *bind.FilterOpts, oldTreasury []common.Address, newTreasury []common.Address) (*BunkerStakingTreasuryUpdatedIterator, error) {
+
+	var oldTreasuryRule []interface{}
+	for _, oldTreasuryItem := range oldTreasury {
+		oldTreasuryRule = append(oldTreasuryRule, oldTreasuryItem)
+	}
+	var newTreasuryRule []interface{}
+	for _, newTreasuryItem := range newTreasury {
+		newTreasuryRule = append(newTreasuryRule, newTreasuryItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "TreasuryUpdated", oldTreasuryRule, newTreasuryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingTreasuryUpdatedIterator{contract: _BunkerStaking.contract, event: "TreasuryUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchTreasuryUpdated is a free log subscription operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_BunkerStaking *BunkerStakingFilterer) WatchTreasuryUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingTreasuryUpdated, oldTreasury []common.Address, newTreasury []common.Address) (event.Subscription, error) {
+
+	var oldTreasuryRule []interface{}
+	for _, oldTreasuryItem := range oldTreasury {
+		oldTreasuryRule = append(oldTreasuryRule, oldTreasuryItem)
+	}
+	var newTreasuryRule []interface{}
+	for _, newTreasuryItem := range newTreasury {
+		newTreasuryRule = append(newTreasuryRule, newTreasuryItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "TreasuryUpdated", oldTreasuryRule, newTreasuryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingTreasuryUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "TreasuryUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTreasuryUpdated is a log parse operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_BunkerStaking *BunkerStakingFilterer) ParseTreasuryUpdated(log types.Log) (*BunkerStakingTreasuryUpdated, error) {
+	event := new(BunkerStakingTreasuryUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "TreasuryUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingUnbondingPeriodUpdatedIterator is returned from FilterUnbondingPeriodUpdated and is used to iterate over the raw logs and unpacked data for UnbondingPeriodUpdated events raised by the BunkerStaking contract.
+type BunkerStakingUnbondingPeriodUpdatedIterator struct {
+	Event *BunkerStakingUnbondingPeriodUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingUnbondingPeriodUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingUnbondingPeriodUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingUnbondingPeriodUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingUnbondingPeriodUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingUnbondingPeriodUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingUnbondingPeriodUpdated represents a UnbondingPeriodUpdated event raised by the BunkerStaking contract.
+type BunkerStakingUnbondingPeriodUpdated struct {
+	NewPeriod *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnbondingPeriodUpdated is a free log retrieval operation binding the contract event 0x38a1644f59872db6fd17fdced395495fcaa3ca7d2825a0704db5a3acbd1dd064.
+//
+// Solidity: event UnbondingPeriodUpdated(uint256 newPeriod)
+func (_BunkerStaking *BunkerStakingFilterer) FilterUnbondingPeriodUpdated(opts *bind.FilterOpts) (*BunkerStakingUnbondingPeriodUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "UnbondingPeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingUnbondingPeriodUpdatedIterator{contract: _BunkerStaking.contract, event: "UnbondingPeriodUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchUnbondingPeriodUpdated is a free log subscription operation binding the contract event 0x38a1644f59872db6fd17fdced395495fcaa3ca7d2825a0704db5a3acbd1dd064.
+//
+// Solidity: event UnbondingPeriodUpdated(uint256 newPeriod)
+func (_BunkerStaking *BunkerStakingFilterer) WatchUnbondingPeriodUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingUnbondingPeriodUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "UnbondingPeriodUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingUnbondingPeriodUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "UnbondingPeriodUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnbondingPeriodUpdated is a log parse operation binding the contract event 0x38a1644f59872db6fd17fdced395495fcaa3ca7d2825a0704db5a3acbd1dd064.
+//
+// Solidity: event UnbondingPeriodUpdated(uint256 newPeriod)
+func (_BunkerStaking *BunkerStakingFilterer) ParseUnbondingPeriodUpdated(log types.Log) (*BunkerStakingUnbondingPeriodUpdated, error) {
+	event := new(BunkerStakingUnbondingPeriodUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "UnbondingPeriodUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the BunkerStaking contract.
+type BunkerStakingUnpausedIterator struct {
+	Event *BunkerStakingUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingUnpaused represents a Unpaused event raised by the BunkerStaking contract.
+type BunkerStakingUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerStaking *BunkerStakingFilterer) FilterUnpaused(opts *bind.FilterOpts) (*BunkerStakingUnpausedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingUnpausedIterator{contract: _BunkerStaking.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerStaking *BunkerStakingFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *BunkerStakingUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingUnpaused)
+				if err := _BunkerStaking.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_BunkerStaking *BunkerStakingFilterer) ParseUnpaused(log types.Log) (*BunkerStakingUnpaused, error) {
+	event := new(BunkerStakingUnpaused)
+	if err := _BunkerStaking.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingUnstakeCompletedIterator is returned from FilterUnstakeCompleted and is used to iterate over the raw logs and unpacked data for UnstakeCompleted events raised by the BunkerStaking contract.
+type BunkerStakingUnstakeCompletedIterator struct {
+	Event *BunkerStakingUnstakeCompleted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingUnstakeCompletedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingUnstakeCompleted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingUnstakeCompleted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingUnstakeCompletedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingUnstakeCompletedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingUnstakeCompleted represents a UnstakeCompleted event raised by the BunkerStaking contract.
+type BunkerStakingUnstakeCompleted struct {
+	Provider     common.Address
+	Amount       *big.Int
+	RequestIndex *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnstakeCompleted is a free log retrieval operation binding the contract event 0xe8cf66c4a1bfe34e4e2e2af0a72f79d3482978050d726564ff9d2e4220835d63.
+//
+// Solidity: event UnstakeCompleted(address indexed provider, uint256 amount, uint256 requestIndex)
+func (_BunkerStaking *BunkerStakingFilterer) FilterUnstakeCompleted(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingUnstakeCompletedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "UnstakeCompleted", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingUnstakeCompletedIterator{contract: _BunkerStaking.contract, event: "UnstakeCompleted", logs: logs, sub: sub}, nil
+}
+
+// WatchUnstakeCompleted is a free log subscription operation binding the contract event 0xe8cf66c4a1bfe34e4e2e2af0a72f79d3482978050d726564ff9d2e4220835d63.
+//
+// Solidity: event UnstakeCompleted(address indexed provider, uint256 amount, uint256 requestIndex)
+func (_BunkerStaking *BunkerStakingFilterer) WatchUnstakeCompleted(opts *bind.WatchOpts, sink chan<- *BunkerStakingUnstakeCompleted, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "UnstakeCompleted", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingUnstakeCompleted)
+				if err := _BunkerStaking.contract.UnpackLog(event, "UnstakeCompleted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnstakeCompleted is a log parse operation binding the contract event 0xe8cf66c4a1bfe34e4e2e2af0a72f79d3482978050d726564ff9d2e4220835d63.
+//
+// Solidity: event UnstakeCompleted(address indexed provider, uint256 amount, uint256 requestIndex)
+func (_BunkerStaking *BunkerStakingFilterer) ParseUnstakeCompleted(log types.Log) (*BunkerStakingUnstakeCompleted, error) {
+	event := new(BunkerStakingUnstakeCompleted)
+	if err := _BunkerStaking.contract.UnpackLog(event, "UnstakeCompleted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingUnstakeRequestedIterator is returned from FilterUnstakeRequested and is used to iterate over the raw logs and unpacked data for UnstakeRequested events raised by the BunkerStaking contract.
+type BunkerStakingUnstakeRequestedIterator struct {
+	Event *BunkerStakingUnstakeRequested // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingUnstakeRequestedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingUnstakeRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingUnstakeRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingUnstakeRequestedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingUnstakeRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingUnstakeRequested represents a UnstakeRequested event raised by the BunkerStaking contract.
+type BunkerStakingUnstakeRequested struct {
+	Provider     common.Address
+	Amount       *big.Int
+	UnlockTime   *big.Int
+	RequestIndex *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnstakeRequested is a free log retrieval operation binding the contract event 0x6930caaa0f0843978bf16992d58b9fd54913ce2e45b8acdd34f5b44f95419db2.
+//
+// Solidity: event UnstakeRequested(address indexed provider, uint256 amount, uint256 unlockTime, uint256 requestIndex)
+func (_BunkerStaking *BunkerStakingFilterer) FilterUnstakeRequested(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingUnstakeRequestedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "UnstakeRequested", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingUnstakeRequestedIterator{contract: _BunkerStaking.contract, event: "UnstakeRequested", logs: logs, sub: sub}, nil
+}
+
+// WatchUnstakeRequested is a free log subscription operation binding the contract event 0x6930caaa0f0843978bf16992d58b9fd54913ce2e45b8acdd34f5b44f95419db2.
+//
+// Solidity: event UnstakeRequested(address indexed provider, uint256 amount, uint256 unlockTime, uint256 requestIndex)
+func (_BunkerStaking *BunkerStakingFilterer) WatchUnstakeRequested(opts *bind.WatchOpts, sink chan<- *BunkerStakingUnstakeRequested, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "UnstakeRequested", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingUnstakeRequested)
+				if err := _BunkerStaking.contract.UnpackLog(event, "UnstakeRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnstakeRequested is a log parse operation binding the contract event 0x6930caaa0f0843978bf16992d58b9fd54913ce2e45b8acdd34f5b44f95419db2.
+//
+// Solidity: event UnstakeRequested(address indexed provider, uint256 amount, uint256 unlockTime, uint256 requestIndex)
+func (_BunkerStaking *BunkerStakingFilterer) ParseUnstakeRequested(log types.Log) (*BunkerStakingUnstakeRequested, error) {
+	event := new(BunkerStakingUnstakeRequested)
+	if err := _BunkerStaking.contract.UnpackLog(event, "UnstakeRequested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingVestedRewardsClaimedIterator is returned from FilterVestedRewardsClaimed and is used to iterate over the raw logs and unpacked data for VestedRewardsClaimed events raised by the BunkerStaking contract.
+type BunkerStakingVestedRewardsClaimedIterator struct {
+	Event *BunkerStakingVestedRewardsClaimed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingVestedRewardsClaimedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingVestedRewardsClaimed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingVestedRewardsClaimed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingVestedRewardsClaimedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingVestedRewardsClaimedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingVestedRewardsClaimed represents a VestedRewardsClaimed event raised by the BunkerStaking contract.
+type BunkerStakingVestedRewardsClaimed struct {
+	Provider common.Address
+	Amount   *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterVestedRewardsClaimed is a free log retrieval operation binding the contract event 0xf295d7b1dc83525860d9a2626877f603a897f06bb6533c5a1ddffa679868dc98.
+//
+// Solidity: event VestedRewardsClaimed(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) FilterVestedRewardsClaimed(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingVestedRewardsClaimedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "VestedRewardsClaimed", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingVestedRewardsClaimedIterator{contract: _BunkerStaking.contract, event: "VestedRewardsClaimed", logs: logs, sub: sub}, nil
+}
+
+// WatchVestedRewardsClaimed is a free log subscription operation binding the contract event 0xf295d7b1dc83525860d9a2626877f603a897f06bb6533c5a1ddffa679868dc98.
+//
+// Solidity: event VestedRewardsClaimed(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) WatchVestedRewardsClaimed(opts *bind.WatchOpts, sink chan<- *BunkerStakingVestedRewardsClaimed, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "VestedRewardsClaimed", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingVestedRewardsClaimed)
+				if err := _BunkerStaking.contract.UnpackLog(event, "VestedRewardsClaimed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseVestedRewardsClaimed is a log parse operation binding the contract event 0xf295d7b1dc83525860d9a2626877f603a897f06bb6533c5a1ddffa679868dc98.
+//
+// Solidity: event VestedRewardsClaimed(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) ParseVestedRewardsClaimed(log types.Log) (*BunkerStakingVestedRewardsClaimed, error) {
+	event := new(BunkerStakingVestedRewardsClaimed)
+	if err := _BunkerStaking.contract.UnpackLog(event, "VestedRewardsClaimed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingVestedRewardsForfeitedIterator is returned from FilterVestedRewardsForfeited and is used to iterate over the raw logs and unpacked data for VestedRewardsForfeited events raised by the BunkerStaking contract.
+type BunkerStakingVestedRewardsForfeitedIterator struct {
+	Event *BunkerStakingVestedRewardsForfeited // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingVestedRewardsForfeitedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingVestedRewardsForfeited)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingVestedRewardsForfeited)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingVestedRewardsForfeitedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingVestedRewardsForfeitedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingVestedRewardsForfeited represents a VestedRewardsForfeited event raised by the BunkerStaking contract.
+type BunkerStakingVestedRewardsForfeited struct {
+	Provider common.Address
+	Amount   *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterVestedRewardsForfeited is a free log retrieval operation binding the contract event 0xec349f79d94fe65197ec13d98c43134830b550972fdd1990702f29d62c17aa7c.
+//
+// Solidity: event VestedRewardsForfeited(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) FilterVestedRewardsForfeited(opts *bind.FilterOpts, provider []common.Address) (*BunkerStakingVestedRewardsForfeitedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "VestedRewardsForfeited", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingVestedRewardsForfeitedIterator{contract: _BunkerStaking.contract, event: "VestedRewardsForfeited", logs: logs, sub: sub}, nil
+}
+
+// WatchVestedRewardsForfeited is a free log subscription operation binding the contract event 0xec349f79d94fe65197ec13d98c43134830b550972fdd1990702f29d62c17aa7c.
+//
+// Solidity: event VestedRewardsForfeited(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) WatchVestedRewardsForfeited(opts *bind.WatchOpts, sink chan<- *BunkerStakingVestedRewardsForfeited, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "VestedRewardsForfeited", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingVestedRewardsForfeited)
+				if err := _BunkerStaking.contract.UnpackLog(event, "VestedRewardsForfeited", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseVestedRewardsForfeited is a log parse operation binding the contract event 0xec349f79d94fe65197ec13d98c43134830b550972fdd1990702f29d62c17aa7c.
+//
+// Solidity: event VestedRewardsForfeited(address indexed provider, uint256 amount)
+func (_BunkerStaking *BunkerStakingFilterer) ParseVestedRewardsForfeited(log types.Log) (*BunkerStakingVestedRewardsForfeited, error) {
+	event := new(BunkerStakingVestedRewardsForfeited)
+	if err := _BunkerStaking.contract.UnpackLog(event, "VestedRewardsForfeited", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerStakingVestingParamsUpdatedIterator is returned from FilterVestingParamsUpdated and is used to iterate over the raw logs and unpacked data for VestingParamsUpdated events raised by the BunkerStaking contract.
+type BunkerStakingVestingParamsUpdatedIterator struct {
+	Event *BunkerStakingVestingParamsUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerStakingVestingParamsUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerStakingVestingParamsUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerStakingVestingParamsUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerStakingVestingParamsUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerStakingVestingParamsUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerStakingVestingParamsUpdated represents a VestingParamsUpdated event raised by the BunkerStaking contract.
+type BunkerStakingVestingParamsUpdated struct {
+	VestingPeriod       *big.Int
+	ImmediateReleaseBps *big.Int
+	Raw                 types.Log // Blockchain specific contextual infos
+}
+
+// FilterVestingParamsUpdated is a free log retrieval operation binding the contract event 0xf9933d06956f6b5949e6bca44fbed2a305cbd0eeb438eb592eff60a65d156bf5.
+//
+// Solidity: event VestingParamsUpdated(uint256 vestingPeriod, uint256 immediateReleaseBps)
+func (_BunkerStaking *BunkerStakingFilterer) FilterVestingParamsUpdated(opts *bind.FilterOpts) (*BunkerStakingVestingParamsUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerStaking.contract.FilterLogs(opts, "VestingParamsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerStakingVestingParamsUpdatedIterator{contract: _BunkerStaking.contract, event: "VestingParamsUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchVestingParamsUpdated is a free log subscription operation binding the contract event 0xf9933d06956f6b5949e6bca44fbed2a305cbd0eeb438eb592eff60a65d156bf5.
+//
+// Solidity: event VestingParamsUpdated(uint256 vestingPeriod, uint256 immediateReleaseBps)
+func (_BunkerStaking *BunkerStakingFilterer) WatchVestingParamsUpdated(opts *bind.WatchOpts, sink chan<- *BunkerStakingVestingParamsUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerStaking.contract.WatchLogs(opts, "VestingParamsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerStakingVestingParamsUpdated)
+				if err := _BunkerStaking.contract.UnpackLog(event, "VestingParamsUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseVestingParamsUpdated is a log parse operation binding the contract event 0xf9933d06956f6b5949e6bca44fbed2a305cbd0eeb438eb592eff60a65d156bf5.
+//
+// Solidity: event VestingParamsUpdated(uint256 vestingPeriod, uint256 immediateReleaseBps)
+func (_BunkerStaking *BunkerStakingFilterer) ParseVestingParamsUpdated(log types.Log) (*BunkerStakingVestingParamsUpdated, error) {
+	event := new(BunkerStakingVestingParamsUpdated)
+	if err := _BunkerStaking.contract.UnpackLog(event, "VestingParamsUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/payment/bindings/bunkertoken.go
+++ b/internal/payment/bindings/bunkertoken.go
@@ -1,0 +1,1611 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BunkerTokenMetaData contains all meta data concerning the BunkerToken contract.
+var BunkerTokenMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"initialOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DOMAIN_SEPARATOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"SUPPLY_CAP\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"allowance\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"approve\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"balanceOf\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"burn\",\"inputs\":[{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"burnFrom\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"decimals\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eip712Domain\",\"inputs\":[],\"outputs\":[{\"name\":\"fields\",\"type\":\"bytes1\",\"internalType\":\"bytes1\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"salt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"extensions\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"mint\",\"inputs\":[{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"mintableSupply\",\"inputs\":[],\"outputs\":[{\"name\":\"remaining\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"name\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"nonces\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"permit\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deadline\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"v\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"r\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"s\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"symbol\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalSupply\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transfer\",\"inputs\":[{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFrom\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"Approval\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"spender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"EIP712DomainChanged\",\"inputs\":[],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Transfer\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ECDSAInvalidSignature\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ECDSAInvalidSignatureLength\",\"inputs\":[{\"name\":\"length\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ECDSAInvalidSignatureS\",\"inputs\":[{\"name\":\"s\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ERC20InsufficientAllowance\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"allowance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"needed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC20InsufficientBalance\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"needed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidApprover\",\"inputs\":[{\"name\":\"approver\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidReceiver\",\"inputs\":[{\"name\":\"receiver\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidSender\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidSpender\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC2612ExpiredSignature\",\"inputs\":[{\"name\":\"deadline\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC2612InvalidSigner\",\"inputs\":[{\"name\":\"signer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"InvalidAccountNonce\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"currentNonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidShortString\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MintAmountZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"StringTooLong\",\"inputs\":[{\"name\":\"str\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"SupplyCapExceeded\",\"inputs\":[{\"name\":\"requested\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"available\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}]",
+}
+
+// BunkerTokenABI is the input ABI used to generate the binding from.
+// Deprecated: Use BunkerTokenMetaData.ABI instead.
+var BunkerTokenABI = BunkerTokenMetaData.ABI
+
+// BunkerToken is an auto generated Go binding around an Ethereum contract.
+type BunkerToken struct {
+	BunkerTokenCaller     // Read-only binding to the contract
+	BunkerTokenTransactor // Write-only binding to the contract
+	BunkerTokenFilterer   // Log filterer for contract events
+}
+
+// BunkerTokenCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BunkerTokenCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerTokenTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BunkerTokenTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerTokenFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BunkerTokenFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerTokenSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BunkerTokenSession struct {
+	Contract     *BunkerToken      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BunkerTokenCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BunkerTokenCallerSession struct {
+	Contract *BunkerTokenCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// BunkerTokenTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BunkerTokenTransactorSession struct {
+	Contract     *BunkerTokenTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// BunkerTokenRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BunkerTokenRaw struct {
+	Contract *BunkerToken // Generic contract binding to access the raw methods on
+}
+
+// BunkerTokenCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BunkerTokenCallerRaw struct {
+	Contract *BunkerTokenCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BunkerTokenTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BunkerTokenTransactorRaw struct {
+	Contract *BunkerTokenTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBunkerToken creates a new instance of BunkerToken, bound to a specific deployed contract.
+func NewBunkerToken(address common.Address, backend bind.ContractBackend) (*BunkerToken, error) {
+	contract, err := bindBunkerToken(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerToken{BunkerTokenCaller: BunkerTokenCaller{contract: contract}, BunkerTokenTransactor: BunkerTokenTransactor{contract: contract}, BunkerTokenFilterer: BunkerTokenFilterer{contract: contract}}, nil
+}
+
+// NewBunkerTokenCaller creates a new read-only instance of BunkerToken, bound to a specific deployed contract.
+func NewBunkerTokenCaller(address common.Address, caller bind.ContractCaller) (*BunkerTokenCaller, error) {
+	contract, err := bindBunkerToken(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerTokenCaller{contract: contract}, nil
+}
+
+// NewBunkerTokenTransactor creates a new write-only instance of BunkerToken, bound to a specific deployed contract.
+func NewBunkerTokenTransactor(address common.Address, transactor bind.ContractTransactor) (*BunkerTokenTransactor, error) {
+	contract, err := bindBunkerToken(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerTokenTransactor{contract: contract}, nil
+}
+
+// NewBunkerTokenFilterer creates a new log filterer instance of BunkerToken, bound to a specific deployed contract.
+func NewBunkerTokenFilterer(address common.Address, filterer bind.ContractFilterer) (*BunkerTokenFilterer, error) {
+	contract, err := bindBunkerToken(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerTokenFilterer{contract: contract}, nil
+}
+
+// bindBunkerToken binds a generic wrapper to an already deployed contract.
+func bindBunkerToken(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BunkerTokenMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerToken *BunkerTokenRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerToken.Contract.BunkerTokenCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerToken *BunkerTokenRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerToken.Contract.BunkerTokenTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerToken *BunkerTokenRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerToken.Contract.BunkerTokenTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerToken *BunkerTokenCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerToken.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerToken *BunkerTokenTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerToken.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerToken *BunkerTokenTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerToken.Contract.contract.Transact(opts, method, params...)
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_BunkerToken *BunkerTokenCaller) DOMAINSEPARATOR(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "DOMAIN_SEPARATOR")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_BunkerToken *BunkerTokenSession) DOMAINSEPARATOR() ([32]byte, error) {
+	return _BunkerToken.Contract.DOMAINSEPARATOR(&_BunkerToken.CallOpts)
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_BunkerToken *BunkerTokenCallerSession) DOMAINSEPARATOR() ([32]byte, error) {
+	return _BunkerToken.Contract.DOMAINSEPARATOR(&_BunkerToken.CallOpts)
+}
+
+// SUPPLYCAP is a free data retrieval call binding the contract method 0x0cfccc83.
+//
+// Solidity: function SUPPLY_CAP() view returns(uint256)
+func (_BunkerToken *BunkerTokenCaller) SUPPLYCAP(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "SUPPLY_CAP")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SUPPLYCAP is a free data retrieval call binding the contract method 0x0cfccc83.
+//
+// Solidity: function SUPPLY_CAP() view returns(uint256)
+func (_BunkerToken *BunkerTokenSession) SUPPLYCAP() (*big.Int, error) {
+	return _BunkerToken.Contract.SUPPLYCAP(&_BunkerToken.CallOpts)
+}
+
+// SUPPLYCAP is a free data retrieval call binding the contract method 0x0cfccc83.
+//
+// Solidity: function SUPPLY_CAP() view returns(uint256)
+func (_BunkerToken *BunkerTokenCallerSession) SUPPLYCAP() (*big.Int, error) {
+	return _BunkerToken.Contract.SUPPLYCAP(&_BunkerToken.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerToken *BunkerTokenCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerToken *BunkerTokenSession) VERSION() (string, error) {
+	return _BunkerToken.Contract.VERSION(&_BunkerToken.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerToken *BunkerTokenCallerSession) VERSION() (string, error) {
+	return _BunkerToken.Contract.VERSION(&_BunkerToken.CallOpts)
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_BunkerToken *BunkerTokenCaller) Allowance(opts *bind.CallOpts, owner common.Address, spender common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "allowance", owner, spender)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_BunkerToken *BunkerTokenSession) Allowance(owner common.Address, spender common.Address) (*big.Int, error) {
+	return _BunkerToken.Contract.Allowance(&_BunkerToken.CallOpts, owner, spender)
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_BunkerToken *BunkerTokenCallerSession) Allowance(owner common.Address, spender common.Address) (*big.Int, error) {
+	return _BunkerToken.Contract.Allowance(&_BunkerToken.CallOpts, owner, spender)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_BunkerToken *BunkerTokenCaller) BalanceOf(opts *bind.CallOpts, account common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "balanceOf", account)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_BunkerToken *BunkerTokenSession) BalanceOf(account common.Address) (*big.Int, error) {
+	return _BunkerToken.Contract.BalanceOf(&_BunkerToken.CallOpts, account)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_BunkerToken *BunkerTokenCallerSession) BalanceOf(account common.Address) (*big.Int, error) {
+	return _BunkerToken.Contract.BalanceOf(&_BunkerToken.CallOpts, account)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_BunkerToken *BunkerTokenCaller) Decimals(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "decimals")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_BunkerToken *BunkerTokenSession) Decimals() (uint8, error) {
+	return _BunkerToken.Contract.Decimals(&_BunkerToken.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_BunkerToken *BunkerTokenCallerSession) Decimals() (uint8, error) {
+	return _BunkerToken.Contract.Decimals(&_BunkerToken.CallOpts)
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_BunkerToken *BunkerTokenCaller) Eip712Domain(opts *bind.CallOpts) (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "eip712Domain")
+
+	outstruct := new(struct {
+		Fields            [1]byte
+		Name              string
+		Version           string
+		ChainId           *big.Int
+		VerifyingContract common.Address
+		Salt              [32]byte
+		Extensions        []*big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Fields = *abi.ConvertType(out[0], new([1]byte)).(*[1]byte)
+	outstruct.Name = *abi.ConvertType(out[1], new(string)).(*string)
+	outstruct.Version = *abi.ConvertType(out[2], new(string)).(*string)
+	outstruct.ChainId = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.VerifyingContract = *abi.ConvertType(out[4], new(common.Address)).(*common.Address)
+	outstruct.Salt = *abi.ConvertType(out[5], new([32]byte)).(*[32]byte)
+	outstruct.Extensions = *abi.ConvertType(out[6], new([]*big.Int)).(*[]*big.Int)
+
+	return *outstruct, err
+
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_BunkerToken *BunkerTokenSession) Eip712Domain() (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	return _BunkerToken.Contract.Eip712Domain(&_BunkerToken.CallOpts)
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_BunkerToken *BunkerTokenCallerSession) Eip712Domain() (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	return _BunkerToken.Contract.Eip712Domain(&_BunkerToken.CallOpts)
+}
+
+// MintableSupply is a free data retrieval call binding the contract method 0xcc5c095c.
+//
+// Solidity: function mintableSupply() view returns(uint256 remaining)
+func (_BunkerToken *BunkerTokenCaller) MintableSupply(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "mintableSupply")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MintableSupply is a free data retrieval call binding the contract method 0xcc5c095c.
+//
+// Solidity: function mintableSupply() view returns(uint256 remaining)
+func (_BunkerToken *BunkerTokenSession) MintableSupply() (*big.Int, error) {
+	return _BunkerToken.Contract.MintableSupply(&_BunkerToken.CallOpts)
+}
+
+// MintableSupply is a free data retrieval call binding the contract method 0xcc5c095c.
+//
+// Solidity: function mintableSupply() view returns(uint256 remaining)
+func (_BunkerToken *BunkerTokenCallerSession) MintableSupply() (*big.Int, error) {
+	return _BunkerToken.Contract.MintableSupply(&_BunkerToken.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_BunkerToken *BunkerTokenCaller) Name(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "name")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_BunkerToken *BunkerTokenSession) Name() (string, error) {
+	return _BunkerToken.Contract.Name(&_BunkerToken.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_BunkerToken *BunkerTokenCallerSession) Name() (string, error) {
+	return _BunkerToken.Contract.Name(&_BunkerToken.CallOpts)
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address owner) view returns(uint256)
+func (_BunkerToken *BunkerTokenCaller) Nonces(opts *bind.CallOpts, owner common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "nonces", owner)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address owner) view returns(uint256)
+func (_BunkerToken *BunkerTokenSession) Nonces(owner common.Address) (*big.Int, error) {
+	return _BunkerToken.Contract.Nonces(&_BunkerToken.CallOpts, owner)
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address owner) view returns(uint256)
+func (_BunkerToken *BunkerTokenCallerSession) Nonces(owner common.Address) (*big.Int, error) {
+	return _BunkerToken.Contract.Nonces(&_BunkerToken.CallOpts, owner)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerToken *BunkerTokenCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerToken *BunkerTokenSession) Owner() (common.Address, error) {
+	return _BunkerToken.Contract.Owner(&_BunkerToken.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerToken *BunkerTokenCallerSession) Owner() (common.Address, error) {
+	return _BunkerToken.Contract.Owner(&_BunkerToken.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerToken *BunkerTokenCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerToken *BunkerTokenSession) PendingOwner() (common.Address, error) {
+	return _BunkerToken.Contract.PendingOwner(&_BunkerToken.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerToken *BunkerTokenCallerSession) PendingOwner() (common.Address, error) {
+	return _BunkerToken.Contract.PendingOwner(&_BunkerToken.CallOpts)
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_BunkerToken *BunkerTokenCaller) Symbol(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "symbol")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_BunkerToken *BunkerTokenSession) Symbol() (string, error) {
+	return _BunkerToken.Contract.Symbol(&_BunkerToken.CallOpts)
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_BunkerToken *BunkerTokenCallerSession) Symbol() (string, error) {
+	return _BunkerToken.Contract.Symbol(&_BunkerToken.CallOpts)
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_BunkerToken *BunkerTokenCaller) TotalSupply(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerToken.contract.Call(opts, &out, "totalSupply")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_BunkerToken *BunkerTokenSession) TotalSupply() (*big.Int, error) {
+	return _BunkerToken.Contract.TotalSupply(&_BunkerToken.CallOpts)
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_BunkerToken *BunkerTokenCallerSession) TotalSupply() (*big.Int, error) {
+	return _BunkerToken.Contract.TotalSupply(&_BunkerToken.CallOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerToken *BunkerTokenTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerToken *BunkerTokenSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerToken.Contract.AcceptOwnership(&_BunkerToken.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerToken *BunkerTokenTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerToken.Contract.AcceptOwnership(&_BunkerToken.TransactOpts)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenTransactor) Approve(opts *bind.TransactOpts, spender common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "approve", spender, value)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenSession) Approve(spender common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Approve(&_BunkerToken.TransactOpts, spender, value)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenTransactorSession) Approve(spender common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Approve(&_BunkerToken.TransactOpts, spender, value)
+}
+
+// Burn is a paid mutator transaction binding the contract method 0x42966c68.
+//
+// Solidity: function burn(uint256 value) returns()
+func (_BunkerToken *BunkerTokenTransactor) Burn(opts *bind.TransactOpts, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "burn", value)
+}
+
+// Burn is a paid mutator transaction binding the contract method 0x42966c68.
+//
+// Solidity: function burn(uint256 value) returns()
+func (_BunkerToken *BunkerTokenSession) Burn(value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Burn(&_BunkerToken.TransactOpts, value)
+}
+
+// Burn is a paid mutator transaction binding the contract method 0x42966c68.
+//
+// Solidity: function burn(uint256 value) returns()
+func (_BunkerToken *BunkerTokenTransactorSession) Burn(value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Burn(&_BunkerToken.TransactOpts, value)
+}
+
+// BurnFrom is a paid mutator transaction binding the contract method 0x79cc6790.
+//
+// Solidity: function burnFrom(address account, uint256 value) returns()
+func (_BunkerToken *BunkerTokenTransactor) BurnFrom(opts *bind.TransactOpts, account common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "burnFrom", account, value)
+}
+
+// BurnFrom is a paid mutator transaction binding the contract method 0x79cc6790.
+//
+// Solidity: function burnFrom(address account, uint256 value) returns()
+func (_BunkerToken *BunkerTokenSession) BurnFrom(account common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.BurnFrom(&_BunkerToken.TransactOpts, account, value)
+}
+
+// BurnFrom is a paid mutator transaction binding the contract method 0x79cc6790.
+//
+// Solidity: function burnFrom(address account, uint256 value) returns()
+func (_BunkerToken *BunkerTokenTransactorSession) BurnFrom(account common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.BurnFrom(&_BunkerToken.TransactOpts, account, value)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x40c10f19.
+//
+// Solidity: function mint(address to, uint256 amount) returns()
+func (_BunkerToken *BunkerTokenTransactor) Mint(opts *bind.TransactOpts, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "mint", to, amount)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x40c10f19.
+//
+// Solidity: function mint(address to, uint256 amount) returns()
+func (_BunkerToken *BunkerTokenSession) Mint(to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Mint(&_BunkerToken.TransactOpts, to, amount)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x40c10f19.
+//
+// Solidity: function mint(address to, uint256 amount) returns()
+func (_BunkerToken *BunkerTokenTransactorSession) Mint(to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Mint(&_BunkerToken.TransactOpts, to, amount)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_BunkerToken *BunkerTokenTransactor) Permit(opts *bind.TransactOpts, owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "permit", owner, spender, value, deadline, v, r, s)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_BunkerToken *BunkerTokenSession) Permit(owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Permit(&_BunkerToken.TransactOpts, owner, spender, value, deadline, v, r, s)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_BunkerToken *BunkerTokenTransactorSession) Permit(owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Permit(&_BunkerToken.TransactOpts, owner, spender, value, deadline, v, r, s)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerToken *BunkerTokenTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerToken *BunkerTokenSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerToken.Contract.RenounceOwnership(&_BunkerToken.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerToken *BunkerTokenTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerToken.Contract.RenounceOwnership(&_BunkerToken.TransactOpts)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenTransactor) Transfer(opts *bind.TransactOpts, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "transfer", to, value)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenSession) Transfer(to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Transfer(&_BunkerToken.TransactOpts, to, value)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenTransactorSession) Transfer(to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.Transfer(&_BunkerToken.TransactOpts, to, value)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenTransactor) TransferFrom(opts *bind.TransactOpts, from common.Address, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "transferFrom", from, to, value)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenSession) TransferFrom(from common.Address, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.TransferFrom(&_BunkerToken.TransactOpts, from, to, value)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 value) returns(bool)
+func (_BunkerToken *BunkerTokenTransactorSession) TransferFrom(from common.Address, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _BunkerToken.Contract.TransferFrom(&_BunkerToken.TransactOpts, from, to, value)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerToken *BunkerTokenTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerToken.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerToken *BunkerTokenSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerToken.Contract.TransferOwnership(&_BunkerToken.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerToken *BunkerTokenTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerToken.Contract.TransferOwnership(&_BunkerToken.TransactOpts, newOwner)
+}
+
+// BunkerTokenApprovalIterator is returned from FilterApproval and is used to iterate over the raw logs and unpacked data for Approval events raised by the BunkerToken contract.
+type BunkerTokenApprovalIterator struct {
+	Event *BunkerTokenApproval // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerTokenApprovalIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerTokenApproval)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerTokenApproval)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerTokenApprovalIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerTokenApprovalIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerTokenApproval represents a Approval event raised by the BunkerToken contract.
+type BunkerTokenApproval struct {
+	Owner   common.Address
+	Spender common.Address
+	Value   *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterApproval is a free log retrieval operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_BunkerToken *BunkerTokenFilterer) FilterApproval(opts *bind.FilterOpts, owner []common.Address, spender []common.Address) (*BunkerTokenApprovalIterator, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+
+	logs, sub, err := _BunkerToken.contract.FilterLogs(opts, "Approval", ownerRule, spenderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerTokenApprovalIterator{contract: _BunkerToken.contract, event: "Approval", logs: logs, sub: sub}, nil
+}
+
+// WatchApproval is a free log subscription operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_BunkerToken *BunkerTokenFilterer) WatchApproval(opts *bind.WatchOpts, sink chan<- *BunkerTokenApproval, owner []common.Address, spender []common.Address) (event.Subscription, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+
+	logs, sub, err := _BunkerToken.contract.WatchLogs(opts, "Approval", ownerRule, spenderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerTokenApproval)
+				if err := _BunkerToken.contract.UnpackLog(event, "Approval", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseApproval is a log parse operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_BunkerToken *BunkerTokenFilterer) ParseApproval(log types.Log) (*BunkerTokenApproval, error) {
+	event := new(BunkerTokenApproval)
+	if err := _BunkerToken.contract.UnpackLog(event, "Approval", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerTokenEIP712DomainChangedIterator is returned from FilterEIP712DomainChanged and is used to iterate over the raw logs and unpacked data for EIP712DomainChanged events raised by the BunkerToken contract.
+type BunkerTokenEIP712DomainChangedIterator struct {
+	Event *BunkerTokenEIP712DomainChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerTokenEIP712DomainChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerTokenEIP712DomainChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerTokenEIP712DomainChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerTokenEIP712DomainChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerTokenEIP712DomainChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerTokenEIP712DomainChanged represents a EIP712DomainChanged event raised by the BunkerToken contract.
+type BunkerTokenEIP712DomainChanged struct {
+	Raw types.Log // Blockchain specific contextual infos
+}
+
+// FilterEIP712DomainChanged is a free log retrieval operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_BunkerToken *BunkerTokenFilterer) FilterEIP712DomainChanged(opts *bind.FilterOpts) (*BunkerTokenEIP712DomainChangedIterator, error) {
+
+	logs, sub, err := _BunkerToken.contract.FilterLogs(opts, "EIP712DomainChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerTokenEIP712DomainChangedIterator{contract: _BunkerToken.contract, event: "EIP712DomainChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchEIP712DomainChanged is a free log subscription operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_BunkerToken *BunkerTokenFilterer) WatchEIP712DomainChanged(opts *bind.WatchOpts, sink chan<- *BunkerTokenEIP712DomainChanged) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerToken.contract.WatchLogs(opts, "EIP712DomainChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerTokenEIP712DomainChanged)
+				if err := _BunkerToken.contract.UnpackLog(event, "EIP712DomainChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEIP712DomainChanged is a log parse operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_BunkerToken *BunkerTokenFilterer) ParseEIP712DomainChanged(log types.Log) (*BunkerTokenEIP712DomainChanged, error) {
+	event := new(BunkerTokenEIP712DomainChanged)
+	if err := _BunkerToken.contract.UnpackLog(event, "EIP712DomainChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerTokenOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the BunkerToken contract.
+type BunkerTokenOwnershipTransferStartedIterator struct {
+	Event *BunkerTokenOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerTokenOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerTokenOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerTokenOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerTokenOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerTokenOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerTokenOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the BunkerToken contract.
+type BunkerTokenOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerToken *BunkerTokenFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerTokenOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerToken.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerTokenOwnershipTransferStartedIterator{contract: _BunkerToken.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerToken *BunkerTokenFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BunkerTokenOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerToken.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerTokenOwnershipTransferStarted)
+				if err := _BunkerToken.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerToken *BunkerTokenFilterer) ParseOwnershipTransferStarted(log types.Log) (*BunkerTokenOwnershipTransferStarted, error) {
+	event := new(BunkerTokenOwnershipTransferStarted)
+	if err := _BunkerToken.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerTokenOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BunkerToken contract.
+type BunkerTokenOwnershipTransferredIterator struct {
+	Event *BunkerTokenOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerTokenOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerTokenOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerTokenOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerTokenOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerTokenOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerTokenOwnershipTransferred represents a OwnershipTransferred event raised by the BunkerToken contract.
+type BunkerTokenOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerToken *BunkerTokenFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerTokenOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerToken.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerTokenOwnershipTransferredIterator{contract: _BunkerToken.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerToken *BunkerTokenFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BunkerTokenOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerToken.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerTokenOwnershipTransferred)
+				if err := _BunkerToken.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerToken *BunkerTokenFilterer) ParseOwnershipTransferred(log types.Log) (*BunkerTokenOwnershipTransferred, error) {
+	event := new(BunkerTokenOwnershipTransferred)
+	if err := _BunkerToken.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerTokenTransferIterator is returned from FilterTransfer and is used to iterate over the raw logs and unpacked data for Transfer events raised by the BunkerToken contract.
+type BunkerTokenTransferIterator struct {
+	Event *BunkerTokenTransfer // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerTokenTransferIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerTokenTransfer)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerTokenTransfer)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerTokenTransferIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerTokenTransferIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerTokenTransfer represents a Transfer event raised by the BunkerToken contract.
+type BunkerTokenTransfer struct {
+	From  common.Address
+	To    common.Address
+	Value *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransfer is a free log retrieval operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_BunkerToken *BunkerTokenFilterer) FilterTransfer(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*BunkerTokenTransferIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _BunkerToken.contract.FilterLogs(opts, "Transfer", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerTokenTransferIterator{contract: _BunkerToken.contract, event: "Transfer", logs: logs, sub: sub}, nil
+}
+
+// WatchTransfer is a free log subscription operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_BunkerToken *BunkerTokenFilterer) WatchTransfer(opts *bind.WatchOpts, sink chan<- *BunkerTokenTransfer, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _BunkerToken.contract.WatchLogs(opts, "Transfer", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerTokenTransfer)
+				if err := _BunkerToken.contract.UnpackLog(event, "Transfer", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransfer is a log parse operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_BunkerToken *BunkerTokenFilterer) ParseTransfer(log types.Log) (*BunkerTokenTransfer, error) {
+	event := new(BunkerTokenTransfer)
+	if err := _BunkerToken.contract.UnpackLog(event, "Transfer", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/payment/bindings/bunkerverification.go
+++ b/internal/payment/bindings/bunkerverification.go
@@ -1,0 +1,2893 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BunkerVerificationAttestationRecord is an auto generated low-level Go binding around an user-defined struct.
+type BunkerVerificationAttestationRecord struct {
+	LastAttestationHash [32]byte
+	LastAttestationTime *big.Int
+	TotalAttestations   uint32
+	MissedAttestations  uint32
+	ConsecutiveMissed   uint32
+	Suspended           bool
+}
+
+// BunkerVerificationMetaData contains all meta data concerning the BunkerVerification contract.
+var BunkerVerificationMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_initialOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERIFIER_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"attestationInterval\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"attestations\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"lastAttestationHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastAttestationTime\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"totalAttestations\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"missedAttestations\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"consecutiveMissed\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"suspended\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"challengeAttestation\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"fraudProof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"checkMissedAttestations\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getAttestation\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"record\",\"type\":\"tuple\",\"internalType\":\"structBunkerVerification.AttestationRecord\",\"components\":[{\"name\":\"lastAttestationHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"lastAttestationTime\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"totalAttestations\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"missedAttestations\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"consecutiveMissed\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"suspended\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isAttestationCurrent\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"current\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"maxMissedAttestations\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingOwner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"reinstateProvider\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"reinstatementCooldown\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setAttestationInterval\",\"inputs\":[{\"name\":\"interval\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMaxMissedAttestations\",\"inputs\":[{\"name\":\"maxMissed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setReinstatementCooldown\",\"inputs\":[{\"name\":\"newCooldown\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"submitAttestation\",\"inputs\":[{\"name\":\"attestationHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"suspendedAt\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"AttestationChallenged\",\"inputs\":[{\"name\":\"challenger\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"attestationHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"AttestationIntervalUpdated\",\"inputs\":[{\"name\":\"oldInterval\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newInterval\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"AttestationMissed\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"consecutiveMissed\",\"type\":\"uint32\",\"indexed\":false,\"internalType\":\"uint32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"AttestationSubmitted\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"attestationHash\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"},{\"name\":\"totalAttestations\",\"type\":\"uint32\",\"indexed\":false,\"internalType\":\"uint32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MaxMissedAttestationsUpdated\",\"inputs\":[{\"name\":\"oldMax\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newMax\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferStarted\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderReinstated\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderSuspended\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"missedCount\",\"type\":\"uint32\",\"indexed\":false,\"internalType\":\"uint32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ReinstatementCooldownUpdated\",\"inputs\":[{\"name\":\"newCooldown\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AttestationTooEarly\",\"inputs\":[{\"name\":\"nextAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"current\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidAttestation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidCooldown\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInterval\",\"inputs\":[{\"name\":\"interval\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidMaxMissed\",\"inputs\":[{\"name\":\"maxMissed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProviderNotAttesting\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProviderSuspendedError\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ReinstatementCooldownActive\",\"inputs\":[]}]",
+}
+
+// BunkerVerificationABI is the input ABI used to generate the binding from.
+// Deprecated: Use BunkerVerificationMetaData.ABI instead.
+var BunkerVerificationABI = BunkerVerificationMetaData.ABI
+
+// BunkerVerification is an auto generated Go binding around an Ethereum contract.
+type BunkerVerification struct {
+	BunkerVerificationCaller     // Read-only binding to the contract
+	BunkerVerificationTransactor // Write-only binding to the contract
+	BunkerVerificationFilterer   // Log filterer for contract events
+}
+
+// BunkerVerificationCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BunkerVerificationCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerVerificationTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BunkerVerificationTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerVerificationFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BunkerVerificationFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BunkerVerificationSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BunkerVerificationSession struct {
+	Contract     *BunkerVerification // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// BunkerVerificationCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BunkerVerificationCallerSession struct {
+	Contract *BunkerVerificationCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
+}
+
+// BunkerVerificationTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BunkerVerificationTransactorSession struct {
+	Contract     *BunkerVerificationTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
+}
+
+// BunkerVerificationRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BunkerVerificationRaw struct {
+	Contract *BunkerVerification // Generic contract binding to access the raw methods on
+}
+
+// BunkerVerificationCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BunkerVerificationCallerRaw struct {
+	Contract *BunkerVerificationCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BunkerVerificationTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BunkerVerificationTransactorRaw struct {
+	Contract *BunkerVerificationTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBunkerVerification creates a new instance of BunkerVerification, bound to a specific deployed contract.
+func NewBunkerVerification(address common.Address, backend bind.ContractBackend) (*BunkerVerification, error) {
+	contract, err := bindBunkerVerification(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerification{BunkerVerificationCaller: BunkerVerificationCaller{contract: contract}, BunkerVerificationTransactor: BunkerVerificationTransactor{contract: contract}, BunkerVerificationFilterer: BunkerVerificationFilterer{contract: contract}}, nil
+}
+
+// NewBunkerVerificationCaller creates a new read-only instance of BunkerVerification, bound to a specific deployed contract.
+func NewBunkerVerificationCaller(address common.Address, caller bind.ContractCaller) (*BunkerVerificationCaller, error) {
+	contract, err := bindBunkerVerification(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationCaller{contract: contract}, nil
+}
+
+// NewBunkerVerificationTransactor creates a new write-only instance of BunkerVerification, bound to a specific deployed contract.
+func NewBunkerVerificationTransactor(address common.Address, transactor bind.ContractTransactor) (*BunkerVerificationTransactor, error) {
+	contract, err := bindBunkerVerification(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationTransactor{contract: contract}, nil
+}
+
+// NewBunkerVerificationFilterer creates a new log filterer instance of BunkerVerification, bound to a specific deployed contract.
+func NewBunkerVerificationFilterer(address common.Address, filterer bind.ContractFilterer) (*BunkerVerificationFilterer, error) {
+	contract, err := bindBunkerVerification(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationFilterer{contract: contract}, nil
+}
+
+// bindBunkerVerification binds a generic wrapper to an already deployed contract.
+func bindBunkerVerification(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BunkerVerificationMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerVerification *BunkerVerificationRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerVerification.Contract.BunkerVerificationCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerVerification *BunkerVerificationRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.BunkerVerificationTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerVerification *BunkerVerificationRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.BunkerVerificationTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BunkerVerification *BunkerVerificationCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BunkerVerification.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BunkerVerification *BunkerVerificationTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BunkerVerification *BunkerVerificationTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.contract.Transact(opts, method, params...)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BunkerVerification.Contract.DEFAULTADMINROLE(&_BunkerVerification.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BunkerVerification.Contract.DEFAULTADMINROLE(&_BunkerVerification.CallOpts)
+}
+
+// VERIFIERROLE is a free data retrieval call binding the contract method 0xe7705db6.
+//
+// Solidity: function VERIFIER_ROLE() view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationCaller) VERIFIERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "VERIFIER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// VERIFIERROLE is a free data retrieval call binding the contract method 0xe7705db6.
+//
+// Solidity: function VERIFIER_ROLE() view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationSession) VERIFIERROLE() ([32]byte, error) {
+	return _BunkerVerification.Contract.VERIFIERROLE(&_BunkerVerification.CallOpts)
+}
+
+// VERIFIERROLE is a free data retrieval call binding the contract method 0xe7705db6.
+//
+// Solidity: function VERIFIER_ROLE() view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationCallerSession) VERIFIERROLE() ([32]byte, error) {
+	return _BunkerVerification.Contract.VERIFIERROLE(&_BunkerVerification.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerVerification *BunkerVerificationCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerVerification *BunkerVerificationSession) VERSION() (string, error) {
+	return _BunkerVerification.Contract.VERSION(&_BunkerVerification.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_BunkerVerification *BunkerVerificationCallerSession) VERSION() (string, error) {
+	return _BunkerVerification.Contract.VERSION(&_BunkerVerification.CallOpts)
+}
+
+// AttestationInterval is a free data retrieval call binding the contract method 0x5ee7bd80.
+//
+// Solidity: function attestationInterval() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationCaller) AttestationInterval(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "attestationInterval")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// AttestationInterval is a free data retrieval call binding the contract method 0x5ee7bd80.
+//
+// Solidity: function attestationInterval() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationSession) AttestationInterval() (*big.Int, error) {
+	return _BunkerVerification.Contract.AttestationInterval(&_BunkerVerification.CallOpts)
+}
+
+// AttestationInterval is a free data retrieval call binding the contract method 0x5ee7bd80.
+//
+// Solidity: function attestationInterval() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationCallerSession) AttestationInterval() (*big.Int, error) {
+	return _BunkerVerification.Contract.AttestationInterval(&_BunkerVerification.CallOpts)
+}
+
+// Attestations is a free data retrieval call binding the contract method 0x20357048.
+//
+// Solidity: function attestations(address ) view returns(bytes32 lastAttestationHash, uint48 lastAttestationTime, uint32 totalAttestations, uint32 missedAttestations, uint32 consecutiveMissed, bool suspended)
+func (_BunkerVerification *BunkerVerificationCaller) Attestations(opts *bind.CallOpts, arg0 common.Address) (struct {
+	LastAttestationHash [32]byte
+	LastAttestationTime *big.Int
+	TotalAttestations   uint32
+	MissedAttestations  uint32
+	ConsecutiveMissed   uint32
+	Suspended           bool
+}, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "attestations", arg0)
+
+	outstruct := new(struct {
+		LastAttestationHash [32]byte
+		LastAttestationTime *big.Int
+		TotalAttestations   uint32
+		MissedAttestations  uint32
+		ConsecutiveMissed   uint32
+		Suspended           bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.LastAttestationHash = *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+	outstruct.LastAttestationTime = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.TotalAttestations = *abi.ConvertType(out[2], new(uint32)).(*uint32)
+	outstruct.MissedAttestations = *abi.ConvertType(out[3], new(uint32)).(*uint32)
+	outstruct.ConsecutiveMissed = *abi.ConvertType(out[4], new(uint32)).(*uint32)
+	outstruct.Suspended = *abi.ConvertType(out[5], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// Attestations is a free data retrieval call binding the contract method 0x20357048.
+//
+// Solidity: function attestations(address ) view returns(bytes32 lastAttestationHash, uint48 lastAttestationTime, uint32 totalAttestations, uint32 missedAttestations, uint32 consecutiveMissed, bool suspended)
+func (_BunkerVerification *BunkerVerificationSession) Attestations(arg0 common.Address) (struct {
+	LastAttestationHash [32]byte
+	LastAttestationTime *big.Int
+	TotalAttestations   uint32
+	MissedAttestations  uint32
+	ConsecutiveMissed   uint32
+	Suspended           bool
+}, error) {
+	return _BunkerVerification.Contract.Attestations(&_BunkerVerification.CallOpts, arg0)
+}
+
+// Attestations is a free data retrieval call binding the contract method 0x20357048.
+//
+// Solidity: function attestations(address ) view returns(bytes32 lastAttestationHash, uint48 lastAttestationTime, uint32 totalAttestations, uint32 missedAttestations, uint32 consecutiveMissed, bool suspended)
+func (_BunkerVerification *BunkerVerificationCallerSession) Attestations(arg0 common.Address) (struct {
+	LastAttestationHash [32]byte
+	LastAttestationTime *big.Int
+	TotalAttestations   uint32
+	MissedAttestations  uint32
+	ConsecutiveMissed   uint32
+	Suspended           bool
+}, error) {
+	return _BunkerVerification.Contract.Attestations(&_BunkerVerification.CallOpts, arg0)
+}
+
+// GetAttestation is a free data retrieval call binding the contract method 0xf9b71797.
+//
+// Solidity: function getAttestation(address provider) view returns((bytes32,uint48,uint32,uint32,uint32,bool) record)
+func (_BunkerVerification *BunkerVerificationCaller) GetAttestation(opts *bind.CallOpts, provider common.Address) (BunkerVerificationAttestationRecord, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "getAttestation", provider)
+
+	if err != nil {
+		return *new(BunkerVerificationAttestationRecord), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(BunkerVerificationAttestationRecord)).(*BunkerVerificationAttestationRecord)
+
+	return out0, err
+
+}
+
+// GetAttestation is a free data retrieval call binding the contract method 0xf9b71797.
+//
+// Solidity: function getAttestation(address provider) view returns((bytes32,uint48,uint32,uint32,uint32,bool) record)
+func (_BunkerVerification *BunkerVerificationSession) GetAttestation(provider common.Address) (BunkerVerificationAttestationRecord, error) {
+	return _BunkerVerification.Contract.GetAttestation(&_BunkerVerification.CallOpts, provider)
+}
+
+// GetAttestation is a free data retrieval call binding the contract method 0xf9b71797.
+//
+// Solidity: function getAttestation(address provider) view returns((bytes32,uint48,uint32,uint32,uint32,bool) record)
+func (_BunkerVerification *BunkerVerificationCallerSession) GetAttestation(provider common.Address) (BunkerVerificationAttestationRecord, error) {
+	return _BunkerVerification.Contract.GetAttestation(&_BunkerVerification.CallOpts, provider)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BunkerVerification.Contract.GetRoleAdmin(&_BunkerVerification.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BunkerVerification *BunkerVerificationCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BunkerVerification.Contract.GetRoleAdmin(&_BunkerVerification.CallOpts, role)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerVerification *BunkerVerificationCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerVerification *BunkerVerificationSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BunkerVerification.Contract.HasRole(&_BunkerVerification.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BunkerVerification *BunkerVerificationCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BunkerVerification.Contract.HasRole(&_BunkerVerification.CallOpts, role, account)
+}
+
+// IsAttestationCurrent is a free data retrieval call binding the contract method 0x6159f222.
+//
+// Solidity: function isAttestationCurrent(address provider) view returns(bool current)
+func (_BunkerVerification *BunkerVerificationCaller) IsAttestationCurrent(opts *bind.CallOpts, provider common.Address) (bool, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "isAttestationCurrent", provider)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsAttestationCurrent is a free data retrieval call binding the contract method 0x6159f222.
+//
+// Solidity: function isAttestationCurrent(address provider) view returns(bool current)
+func (_BunkerVerification *BunkerVerificationSession) IsAttestationCurrent(provider common.Address) (bool, error) {
+	return _BunkerVerification.Contract.IsAttestationCurrent(&_BunkerVerification.CallOpts, provider)
+}
+
+// IsAttestationCurrent is a free data retrieval call binding the contract method 0x6159f222.
+//
+// Solidity: function isAttestationCurrent(address provider) view returns(bool current)
+func (_BunkerVerification *BunkerVerificationCallerSession) IsAttestationCurrent(provider common.Address) (bool, error) {
+	return _BunkerVerification.Contract.IsAttestationCurrent(&_BunkerVerification.CallOpts, provider)
+}
+
+// MaxMissedAttestations is a free data retrieval call binding the contract method 0x88af3fe0.
+//
+// Solidity: function maxMissedAttestations() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationCaller) MaxMissedAttestations(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "maxMissedAttestations")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MaxMissedAttestations is a free data retrieval call binding the contract method 0x88af3fe0.
+//
+// Solidity: function maxMissedAttestations() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationSession) MaxMissedAttestations() (*big.Int, error) {
+	return _BunkerVerification.Contract.MaxMissedAttestations(&_BunkerVerification.CallOpts)
+}
+
+// MaxMissedAttestations is a free data retrieval call binding the contract method 0x88af3fe0.
+//
+// Solidity: function maxMissedAttestations() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationCallerSession) MaxMissedAttestations() (*big.Int, error) {
+	return _BunkerVerification.Contract.MaxMissedAttestations(&_BunkerVerification.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerVerification *BunkerVerificationCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerVerification *BunkerVerificationSession) Owner() (common.Address, error) {
+	return _BunkerVerification.Contract.Owner(&_BunkerVerification.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_BunkerVerification *BunkerVerificationCallerSession) Owner() (common.Address, error) {
+	return _BunkerVerification.Contract.Owner(&_BunkerVerification.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerVerification *BunkerVerificationCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerVerification *BunkerVerificationSession) PendingOwner() (common.Address, error) {
+	return _BunkerVerification.Contract.PendingOwner(&_BunkerVerification.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_BunkerVerification *BunkerVerificationCallerSession) PendingOwner() (common.Address, error) {
+	return _BunkerVerification.Contract.PendingOwner(&_BunkerVerification.CallOpts)
+}
+
+// ReinstatementCooldown is a free data retrieval call binding the contract method 0x047bccf5.
+//
+// Solidity: function reinstatementCooldown() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationCaller) ReinstatementCooldown(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "reinstatementCooldown")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ReinstatementCooldown is a free data retrieval call binding the contract method 0x047bccf5.
+//
+// Solidity: function reinstatementCooldown() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationSession) ReinstatementCooldown() (*big.Int, error) {
+	return _BunkerVerification.Contract.ReinstatementCooldown(&_BunkerVerification.CallOpts)
+}
+
+// ReinstatementCooldown is a free data retrieval call binding the contract method 0x047bccf5.
+//
+// Solidity: function reinstatementCooldown() view returns(uint256)
+func (_BunkerVerification *BunkerVerificationCallerSession) ReinstatementCooldown() (*big.Int, error) {
+	return _BunkerVerification.Contract.ReinstatementCooldown(&_BunkerVerification.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerVerification *BunkerVerificationCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerVerification *BunkerVerificationSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BunkerVerification.Contract.SupportsInterface(&_BunkerVerification.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BunkerVerification *BunkerVerificationCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BunkerVerification.Contract.SupportsInterface(&_BunkerVerification.CallOpts, interfaceId)
+}
+
+// SuspendedAt is a free data retrieval call binding the contract method 0x989b1d60.
+//
+// Solidity: function suspendedAt(address ) view returns(uint256)
+func (_BunkerVerification *BunkerVerificationCaller) SuspendedAt(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _BunkerVerification.contract.Call(opts, &out, "suspendedAt", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SuspendedAt is a free data retrieval call binding the contract method 0x989b1d60.
+//
+// Solidity: function suspendedAt(address ) view returns(uint256)
+func (_BunkerVerification *BunkerVerificationSession) SuspendedAt(arg0 common.Address) (*big.Int, error) {
+	return _BunkerVerification.Contract.SuspendedAt(&_BunkerVerification.CallOpts, arg0)
+}
+
+// SuspendedAt is a free data retrieval call binding the contract method 0x989b1d60.
+//
+// Solidity: function suspendedAt(address ) view returns(uint256)
+func (_BunkerVerification *BunkerVerificationCallerSession) SuspendedAt(arg0 common.Address) (*big.Int, error) {
+	return _BunkerVerification.Contract.SuspendedAt(&_BunkerVerification.CallOpts, arg0)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerVerification *BunkerVerificationTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerVerification *BunkerVerificationSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerVerification.Contract.AcceptOwnership(&_BunkerVerification.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _BunkerVerification.Contract.AcceptOwnership(&_BunkerVerification.TransactOpts)
+}
+
+// ChallengeAttestation is a paid mutator transaction binding the contract method 0x904aa811.
+//
+// Solidity: function challengeAttestation(address provider, bytes fraudProof) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) ChallengeAttestation(opts *bind.TransactOpts, provider common.Address, fraudProof []byte) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "challengeAttestation", provider, fraudProof)
+}
+
+// ChallengeAttestation is a paid mutator transaction binding the contract method 0x904aa811.
+//
+// Solidity: function challengeAttestation(address provider, bytes fraudProof) returns()
+func (_BunkerVerification *BunkerVerificationSession) ChallengeAttestation(provider common.Address, fraudProof []byte) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.ChallengeAttestation(&_BunkerVerification.TransactOpts, provider, fraudProof)
+}
+
+// ChallengeAttestation is a paid mutator transaction binding the contract method 0x904aa811.
+//
+// Solidity: function challengeAttestation(address provider, bytes fraudProof) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) ChallengeAttestation(provider common.Address, fraudProof []byte) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.ChallengeAttestation(&_BunkerVerification.TransactOpts, provider, fraudProof)
+}
+
+// CheckMissedAttestations is a paid mutator transaction binding the contract method 0x9b22ab77.
+//
+// Solidity: function checkMissedAttestations(address provider) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) CheckMissedAttestations(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "checkMissedAttestations", provider)
+}
+
+// CheckMissedAttestations is a paid mutator transaction binding the contract method 0x9b22ab77.
+//
+// Solidity: function checkMissedAttestations(address provider) returns()
+func (_BunkerVerification *BunkerVerificationSession) CheckMissedAttestations(provider common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.CheckMissedAttestations(&_BunkerVerification.TransactOpts, provider)
+}
+
+// CheckMissedAttestations is a paid mutator transaction binding the contract method 0x9b22ab77.
+//
+// Solidity: function checkMissedAttestations(address provider) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) CheckMissedAttestations(provider common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.CheckMissedAttestations(&_BunkerVerification.TransactOpts, provider)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerVerification *BunkerVerificationSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.GrantRole(&_BunkerVerification.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.GrantRole(&_BunkerVerification.TransactOpts, role, account)
+}
+
+// ReinstateProvider is a paid mutator transaction binding the contract method 0x99e82915.
+//
+// Solidity: function reinstateProvider(address provider) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) ReinstateProvider(opts *bind.TransactOpts, provider common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "reinstateProvider", provider)
+}
+
+// ReinstateProvider is a paid mutator transaction binding the contract method 0x99e82915.
+//
+// Solidity: function reinstateProvider(address provider) returns()
+func (_BunkerVerification *BunkerVerificationSession) ReinstateProvider(provider common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.ReinstateProvider(&_BunkerVerification.TransactOpts, provider)
+}
+
+// ReinstateProvider is a paid mutator transaction binding the contract method 0x99e82915.
+//
+// Solidity: function reinstateProvider(address provider) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) ReinstateProvider(provider common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.ReinstateProvider(&_BunkerVerification.TransactOpts, provider)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerVerification *BunkerVerificationTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerVerification *BunkerVerificationSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerVerification.Contract.RenounceOwnership(&_BunkerVerification.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _BunkerVerification.Contract.RenounceOwnership(&_BunkerVerification.TransactOpts)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerVerification *BunkerVerificationSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.RenounceRole(&_BunkerVerification.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.RenounceRole(&_BunkerVerification.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerVerification *BunkerVerificationSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.RevokeRole(&_BunkerVerification.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.RevokeRole(&_BunkerVerification.TransactOpts, role, account)
+}
+
+// SetAttestationInterval is a paid mutator transaction binding the contract method 0xf5264a2a.
+//
+// Solidity: function setAttestationInterval(uint256 interval) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) SetAttestationInterval(opts *bind.TransactOpts, interval *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "setAttestationInterval", interval)
+}
+
+// SetAttestationInterval is a paid mutator transaction binding the contract method 0xf5264a2a.
+//
+// Solidity: function setAttestationInterval(uint256 interval) returns()
+func (_BunkerVerification *BunkerVerificationSession) SetAttestationInterval(interval *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.SetAttestationInterval(&_BunkerVerification.TransactOpts, interval)
+}
+
+// SetAttestationInterval is a paid mutator transaction binding the contract method 0xf5264a2a.
+//
+// Solidity: function setAttestationInterval(uint256 interval) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) SetAttestationInterval(interval *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.SetAttestationInterval(&_BunkerVerification.TransactOpts, interval)
+}
+
+// SetMaxMissedAttestations is a paid mutator transaction binding the contract method 0x7b8093cd.
+//
+// Solidity: function setMaxMissedAttestations(uint256 maxMissed) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) SetMaxMissedAttestations(opts *bind.TransactOpts, maxMissed *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "setMaxMissedAttestations", maxMissed)
+}
+
+// SetMaxMissedAttestations is a paid mutator transaction binding the contract method 0x7b8093cd.
+//
+// Solidity: function setMaxMissedAttestations(uint256 maxMissed) returns()
+func (_BunkerVerification *BunkerVerificationSession) SetMaxMissedAttestations(maxMissed *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.SetMaxMissedAttestations(&_BunkerVerification.TransactOpts, maxMissed)
+}
+
+// SetMaxMissedAttestations is a paid mutator transaction binding the contract method 0x7b8093cd.
+//
+// Solidity: function setMaxMissedAttestations(uint256 maxMissed) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) SetMaxMissedAttestations(maxMissed *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.SetMaxMissedAttestations(&_BunkerVerification.TransactOpts, maxMissed)
+}
+
+// SetReinstatementCooldown is a paid mutator transaction binding the contract method 0xe37020c6.
+//
+// Solidity: function setReinstatementCooldown(uint256 newCooldown) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) SetReinstatementCooldown(opts *bind.TransactOpts, newCooldown *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "setReinstatementCooldown", newCooldown)
+}
+
+// SetReinstatementCooldown is a paid mutator transaction binding the contract method 0xe37020c6.
+//
+// Solidity: function setReinstatementCooldown(uint256 newCooldown) returns()
+func (_BunkerVerification *BunkerVerificationSession) SetReinstatementCooldown(newCooldown *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.SetReinstatementCooldown(&_BunkerVerification.TransactOpts, newCooldown)
+}
+
+// SetReinstatementCooldown is a paid mutator transaction binding the contract method 0xe37020c6.
+//
+// Solidity: function setReinstatementCooldown(uint256 newCooldown) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) SetReinstatementCooldown(newCooldown *big.Int) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.SetReinstatementCooldown(&_BunkerVerification.TransactOpts, newCooldown)
+}
+
+// SubmitAttestation is a paid mutator transaction binding the contract method 0x4506b5c5.
+//
+// Solidity: function submitAttestation(bytes32 attestationHash) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) SubmitAttestation(opts *bind.TransactOpts, attestationHash [32]byte) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "submitAttestation", attestationHash)
+}
+
+// SubmitAttestation is a paid mutator transaction binding the contract method 0x4506b5c5.
+//
+// Solidity: function submitAttestation(bytes32 attestationHash) returns()
+func (_BunkerVerification *BunkerVerificationSession) SubmitAttestation(attestationHash [32]byte) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.SubmitAttestation(&_BunkerVerification.TransactOpts, attestationHash)
+}
+
+// SubmitAttestation is a paid mutator transaction binding the contract method 0x4506b5c5.
+//
+// Solidity: function submitAttestation(bytes32 attestationHash) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) SubmitAttestation(attestationHash [32]byte) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.SubmitAttestation(&_BunkerVerification.TransactOpts, attestationHash)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerVerification *BunkerVerificationTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerVerification *BunkerVerificationSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.TransferOwnership(&_BunkerVerification.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_BunkerVerification *BunkerVerificationTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _BunkerVerification.Contract.TransferOwnership(&_BunkerVerification.TransactOpts, newOwner)
+}
+
+// BunkerVerificationAttestationChallengedIterator is returned from FilterAttestationChallenged and is used to iterate over the raw logs and unpacked data for AttestationChallenged events raised by the BunkerVerification contract.
+type BunkerVerificationAttestationChallengedIterator struct {
+	Event *BunkerVerificationAttestationChallenged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationAttestationChallengedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationAttestationChallenged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationAttestationChallenged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationAttestationChallengedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationAttestationChallengedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationAttestationChallenged represents a AttestationChallenged event raised by the BunkerVerification contract.
+type BunkerVerificationAttestationChallenged struct {
+	Challenger      common.Address
+	Provider        common.Address
+	AttestationHash [32]byte
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterAttestationChallenged is a free log retrieval operation binding the contract event 0x48d84a903b64623652d0d22252a4a66df37f59e49c2e25804d03eaa1e2a3c425.
+//
+// Solidity: event AttestationChallenged(address indexed challenger, address indexed provider, bytes32 attestationHash)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterAttestationChallenged(opts *bind.FilterOpts, challenger []common.Address, provider []common.Address) (*BunkerVerificationAttestationChallengedIterator, error) {
+
+	var challengerRule []interface{}
+	for _, challengerItem := range challenger {
+		challengerRule = append(challengerRule, challengerItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "AttestationChallenged", challengerRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationAttestationChallengedIterator{contract: _BunkerVerification.contract, event: "AttestationChallenged", logs: logs, sub: sub}, nil
+}
+
+// WatchAttestationChallenged is a free log subscription operation binding the contract event 0x48d84a903b64623652d0d22252a4a66df37f59e49c2e25804d03eaa1e2a3c425.
+//
+// Solidity: event AttestationChallenged(address indexed challenger, address indexed provider, bytes32 attestationHash)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchAttestationChallenged(opts *bind.WatchOpts, sink chan<- *BunkerVerificationAttestationChallenged, challenger []common.Address, provider []common.Address) (event.Subscription, error) {
+
+	var challengerRule []interface{}
+	for _, challengerItem := range challenger {
+		challengerRule = append(challengerRule, challengerItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "AttestationChallenged", challengerRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationAttestationChallenged)
+				if err := _BunkerVerification.contract.UnpackLog(event, "AttestationChallenged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAttestationChallenged is a log parse operation binding the contract event 0x48d84a903b64623652d0d22252a4a66df37f59e49c2e25804d03eaa1e2a3c425.
+//
+// Solidity: event AttestationChallenged(address indexed challenger, address indexed provider, bytes32 attestationHash)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseAttestationChallenged(log types.Log) (*BunkerVerificationAttestationChallenged, error) {
+	event := new(BunkerVerificationAttestationChallenged)
+	if err := _BunkerVerification.contract.UnpackLog(event, "AttestationChallenged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationAttestationIntervalUpdatedIterator is returned from FilterAttestationIntervalUpdated and is used to iterate over the raw logs and unpacked data for AttestationIntervalUpdated events raised by the BunkerVerification contract.
+type BunkerVerificationAttestationIntervalUpdatedIterator struct {
+	Event *BunkerVerificationAttestationIntervalUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationAttestationIntervalUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationAttestationIntervalUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationAttestationIntervalUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationAttestationIntervalUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationAttestationIntervalUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationAttestationIntervalUpdated represents a AttestationIntervalUpdated event raised by the BunkerVerification contract.
+type BunkerVerificationAttestationIntervalUpdated struct {
+	OldInterval *big.Int
+	NewInterval *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterAttestationIntervalUpdated is a free log retrieval operation binding the contract event 0x269143a4310afed4c9c59d993804ae3a0c5a60064c6b5aa267857857f98f4bd1.
+//
+// Solidity: event AttestationIntervalUpdated(uint256 oldInterval, uint256 newInterval)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterAttestationIntervalUpdated(opts *bind.FilterOpts) (*BunkerVerificationAttestationIntervalUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "AttestationIntervalUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationAttestationIntervalUpdatedIterator{contract: _BunkerVerification.contract, event: "AttestationIntervalUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchAttestationIntervalUpdated is a free log subscription operation binding the contract event 0x269143a4310afed4c9c59d993804ae3a0c5a60064c6b5aa267857857f98f4bd1.
+//
+// Solidity: event AttestationIntervalUpdated(uint256 oldInterval, uint256 newInterval)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchAttestationIntervalUpdated(opts *bind.WatchOpts, sink chan<- *BunkerVerificationAttestationIntervalUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "AttestationIntervalUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationAttestationIntervalUpdated)
+				if err := _BunkerVerification.contract.UnpackLog(event, "AttestationIntervalUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAttestationIntervalUpdated is a log parse operation binding the contract event 0x269143a4310afed4c9c59d993804ae3a0c5a60064c6b5aa267857857f98f4bd1.
+//
+// Solidity: event AttestationIntervalUpdated(uint256 oldInterval, uint256 newInterval)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseAttestationIntervalUpdated(log types.Log) (*BunkerVerificationAttestationIntervalUpdated, error) {
+	event := new(BunkerVerificationAttestationIntervalUpdated)
+	if err := _BunkerVerification.contract.UnpackLog(event, "AttestationIntervalUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationAttestationMissedIterator is returned from FilterAttestationMissed and is used to iterate over the raw logs and unpacked data for AttestationMissed events raised by the BunkerVerification contract.
+type BunkerVerificationAttestationMissedIterator struct {
+	Event *BunkerVerificationAttestationMissed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationAttestationMissedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationAttestationMissed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationAttestationMissed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationAttestationMissedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationAttestationMissedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationAttestationMissed represents a AttestationMissed event raised by the BunkerVerification contract.
+type BunkerVerificationAttestationMissed struct {
+	Provider          common.Address
+	ConsecutiveMissed uint32
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterAttestationMissed is a free log retrieval operation binding the contract event 0x280ba3e3e6e91883f617dd57a3f1a133eadd1364f3f394d6551bb09d1ba77581.
+//
+// Solidity: event AttestationMissed(address indexed provider, uint32 consecutiveMissed)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterAttestationMissed(opts *bind.FilterOpts, provider []common.Address) (*BunkerVerificationAttestationMissedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "AttestationMissed", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationAttestationMissedIterator{contract: _BunkerVerification.contract, event: "AttestationMissed", logs: logs, sub: sub}, nil
+}
+
+// WatchAttestationMissed is a free log subscription operation binding the contract event 0x280ba3e3e6e91883f617dd57a3f1a133eadd1364f3f394d6551bb09d1ba77581.
+//
+// Solidity: event AttestationMissed(address indexed provider, uint32 consecutiveMissed)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchAttestationMissed(opts *bind.WatchOpts, sink chan<- *BunkerVerificationAttestationMissed, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "AttestationMissed", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationAttestationMissed)
+				if err := _BunkerVerification.contract.UnpackLog(event, "AttestationMissed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAttestationMissed is a log parse operation binding the contract event 0x280ba3e3e6e91883f617dd57a3f1a133eadd1364f3f394d6551bb09d1ba77581.
+//
+// Solidity: event AttestationMissed(address indexed provider, uint32 consecutiveMissed)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseAttestationMissed(log types.Log) (*BunkerVerificationAttestationMissed, error) {
+	event := new(BunkerVerificationAttestationMissed)
+	if err := _BunkerVerification.contract.UnpackLog(event, "AttestationMissed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationAttestationSubmittedIterator is returned from FilterAttestationSubmitted and is used to iterate over the raw logs and unpacked data for AttestationSubmitted events raised by the BunkerVerification contract.
+type BunkerVerificationAttestationSubmittedIterator struct {
+	Event *BunkerVerificationAttestationSubmitted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationAttestationSubmittedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationAttestationSubmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationAttestationSubmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationAttestationSubmittedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationAttestationSubmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationAttestationSubmitted represents a AttestationSubmitted event raised by the BunkerVerification contract.
+type BunkerVerificationAttestationSubmitted struct {
+	Provider          common.Address
+	AttestationHash   [32]byte
+	TotalAttestations uint32
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterAttestationSubmitted is a free log retrieval operation binding the contract event 0x424013c4cbe6b87d14eb842300bd7feb22f8a369fe66c29ed215cbe89b966e51.
+//
+// Solidity: event AttestationSubmitted(address indexed provider, bytes32 attestationHash, uint32 totalAttestations)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterAttestationSubmitted(opts *bind.FilterOpts, provider []common.Address) (*BunkerVerificationAttestationSubmittedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "AttestationSubmitted", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationAttestationSubmittedIterator{contract: _BunkerVerification.contract, event: "AttestationSubmitted", logs: logs, sub: sub}, nil
+}
+
+// WatchAttestationSubmitted is a free log subscription operation binding the contract event 0x424013c4cbe6b87d14eb842300bd7feb22f8a369fe66c29ed215cbe89b966e51.
+//
+// Solidity: event AttestationSubmitted(address indexed provider, bytes32 attestationHash, uint32 totalAttestations)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchAttestationSubmitted(opts *bind.WatchOpts, sink chan<- *BunkerVerificationAttestationSubmitted, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "AttestationSubmitted", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationAttestationSubmitted)
+				if err := _BunkerVerification.contract.UnpackLog(event, "AttestationSubmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAttestationSubmitted is a log parse operation binding the contract event 0x424013c4cbe6b87d14eb842300bd7feb22f8a369fe66c29ed215cbe89b966e51.
+//
+// Solidity: event AttestationSubmitted(address indexed provider, bytes32 attestationHash, uint32 totalAttestations)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseAttestationSubmitted(log types.Log) (*BunkerVerificationAttestationSubmitted, error) {
+	event := new(BunkerVerificationAttestationSubmitted)
+	if err := _BunkerVerification.contract.UnpackLog(event, "AttestationSubmitted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationMaxMissedAttestationsUpdatedIterator is returned from FilterMaxMissedAttestationsUpdated and is used to iterate over the raw logs and unpacked data for MaxMissedAttestationsUpdated events raised by the BunkerVerification contract.
+type BunkerVerificationMaxMissedAttestationsUpdatedIterator struct {
+	Event *BunkerVerificationMaxMissedAttestationsUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationMaxMissedAttestationsUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationMaxMissedAttestationsUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationMaxMissedAttestationsUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationMaxMissedAttestationsUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationMaxMissedAttestationsUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationMaxMissedAttestationsUpdated represents a MaxMissedAttestationsUpdated event raised by the BunkerVerification contract.
+type BunkerVerificationMaxMissedAttestationsUpdated struct {
+	OldMax *big.Int
+	NewMax *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterMaxMissedAttestationsUpdated is a free log retrieval operation binding the contract event 0x5a1cf7b040e3f28a0035107d9e150b6593f46205cb2c131835c5e26141708a64.
+//
+// Solidity: event MaxMissedAttestationsUpdated(uint256 oldMax, uint256 newMax)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterMaxMissedAttestationsUpdated(opts *bind.FilterOpts) (*BunkerVerificationMaxMissedAttestationsUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "MaxMissedAttestationsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationMaxMissedAttestationsUpdatedIterator{contract: _BunkerVerification.contract, event: "MaxMissedAttestationsUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMaxMissedAttestationsUpdated is a free log subscription operation binding the contract event 0x5a1cf7b040e3f28a0035107d9e150b6593f46205cb2c131835c5e26141708a64.
+//
+// Solidity: event MaxMissedAttestationsUpdated(uint256 oldMax, uint256 newMax)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchMaxMissedAttestationsUpdated(opts *bind.WatchOpts, sink chan<- *BunkerVerificationMaxMissedAttestationsUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "MaxMissedAttestationsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationMaxMissedAttestationsUpdated)
+				if err := _BunkerVerification.contract.UnpackLog(event, "MaxMissedAttestationsUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMaxMissedAttestationsUpdated is a log parse operation binding the contract event 0x5a1cf7b040e3f28a0035107d9e150b6593f46205cb2c131835c5e26141708a64.
+//
+// Solidity: event MaxMissedAttestationsUpdated(uint256 oldMax, uint256 newMax)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseMaxMissedAttestationsUpdated(log types.Log) (*BunkerVerificationMaxMissedAttestationsUpdated, error) {
+	event := new(BunkerVerificationMaxMissedAttestationsUpdated)
+	if err := _BunkerVerification.contract.UnpackLog(event, "MaxMissedAttestationsUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the BunkerVerification contract.
+type BunkerVerificationOwnershipTransferStartedIterator struct {
+	Event *BunkerVerificationOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the BunkerVerification contract.
+type BunkerVerificationOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerVerificationOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationOwnershipTransferStartedIterator{contract: _BunkerVerification.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *BunkerVerificationOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationOwnershipTransferStarted)
+				if err := _BunkerVerification.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseOwnershipTransferStarted(log types.Log) (*BunkerVerificationOwnershipTransferStarted, error) {
+	event := new(BunkerVerificationOwnershipTransferStarted)
+	if err := _BunkerVerification.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the BunkerVerification contract.
+type BunkerVerificationOwnershipTransferredIterator struct {
+	Event *BunkerVerificationOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationOwnershipTransferred represents a OwnershipTransferred event raised by the BunkerVerification contract.
+type BunkerVerificationOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BunkerVerificationOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationOwnershipTransferredIterator{contract: _BunkerVerification.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BunkerVerificationOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationOwnershipTransferred)
+				if err := _BunkerVerification.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseOwnershipTransferred(log types.Log) (*BunkerVerificationOwnershipTransferred, error) {
+	event := new(BunkerVerificationOwnershipTransferred)
+	if err := _BunkerVerification.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationProviderReinstatedIterator is returned from FilterProviderReinstated and is used to iterate over the raw logs and unpacked data for ProviderReinstated events raised by the BunkerVerification contract.
+type BunkerVerificationProviderReinstatedIterator struct {
+	Event *BunkerVerificationProviderReinstated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationProviderReinstatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationProviderReinstated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationProviderReinstated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationProviderReinstatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationProviderReinstatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationProviderReinstated represents a ProviderReinstated event raised by the BunkerVerification contract.
+type BunkerVerificationProviderReinstated struct {
+	Provider common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderReinstated is a free log retrieval operation binding the contract event 0x0b8ceb75fcf9401085a9e463cacfa4e32c097b1c72ed746b9a140e7ddb628e6e.
+//
+// Solidity: event ProviderReinstated(address indexed provider)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterProviderReinstated(opts *bind.FilterOpts, provider []common.Address) (*BunkerVerificationProviderReinstatedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "ProviderReinstated", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationProviderReinstatedIterator{contract: _BunkerVerification.contract, event: "ProviderReinstated", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderReinstated is a free log subscription operation binding the contract event 0x0b8ceb75fcf9401085a9e463cacfa4e32c097b1c72ed746b9a140e7ddb628e6e.
+//
+// Solidity: event ProviderReinstated(address indexed provider)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchProviderReinstated(opts *bind.WatchOpts, sink chan<- *BunkerVerificationProviderReinstated, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "ProviderReinstated", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationProviderReinstated)
+				if err := _BunkerVerification.contract.UnpackLog(event, "ProviderReinstated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderReinstated is a log parse operation binding the contract event 0x0b8ceb75fcf9401085a9e463cacfa4e32c097b1c72ed746b9a140e7ddb628e6e.
+//
+// Solidity: event ProviderReinstated(address indexed provider)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseProviderReinstated(log types.Log) (*BunkerVerificationProviderReinstated, error) {
+	event := new(BunkerVerificationProviderReinstated)
+	if err := _BunkerVerification.contract.UnpackLog(event, "ProviderReinstated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationProviderSuspendedIterator is returned from FilterProviderSuspended and is used to iterate over the raw logs and unpacked data for ProviderSuspended events raised by the BunkerVerification contract.
+type BunkerVerificationProviderSuspendedIterator struct {
+	Event *BunkerVerificationProviderSuspended // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationProviderSuspendedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationProviderSuspended)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationProviderSuspended)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationProviderSuspendedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationProviderSuspendedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationProviderSuspended represents a ProviderSuspended event raised by the BunkerVerification contract.
+type BunkerVerificationProviderSuspended struct {
+	Provider    common.Address
+	MissedCount uint32
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderSuspended is a free log retrieval operation binding the contract event 0xca4b96ff49bd532b6699fa016a2eb5604552e789c2d54dc64bfc4a3e9beb2072.
+//
+// Solidity: event ProviderSuspended(address indexed provider, uint32 missedCount)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterProviderSuspended(opts *bind.FilterOpts, provider []common.Address) (*BunkerVerificationProviderSuspendedIterator, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "ProviderSuspended", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationProviderSuspendedIterator{contract: _BunkerVerification.contract, event: "ProviderSuspended", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderSuspended is a free log subscription operation binding the contract event 0xca4b96ff49bd532b6699fa016a2eb5604552e789c2d54dc64bfc4a3e9beb2072.
+//
+// Solidity: event ProviderSuspended(address indexed provider, uint32 missedCount)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchProviderSuspended(opts *bind.WatchOpts, sink chan<- *BunkerVerificationProviderSuspended, provider []common.Address) (event.Subscription, error) {
+
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "ProviderSuspended", providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationProviderSuspended)
+				if err := _BunkerVerification.contract.UnpackLog(event, "ProviderSuspended", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderSuspended is a log parse operation binding the contract event 0xca4b96ff49bd532b6699fa016a2eb5604552e789c2d54dc64bfc4a3e9beb2072.
+//
+// Solidity: event ProviderSuspended(address indexed provider, uint32 missedCount)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseProviderSuspended(log types.Log) (*BunkerVerificationProviderSuspended, error) {
+	event := new(BunkerVerificationProviderSuspended)
+	if err := _BunkerVerification.contract.UnpackLog(event, "ProviderSuspended", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationReinstatementCooldownUpdatedIterator is returned from FilterReinstatementCooldownUpdated and is used to iterate over the raw logs and unpacked data for ReinstatementCooldownUpdated events raised by the BunkerVerification contract.
+type BunkerVerificationReinstatementCooldownUpdatedIterator struct {
+	Event *BunkerVerificationReinstatementCooldownUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationReinstatementCooldownUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationReinstatementCooldownUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationReinstatementCooldownUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationReinstatementCooldownUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationReinstatementCooldownUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationReinstatementCooldownUpdated represents a ReinstatementCooldownUpdated event raised by the BunkerVerification contract.
+type BunkerVerificationReinstatementCooldownUpdated struct {
+	NewCooldown *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterReinstatementCooldownUpdated is a free log retrieval operation binding the contract event 0x7ed9b7a5ed787cf9733dfeaa734c68bb16202158613f1c65e62bb45f60425539.
+//
+// Solidity: event ReinstatementCooldownUpdated(uint256 newCooldown)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterReinstatementCooldownUpdated(opts *bind.FilterOpts) (*BunkerVerificationReinstatementCooldownUpdatedIterator, error) {
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "ReinstatementCooldownUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationReinstatementCooldownUpdatedIterator{contract: _BunkerVerification.contract, event: "ReinstatementCooldownUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchReinstatementCooldownUpdated is a free log subscription operation binding the contract event 0x7ed9b7a5ed787cf9733dfeaa734c68bb16202158613f1c65e62bb45f60425539.
+//
+// Solidity: event ReinstatementCooldownUpdated(uint256 newCooldown)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchReinstatementCooldownUpdated(opts *bind.WatchOpts, sink chan<- *BunkerVerificationReinstatementCooldownUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "ReinstatementCooldownUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationReinstatementCooldownUpdated)
+				if err := _BunkerVerification.contract.UnpackLog(event, "ReinstatementCooldownUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReinstatementCooldownUpdated is a log parse operation binding the contract event 0x7ed9b7a5ed787cf9733dfeaa734c68bb16202158613f1c65e62bb45f60425539.
+//
+// Solidity: event ReinstatementCooldownUpdated(uint256 newCooldown)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseReinstatementCooldownUpdated(log types.Log) (*BunkerVerificationReinstatementCooldownUpdated, error) {
+	event := new(BunkerVerificationReinstatementCooldownUpdated)
+	if err := _BunkerVerification.contract.UnpackLog(event, "ReinstatementCooldownUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the BunkerVerification contract.
+type BunkerVerificationRoleAdminChangedIterator struct {
+	Event *BunkerVerificationRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationRoleAdminChanged represents a RoleAdminChanged event raised by the BunkerVerification contract.
+type BunkerVerificationRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*BunkerVerificationRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationRoleAdminChangedIterator{contract: _BunkerVerification.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *BunkerVerificationRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationRoleAdminChanged)
+				if err := _BunkerVerification.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseRoleAdminChanged(log types.Log) (*BunkerVerificationRoleAdminChanged, error) {
+	event := new(BunkerVerificationRoleAdminChanged)
+	if err := _BunkerVerification.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the BunkerVerification contract.
+type BunkerVerificationRoleGrantedIterator struct {
+	Event *BunkerVerificationRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationRoleGranted represents a RoleGranted event raised by the BunkerVerification contract.
+type BunkerVerificationRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BunkerVerificationRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationRoleGrantedIterator{contract: _BunkerVerification.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *BunkerVerificationRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationRoleGranted)
+				if err := _BunkerVerification.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseRoleGranted(log types.Log) (*BunkerVerificationRoleGranted, error) {
+	event := new(BunkerVerificationRoleGranted)
+	if err := _BunkerVerification.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BunkerVerificationRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the BunkerVerification contract.
+type BunkerVerificationRoleRevokedIterator struct {
+	Event *BunkerVerificationRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BunkerVerificationRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BunkerVerificationRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BunkerVerificationRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BunkerVerificationRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BunkerVerificationRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BunkerVerificationRoleRevoked represents a RoleRevoked event raised by the BunkerVerification contract.
+type BunkerVerificationRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerVerification *BunkerVerificationFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BunkerVerificationRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BunkerVerificationRoleRevokedIterator{contract: _BunkerVerification.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerVerification *BunkerVerificationFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *BunkerVerificationRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BunkerVerification.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BunkerVerificationRoleRevoked)
+				if err := _BunkerVerification.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BunkerVerification *BunkerVerificationFilterer) ParseRoleRevoked(log types.Log) (*BunkerVerificationRoleRevoked, error) {
+	event := new(BunkerVerificationRoleRevoked)
+	if err := _BunkerVerification.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/internal/payment/contracts.go
+++ b/internal/payment/contracts.go
@@ -1293,7 +1293,20 @@ func (s DisputeState) String() string {
 
 // ─── Governance Contract ABIs ────────────────────────────────────────────────
 
-// DelegationContractABI is the ABI for the BunkerDelegation contract
+// DelegationContractABI is the ABI for the BunkerDelegation contract.
+//
+// DEPRECATED (ABIGEN-01): this hand-typed ABI is being retired. The read paths
+// (getDelegation, getProviderConfig) now decode through the abigen-generated
+// binding in internal/payment/bindings (bunkerdelegation.go); the only remaining
+// consumer is DelegationContract's Transact methods (delegate, requestUndelegate,
+// setDelegationConfig, …), which ABIGEN-01 Phase 2 will move onto the generated
+// Transactor. At that point this const is deleted.
+//
+// Do NOT edit this string to "fix" a decode mismatch — the canonical ABI source
+// is contracts/out/BunkerDelegation.sol/BunkerDelegation.json. Regenerate with
+// `make gen-bindings`. (This hand-typed getProviderConfig tuple was, in fact,
+// wrong — five fields instead of the on-chain six, in the wrong order — which is
+// exactly why read decoding moved to the generated binding.)
 const DelegationContractABI = `[
 	{
 		"inputs": [

--- a/internal/payment/delegation_contract.go
+++ b/internal/payment/delegation_contract.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/moltbunker/moltbunker/internal/logging"
+	"github.com/moltbunker/moltbunker/internal/payment/bindings"
 )
 
 // DelegationContract provides interface to the BunkerDelegation smart contract.
@@ -22,6 +23,15 @@ type DelegationContract struct {
 	contractABI  abi.ABI
 	contractAddr common.Address
 	mockMode     bool
+
+	// caller is the abigen-generated, type-safe read binding (ABIGEN-01 Phase 1).
+	// Read paths (GetDelegation, GetProviderConfig) decode through this instead of
+	// the hand-typed DelegationContractABI + fragile struct assertions. The
+	// contract/contractABI fields above are still used by the Transact methods
+	// until Phase 2 migrates them to the generated Transactor.
+	// TODO(ABIGEN-01-phase2): move Transact methods onto the generated binding and
+	// drop the hand-typed DelegationContractABI + the dual ABI load.
+	caller *bindings.BunkerDelegationCaller
 
 	// Mock state
 	mockDelegations    map[common.Address]*DelegationData
@@ -58,6 +68,17 @@ func NewDelegationContract(baseClient *BaseClient, contractAddr common.Address) 
 
 	client := baseClient.Client()
 	dc.contract = bind.NewBoundContract(contractAddr, parsedABI, client, client, client)
+
+	// ABIGEN-01 Phase 1: build the generated, type-safe read binding. Its ABI
+	// is sourced from contracts/out/BunkerDelegation.sol (canonical), so the
+	// getDelegation/getProviderConfig tuple shapes always match the deployed
+	// contract — closing the silent-decode-mismatch class of bugs that PAY-01
+	// patched by hand.
+	caller, err := bindings.NewBunkerDelegationCaller(contractAddr, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build delegation caller binding: %w", err)
+	}
+	dc.caller = caller
 
 	return dc, nil
 }
@@ -211,38 +232,6 @@ func (dc *DelegationContract) mockCompleteUndelegate(_ context.Context, index *b
 	return nil, nil
 }
 
-// delegationInfoTuple is the canonical Go shape that go-ethereum unpacks the
-// getDelegation() return tuple into. It must match the on-chain DelegationInfo
-// struct field-for-field, in declaration order:
-//
-//	struct DelegationInfo { address provider; uint128 amount; uint48 delegatedAt; bool active; }
-//
-// go-ethereum decodes uint128/uint48 into *big.Int. Field names (capitalized)
-// map to ABI component names by case-insensitive match. Keeping this as a named
-// type (rather than an inline anonymous struct) makes the decode path stable and
-// grep-able, and is the seam the abigen migration (ABIGEN-01) will replace.
-//
-// TODO(ABIGEN-01): replace with abigen-generated binding.
-type delegationInfoTuple struct {
-	Provider    common.Address
-	Amount      *big.Int
-	DelegatedAt *big.Int
-	Active      bool
-}
-
-// providerConfigTuple is the canonical Go shape getProviderConfig() unpacks
-// into, matching the Go-side ABI tuple declared in DelegationContractABI.
-// rewardCutEffectiveAt is uint48 on-chain and decodes as *big.Int (seconds).
-//
-// TODO(ABIGEN-01): replace with abigen-generated binding.
-type providerConfigTuple struct {
-	RewardCutBps         uint16
-	FeeShareBps          uint16
-	AcceptDelegations    bool
-	PendingRewardCutBps  uint16
-	RewardCutEffectiveAt *big.Int
-}
-
 // GetDelegation returns the delegation data for a delegator.
 func (dc *DelegationContract) GetDelegation(ctx context.Context, delegator common.Address) (*DelegationData, error) {
 	if dc.mockMode {
@@ -260,31 +249,26 @@ func (dc *DelegationContract) GetDelegation(ctx context.Context, delegator commo
 		}, nil
 	}
 
-	// go-ethereum decodes a single tuple return by mapping the output argument
-	// positionally onto the fields of the destination struct. The tuple is
-	// therefore the single field of an outer wrapper, decoded via
-	// UnpackIntoInterface (the bind.Call res[0] path). Asserting on the raw
-	// []interface{} fails because the runtime tuple type is a reflect.StructOf
-	// (with json tags) that is not identical to any named Go type — that
-	// mismatch is exactly the silent-zero bug this PR fixes.
-	var out struct {
-		Info delegationInfoTuple
-	}
-	result := []interface{}{&out}
-	if err := dc.contract.Call(&bind.CallOpts{Context: ctx}, &result, "getDelegation", delegator); err != nil {
+	// ABIGEN-01 Phase 1: decode through the generated, type-safe caller. The
+	// returned BunkerDelegationDelegationInfo mirrors the on-chain DelegationInfo
+	// struct exactly (provider address, amount uint128->*big.Int,
+	// delegatedAt uint48->*big.Int, active bool), so there is no positional
+	// struct-assertion to silently mismatch.
+	info, err := dc.caller.GetDelegation(&bind.CallOpts{Context: ctx}, delegator)
+	if err != nil {
 		return nil, fmt.Errorf("failed to get delegation: %w", err)
 	}
 
 	data := &DelegationData{
-		Provider: out.Info.Provider,
+		Provider: info.Provider,
 		Amount:   big.NewInt(0),
-		Active:   out.Info.Active,
+		Active:   info.Active,
 	}
-	if out.Info.Amount != nil {
-		data.Amount = out.Info.Amount
+	if info.Amount != nil {
+		data.Amount = info.Amount
 	}
-	if out.Info.DelegatedAt != nil {
-		data.DelegatedAt = time.Unix(out.Info.DelegatedAt.Int64(), 0)
+	if info.DelegatedAt != nil {
+		data.DelegatedAt = time.Unix(info.DelegatedAt.Int64(), 0)
 	}
 	return data, nil
 }
@@ -310,26 +294,32 @@ func (dc *DelegationContract) GetProviderConfig(ctx context.Context, provider co
 		}, nil
 	}
 
-	// Same single-tuple-output decode pattern as GetDelegation: the tuple is the
-	// single field of an outer wrapper, mapped positionally via the bind.Call
-	// res[0] UnpackIntoInterface path (a raw []interface{} assertion would
-	// silently fail because the runtime tuple type is a reflect.StructOf).
-	var out struct {
-		Config providerConfigTuple
-	}
-	result := []interface{}{&out}
-	if err := dc.contract.Call(&bind.CallOpts{Context: ctx}, &result, "getProviderConfig", provider); err != nil {
+	// ABIGEN-01 Phase 1: decode through the generated caller. The on-chain
+	// ProviderDelegationConfig tuple is
+	//   {rewardCutBps, pendingRewardCutBps, rewardCutEffectiveAt, feeShareBps,
+	//    totalDelegated, acceptingDelegations}
+	// — which the hand-typed DelegationContractABI got wrong (only five fields,
+	// in the wrong order, with acceptDelegations instead of acceptingDelegations
+	// and no totalDelegated). The generated binding always matches the deployed
+	// contract.
+	//
+	// NOTE: cfg.TotalDelegated is decoded by the binding but not carried on the
+	// domain ProviderDelegationConfigData yet; GetTotalDelegatedTo already serves
+	// that value. Surfacing it here (and feeding determineTier in
+	// staking_contract.go) is the C4 follow-up.
+	cfg, err := dc.caller.GetProviderConfig(&bind.CallOpts{Context: ctx}, provider)
+	if err != nil {
 		return nil, fmt.Errorf("failed to get provider config: %w", err)
 	}
 
 	data := &ProviderDelegationConfigData{
-		RewardCutBps:        out.Config.RewardCutBps,
-		FeeShareBps:         out.Config.FeeShareBps,
-		AcceptDelegations:   out.Config.AcceptDelegations,
-		PendingRewardCutBps: out.Config.PendingRewardCutBps,
+		RewardCutBps:        cfg.RewardCutBps,
+		FeeShareBps:         cfg.FeeShareBps,
+		AcceptDelegations:   cfg.AcceptingDelegations,
+		PendingRewardCutBps: cfg.PendingRewardCutBps,
 	}
-	if out.Config.RewardCutEffectiveAt != nil {
-		data.RewardCutEffectiveAt = time.Unix(out.Config.RewardCutEffectiveAt.Int64(), 0)
+	if cfg.RewardCutEffectiveAt != nil {
+		data.RewardCutEffectiveAt = time.Unix(cfg.RewardCutEffectiveAt.Int64(), 0)
 	}
 	return data, nil
 }

--- a/internal/payment/delegation_contract_test.go
+++ b/internal/payment/delegation_contract_test.go
@@ -66,6 +66,41 @@ func TestDelegationContract_MockGetDelegation(t *testing.T) {
 	}
 }
 
+// TestDelegationContract_MockGetDelegationActive verifies the Active bool field
+// is preserved through the mock GetDelegation path. The pre-PAY-01/ABIGEN-01 bug
+// silently dropped Active (always false); this guards the mock branch that the
+// generated-binding production path is modeled on.
+func TestDelegationContract_MockGetDelegationActive(t *testing.T) {
+	dc := NewMockDelegationContract()
+	ctx := context.Background()
+	provider := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	delegator := common.Address{}
+
+	// No delegation yet: zero-value, not active.
+	empty, err := dc.GetDelegation(ctx, delegator)
+	if err != nil {
+		t.Fatalf("get empty delegation: %v", err)
+	}
+	if empty.Active {
+		t.Error("expected Active=false for absent delegation")
+	}
+
+	// After delegating, Active must be true.
+	if _, err := dc.Delegate(ctx, provider, parseWei("750")); err != nil {
+		t.Fatalf("delegate: %v", err)
+	}
+	del, err := dc.GetDelegation(ctx, delegator)
+	if err != nil {
+		t.Fatalf("get delegation: %v", err)
+	}
+	if !del.Active {
+		t.Error("expected Active=true after delegation (the old bug returned false)")
+	}
+	if del.Amount.Cmp(parseWei("750")) != 0 {
+		t.Errorf("expected 750 delegated, got %s", del.Amount.String())
+	}
+}
+
 func TestDelegationContract_MockProviderConfig(t *testing.T) {
 	dc := NewMockDelegationContract()
 	ctx := context.Background()

--- a/internal/payment/generate.go
+++ b/internal/payment/generate.go
@@ -1,0 +1,12 @@
+package payment
+
+// Contract bindings in internal/payment/bindings/ are generated from the
+// canonical forge artifacts in contracts/out/ by scripts/gen-bindings.sh.
+//
+// Run `go generate ./internal/payment/...` (or `make gen-bindings`) after the
+// Solidity contracts change. The generated files are committed, so a normal
+// `go build` needs only the Go toolchain — the generation toolchain (forge, jq,
+// abigen) is required only when regenerating. `make bindings-check` detects
+// drift between the committed bindings and a fresh generation.
+
+//go:generate ../../scripts/gen-bindings.sh

--- a/internal/payment/payment_abi_test.go
+++ b/internal/payment/payment_abi_test.go
@@ -1,18 +1,22 @@
 package payment
 
 import (
+	"encoding/json"
 	"math/big"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/moltbunker/moltbunker/internal/payment/bindings"
 )
 
-// TestDelegationABIRoundTrip pins the getDelegation output tuple shape at ABI
-// parse time so a future edit that reintroduces the phantom rewardDebt field or
-// the wrong integer width is caught immediately (regression guard for the
-// silent-zero decode bug).
+// TestDelegationABIRoundTrip pins the getDelegation output tuple shape in the
+// hand-typed DelegationContractABI (still loaded for the Transact methods until
+// ABIGEN-01 Phase 2) so a future edit that reintroduces the phantom rewardDebt
+// field or the wrong integer width is caught immediately.
 func TestDelegationABIRoundTrip(t *testing.T) {
 	parsed, err := abi.JSON(strings.NewReader(DelegationContractABI))
 	if err != nil {
@@ -32,7 +36,6 @@ func TestDelegationABIRoundTrip(t *testing.T) {
 		t.Fatalf("expected tuple output, got %v", tuple.T)
 	}
 
-	// Exactly four components, in declaration order, with the correct types.
 	wantNames := []string{"provider", "amount", "delegatedAt", "active"}
 	if len(tuple.TupleElems) != len(wantNames) {
 		t.Fatalf("expected %d tuple components, got %d (%v)",
@@ -44,14 +47,12 @@ func TestDelegationABIRoundTrip(t *testing.T) {
 		}
 	}
 
-	// Assert no rewardDebt component lingers anywhere in the tuple.
 	for _, n := range tuple.TupleRawNames {
 		if n == "rewardDebt" {
 			t.Fatal("phantom rewardDebt component must not exist in getDelegation tuple")
 		}
 	}
 
-	// Type assertions: provider=address, amount=uint128, delegatedAt=uint48, active=bool.
 	if got := tuple.TupleElems[0].String(); got != "address" {
 		t.Errorf("provider type: want address, got %s", got)
 	}
@@ -66,15 +67,15 @@ func TestDelegationABIRoundTrip(t *testing.T) {
 	}
 }
 
-// TestDelegationDecodeSilentZero_Regression encodes a DelegationInfo tuple with
-// the corrected ABI and decodes it the same way production does — via
-// UnpackIntoInterface into the canonical delegationInfoTuple — proving the
-// decode succeeds and active=true is preserved (the old mismatched ABI silently
-// returned zero values, so active was always false).
-func TestDelegationDecodeSilentZero_Regression(t *testing.T) {
-	parsed, err := abi.JSON(strings.NewReader(DelegationContractABI))
+// TestDelegationGeneratedBindingDecode packs a DelegationInfo tuple using the
+// generated binding's ABI and decodes it into the generated
+// BunkerDelegationDelegationInfo struct — proving the production read path
+// (GetDelegation -> caller.GetDelegation) round-trips and active=true survives
+// (the old mismatched ABI silently zeroed it).
+func TestDelegationGeneratedBindingDecode(t *testing.T) {
+	parsed, err := bindings.BunkerDelegationMetaData.GetAbi()
 	if err != nil {
-		t.Fatalf("parse delegation ABI: %v", err)
+		t.Fatalf("load generated binding ABI: %v", err)
 	}
 	args := parsed.Methods["getDelegation"].Outputs
 
@@ -82,7 +83,7 @@ func TestDelegationDecodeSilentZero_Regression(t *testing.T) {
 	amount := big.NewInt(1000)
 	delegatedAt := big.NewInt(1718000000)
 
-	packed, err := args.Pack(delegationInfoTuple{
+	packed, err := args.Pack(bindings.BunkerDelegationDelegationInfo{
 		Provider:    provider,
 		Amount:      amount,
 		DelegatedAt: delegatedAt,
@@ -92,10 +93,8 @@ func TestDelegationDecodeSilentZero_Regression(t *testing.T) {
 		t.Fatalf("pack tuple: %v", err)
 	}
 
-	// Decode exactly as GetDelegation does: tuple is the single field of an
-	// outer wrapper, mapped positionally by UnpackIntoInterface.
 	var out struct {
-		Info delegationInfoTuple
+		Info bindings.BunkerDelegationDelegationInfo
 	}
 	if err := parsed.UnpackIntoInterface(&out, "getDelegation", packed); err != nil {
 		t.Fatalf("UnpackIntoInterface: %v", err)
@@ -111,44 +110,44 @@ func TestDelegationDecodeSilentZero_Regression(t *testing.T) {
 		t.Errorf("delegatedAt: want %s, got %v", delegatedAt, res.DelegatedAt)
 	}
 	if !res.Active {
-		t.Error("active: want true (the bug always returned false)")
+		t.Error("active: want true (the old bug always returned false)")
 	}
 }
 
-// TestGetProviderConfigDecode encodes a ProviderDelegationConfig tuple in the
-// Go-side ABI's declared shape and verifies all five components decode via the
-// same UnpackIntoInterface path the contract client uses.
-func TestGetProviderConfigDecode(t *testing.T) {
-	parsed, err := abi.JSON(strings.NewReader(DelegationContractABI))
+// TestProviderConfigGeneratedBindingDecode packs a ProviderDelegationConfig tuple
+// using the generated binding's ABI (six fields, on-chain order) and decodes it
+// into BunkerDelegationProviderDelegationConfig. This is the field that the
+// hand-typed ABI got wrong (five fields, wrong order, acceptDelegations instead
+// of acceptingDelegations, no totalDelegated) — the generated binding decodes
+// acceptingDelegations and totalDelegated correctly.
+func TestProviderConfigGeneratedBindingDecode(t *testing.T) {
+	parsed, err := bindings.BunkerDelegationMetaData.GetAbi()
 	if err != nil {
-		t.Fatalf("parse delegation ABI: %v", err)
+		t.Fatalf("load generated binding ABI: %v", err)
 	}
-	method, ok := parsed.Methods["getProviderConfig"]
-	if !ok {
-		t.Fatal("getProviderConfig method missing from ABI")
-	}
-	args := method.Outputs
+	args := parsed.Methods["getProviderConfig"].Outputs
 	tuple := args[0].Type
 	if tuple.T != abi.TupleTy {
 		t.Fatalf("expected tuple output, got %v", tuple.T)
 	}
-	if len(tuple.TupleElems) != 5 {
-		t.Fatalf("expected 5 tuple components, got %d", len(tuple.TupleElems))
+	if len(tuple.TupleElems) != 6 {
+		t.Fatalf("expected 6 tuple components, got %d", len(tuple.TupleElems))
 	}
 
-	packed, err := args.Pack(providerConfigTuple{
+	packed, err := args.Pack(bindings.BunkerDelegationProviderDelegationConfig{
 		RewardCutBps:         1000,
-		FeeShareBps:          250,
-		AcceptDelegations:    true,
 		PendingRewardCutBps:  1500,
 		RewardCutEffectiveAt: big.NewInt(1718000000),
+		FeeShareBps:          250,
+		TotalDelegated:       big.NewInt(42),
+		AcceptingDelegations: true,
 	})
 	if err != nil {
 		t.Fatalf("pack config tuple: %v", err)
 	}
 
 	var out struct {
-		Config providerConfigTuple
+		Config bindings.BunkerDelegationProviderDelegationConfig
 	}
 	if err := parsed.UnpackIntoInterface(&out, "getProviderConfig", packed); err != nil {
 		t.Fatalf("UnpackIntoInterface: %v", err)
@@ -157,16 +156,92 @@ func TestGetProviderConfigDecode(t *testing.T) {
 	if res.RewardCutBps != 1000 {
 		t.Errorf("rewardCutBps: want 1000, got %d", res.RewardCutBps)
 	}
-	if res.FeeShareBps != 250 {
-		t.Errorf("feeShareBps: want 250, got %d", res.FeeShareBps)
-	}
-	if !res.AcceptDelegations {
-		t.Error("acceptDelegations: want true")
-	}
 	if res.PendingRewardCutBps != 1500 {
 		t.Errorf("pendingRewardCutBps: want 1500, got %d", res.PendingRewardCutBps)
 	}
+	if res.FeeShareBps != 250 {
+		t.Errorf("feeShareBps: want 250, got %d", res.FeeShareBps)
+	}
+	if res.TotalDelegated == nil || res.TotalDelegated.Cmp(big.NewInt(42)) != 0 {
+		t.Errorf("totalDelegated: want 42, got %v", res.TotalDelegated)
+	}
+	if !res.AcceptingDelegations {
+		t.Error("acceptingDelegations: want true (hand-typed ABI could not decode this field)")
+	}
 	if res.RewardCutEffectiveAt == nil || res.RewardCutEffectiveAt.Cmp(big.NewInt(1718000000)) != 0 {
 		t.Errorf("rewardCutEffectiveAt: want 1718000000, got %v", res.RewardCutEffectiveAt)
+	}
+}
+
+// forgeArtifact is the minimal shape we read out of a forge build artifact.
+type forgeArtifact struct {
+	ABI json.RawMessage `json:"abi"`
+}
+
+// TestDelegationABIMatchesSolidity is the schema-drift regression guard: it loads
+// the canonical forge artifact for BunkerDelegation and asserts that the
+// getDelegation and getProviderConfig output tuples match exactly what the
+// generated Go binding expects. If forge has not produced the artifact (e.g. CI
+// without the contracts toolchain), the test is skipped so `go test ./...` stays
+// green. When the artifact is present, this prevents silent re-introduction of
+// the decode mismatch that PAY-01/ABIGEN-01 addressed.
+func TestDelegationABIMatchesSolidity(t *testing.T) {
+	// internal/payment -> repo root is two levels up.
+	artifactPath := filepath.Join("..", "..", "contracts", "out", "BunkerDelegation.sol", "BunkerDelegation.json")
+	raw, err := os.ReadFile(artifactPath) // #nosec G304 -- fixed, repo-relative path to a build artifact in tests
+	if err != nil {
+		t.Skipf("forge artifact not present (%s); run `make gen-bindings` or `forge build`: %v", artifactPath, err)
+	}
+
+	var art forgeArtifact
+	if err := json.Unmarshal(raw, &art); err != nil {
+		t.Fatalf("unmarshal artifact: %v", err)
+	}
+	solABI, err := abi.JSON(strings.NewReader(string(art.ABI)))
+	if err != nil {
+		t.Fatalf("parse solidity ABI from artifact: %v", err)
+	}
+
+	// getDelegation: [provider address, amount uint128, delegatedAt uint48, active bool]
+	delTuple := solABI.Methods["getDelegation"].Outputs[0].Type
+	wantDel := []struct{ name, typ string }{
+		{"provider", "address"},
+		{"amount", "uint128"},
+		{"delegatedAt", "uint48"},
+		{"active", "bool"},
+	}
+	if len(delTuple.TupleElems) != len(wantDel) {
+		t.Fatalf("getDelegation: want %d components, got %d", len(wantDel), len(delTuple.TupleElems))
+	}
+	for i, w := range wantDel {
+		if delTuple.TupleRawNames[i] != w.name {
+			t.Errorf("getDelegation component %d: want name %q, got %q", i, w.name, delTuple.TupleRawNames[i])
+		}
+		if got := delTuple.TupleElems[i].String(); got != w.typ {
+			t.Errorf("getDelegation component %d (%s): want type %q, got %q", i, w.name, w.typ, got)
+		}
+	}
+
+	// getProviderConfig: the on-chain six-field tuple in declaration order.
+	cfgTuple := solABI.Methods["getProviderConfig"].Outputs[0].Type
+	wantCfg := []struct{ name, typ string }{
+		{"rewardCutBps", "uint16"},
+		{"pendingRewardCutBps", "uint16"},
+		{"rewardCutEffectiveAt", "uint48"},
+		{"feeShareBps", "uint16"},
+		{"totalDelegated", "uint128"},
+		{"acceptingDelegations", "bool"},
+	}
+	if len(cfgTuple.TupleElems) != len(wantCfg) {
+		t.Fatalf("getProviderConfig: want %d components, got %d (%v)",
+			len(wantCfg), len(cfgTuple.TupleElems), cfgTuple.TupleRawNames)
+	}
+	for i, w := range wantCfg {
+		if cfgTuple.TupleRawNames[i] != w.name {
+			t.Errorf("getProviderConfig component %d: want name %q, got %q", i, w.name, cfgTuple.TupleRawNames[i])
+		}
+		if got := cfgTuple.TupleElems[i].String(); got != w.typ {
+			t.Errorf("getProviderConfig component %d (%s): want type %q, got %q", i, w.name, w.typ, got)
+		}
 	}
 }

--- a/scripts/gen-bindings.sh
+++ b/scripts/gen-bindings.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# gen-bindings.sh — regenerate the Go contract bindings in
+# internal/payment/bindings/ from the canonical forge artifacts in
+# contracts/out/.
+#
+# Pipeline:
+#   1. forge build           -> refresh contracts/out/<Name>.sol/<Name>.json
+#   2. jq -r '.abi' …        -> extract the ABI array from each artifact
+#   3. abigen --abi … --out  -> emit a typed Go binding into bindings/
+#
+# The generated files are committed to the repo, so a normal `go build` needs
+# only the Go toolchain. This script is a developer tool, invoked intentionally
+# (via `make gen-bindings` / `go generate ./internal/payment/...`) when the
+# contracts change. CI uses `make bindings-check` to detect drift.
+#
+# Requirements on PATH (only when running this script, not for normal builds):
+#   - forge   (foundry)   : compile Solidity
+#   - jq                  : extract the .abi field from forge JSON
+#   - abigen  (go-ethereum): generate Go bindings
+#
+# NOTE on abigen version: the blueprint specified pinning abigen to the go.mod
+# go-ethereum version via `go run github.com/ethereum/go-ethereum/cmd/abigen`.
+# That path does not link on modern Go toolchains (the v1.13.10 abigen depends
+# on github.com/fjl/memsize, which references the now-removed runtime.stopTheWorld
+# symbol). We therefore use the `abigen` binary on PATH. Its output is the
+# stable abigen format and compiles cleanly against the pinned go-ethereum in
+# go.mod (verified). The bindings-check target guards against any drift.
+
+set -euo pipefail
+
+# Resolve repo root from this script's location (scripts/ lives at the root).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CONTRACTS_DIR="${ROOT_DIR}/contracts"
+BINDINGS_DIR="${ROOT_DIR}/internal/payment/bindings"
+PKG="bindings"
+
+# Foundry may not be on PATH but installed in the standard location; mirror the
+# Makefile's FOUNDRY_BIN fallback.
+if ! command -v forge >/dev/null 2>&1 && [ -x "${HOME}/.foundry/bin/forge" ]; then
+	export PATH="${HOME}/.foundry/bin:${PATH}"
+fi
+
+die() {
+	echo "error: $*" >&2
+	exit 1
+}
+
+# ─── Tool checks ──────────────────────────────────────────────────────────────
+command -v forge >/dev/null 2>&1 || die "'forge' not found on PATH. Install foundry: https://getfoundry.sh (curl -L https://foundry.paradigm.xyz | bash && foundryup)"
+command -v jq >/dev/null 2>&1 || die "'jq' not found on PATH. Install it (macOS: brew install jq, Debian/Ubuntu: apt-get install jq)."
+command -v abigen >/dev/null 2>&1 || die "'abigen' not found on PATH. Install it: go install github.com/ethereum/go-ethereum/cmd/abigen@latest"
+
+# ─── 1. Compile Solidity, refresh out/ ──────────────────────────────────────────
+echo ">> forge build (refreshing contracts/out/)"
+( cd "${CONTRACTS_DIR}" && forge build --quiet )
+
+# ─── 2. + 3. Extract ABI + generate binding for each contract ───────────────────
+mkdir -p "${BINDINGS_DIR}"
+
+# The eight first-party contracts whose bindings we generate. Phase 1 (ABIGEN-01)
+# only ADOPTS bunkerdelegation in code; the rest are generated so Phase 2 can
+# adopt them file-by-file without re-running the toolchain setup.
+CONTRACTS=(
+	BunkerToken
+	BunkerStaking
+	BunkerEscrow
+	BunkerPricing
+	BunkerDelegation
+	BunkerReputation
+	BunkerVerification
+	BunkerRegistry
+)
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+for name in "${CONTRACTS[@]}"; do
+	artifact="${CONTRACTS_DIR}/out/${name}.sol/${name}.json"
+	lower="$(echo "${name}" | tr '[:upper:]' '[:lower:]')"
+	abi_file="${TMP_DIR}/${lower}.abi"
+	out_file="${BINDINGS_DIR}/${lower}.go"
+
+	[ -f "${artifact}" ] || die "artifact not found: ${artifact} (did 'forge build' succeed?)"
+
+	# Extract the .abi array. Forge writes it as a JSON array under the top-level
+	# "abi" key; emit it compactly so abigen reads a clean ABI document.
+	jq -c '.abi' "${artifact}" > "${abi_file}"
+	[ -s "${abi_file}" ] || die "empty ABI extracted for ${name}"
+
+	echo ">> abigen ${name} -> internal/payment/bindings/${lower}.go"
+	abigen --abi "${abi_file}" --pkg "${PKG}" --type "${name}" --out "${out_file}"
+	# abigen writes 0600; normalize to 0644 so the committed source mode is stable
+	# and `make bindings-check` does not flag a mode-only diff.
+	chmod 0644 "${out_file}"
+done
+
+echo ">> done. Generated ${#CONTRACTS[@]} bindings in internal/payment/bindings/"


### PR DESCRIPTION
## ABIGEN-01 — Generated Go contract bindings (retire hand-typed ABI)

- **abigen + go:generate pipeline:** `scripts/gen-bindings.sh` runs `forge build` → `jq` → `abigen` into `internal/payment/bindings/` for all 8 first-party contracts; `make gen-bindings` regenerates and `make bindings-check` is a CI drift detector. Bindings are committed so normal builds need only Go.
- **Phase 1 migration:** `GetDelegation` + `GetProviderConfig` now decode through the generated binding. This fixes a **second latent ABI bug** beyond PAY-01: the hand-typed `getProviderConfig` declared 5 fields in the wrong order vs the on-chain 6-field `ProviderDelegationConfig` — the generated binding always matches the deployed contract. Public `PaymentService` API unchanged; artifact-vs-binding regression + round-trip tests added.
- Phase 2 (migrating the other 6 contracts' read paths) is a documented follow-up (`TODO(ABIGEN-01-phase2)`); all 8 binding files are already generated/committed.

Verification: build + vet + linux cross-build + gosec(0) + payment tests green; `make bindings-check` reproducible. Secret-scan clean — the 64-hex strings in bindings are public keccak event-topic hashes, not keys; no addresses embedded.

> **Stacked PR — base `PAY-01` (#35), sibling to RUN-01.** Structurally prevents the ABI-drift class of bug that PAY-01 fixed by hand.
