### PR TITLE
HARDEN-01 Harden container isolation: AppArmor, opt-in userns, disk-quota, Kata PIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,12 @@ configs/*
 # addresses-fragment.yaml is a deliberately committed codegen artifact
 # (human-readable reference generated from deployments/addresses.json). See ADDR-01.
 !configs/addresses-fragment.yaml
+# configs/apparmor/ holds the committed moltbunker-container AppArmor profile and
+# its SELinux note — shipped in-repo and embedded into the daemon binary. Re-include
+# the dir (so git can traverse it) and its non-secret policy text files. See HARDEN-01.
+!configs/apparmor/
+!configs/apparmor/moltbunker-container
+!configs/apparmor/moltbunker-container.selinux-note
 
 docs/
 

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/moltbunker/moltbunker/internal/p2p"
 	"github.com/moltbunker/moltbunker/internal/payment"
 	"github.com/moltbunker/moltbunker/internal/proxy"
+	"github.com/moltbunker/moltbunker/internal/runtime"
 	"github.com/moltbunker/moltbunker/internal/snapshot"
 	"github.com/moltbunker/moltbunker/internal/state"
 	"github.com/moltbunker/moltbunker/internal/storage"
@@ -142,6 +143,22 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// R9 (HARDEN-01): load the embedded moltbunker-container AppArmor profile into
+	// the kernel so the runtime's AppArmor confinement gate fires on a fresh
+	// install instead of silently no-op'ing. Linux-only (the loader is a no-op on
+	// other platforms) and non-fatal: a failure (missing apparmor_parser, AppArmor
+	// not enabled) only logs a warning — the deploy still proceeds without AA
+	// confinement. Operators can also load it via `moltbunker doctor --fix`.
+	if cfg.Security.AppArmorAutoLoad && goruntime.GOOS == "linux" {
+		if aaErr := (&runtime.AppArmorLoader{}).EnsureProfile(ctx, runtime.AppArmorProfileName, ""); aaErr != nil {
+			logging.Warn("AppArmor profile auto-load failed; containers will run without AppArmor confinement until loaded",
+				logging.Err(aaErr), logging.Component("apparmor"))
+		} else {
+			logging.Info("AppArmor profile auto-loaded",
+				"profile", runtime.AppArmorProfileName, logging.Component("apparmor"))
+		}
+	}
 
 	// Run JSON → bbolt migration (no-op if already migrated or no JSON files)
 	if err := state.MigrateFromJSON(ctx, stateStore, cfg.Daemon.DataDir); err != nil {

--- a/configs/apparmor/moltbunker-container
+++ b/configs/apparmor/moltbunker-container
@@ -1,0 +1,75 @@
+# moltbunker-container — canonical AppArmor profile for moltbunker tenant workloads
+#
+# Shipped in-repo and loaded into the kernel on first daemon start by
+# internal/runtime/apparmor_loader_linux.go (HARDEN-01, R9). Before this
+# profile existed and was auto-loaded, the gate in security_profile.go
+# (isAppArmorProfileLoaded) always fell through on a fresh install, so the
+# AppArmor branch silently no-op'd. This profile makes that gate fire.
+#
+# Structure intentionally mirrors Docker/moby's default container profile
+# (docker-default) so real-world base images (alpine, ubuntu, nginx) run
+# unmodified. It denies the dangerous classes the runtime should never need:
+# raw kernel memory, firmware, kernel module loading, mount/pivot_root, and
+# ptrace of processes outside the container's own peer group.
+#
+# See HARDEN-01 PR for rationale. SELinux hosts: see the companion
+# moltbunker-container.selinux-note file (we delegate to the OS vendor policy).
+
+#include <tunables/global>
+
+profile moltbunker-container flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network,
+  capability,
+  file,
+  umount,
+
+  # Allow signalling and ptrace within the same profile peer group only
+  # (containers may manage their own processes; cannot reach the host).
+  signal (receive) peer=moltbunker-container,
+  signal (send) peer=moltbunker-container,
+  ptrace (trace,read,tracedby,readby) peer=moltbunker-container,
+
+  # Host-side runtime control paths must remain off-limits to the container.
+  deny @{PROC}/* w,                          # deny write to all files in /proc not otherwise allowed
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** wkx,
+  deny @{PROC}/sys/[^k]** w,                  # deny /proc/sys except /proc/sys/k* (kernel.shm*)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm tunables
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/kcore rwklx,
+  deny @{PROC}/kmem rwklx,
+  deny @{PROC}/mem rwklx,
+
+  deny mount,
+  deny pivot_root,
+
+  # Block kernel module loading and raw firmware access.
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+  # Read-only access to the kernel-config surface the runtime needs.
+  @{PROC}/sys/kernel/shm* r,
+  /sys/fs/cgroup/** r,
+
+  # Allow normal filesystem layout used by base images.
+  /etc/** rk,
+  /lib/** rmix,
+  /lib64/** rmix,
+  /usr/** rmix,
+  /bin/** rmix,
+  /sbin/** rmix,
+  /tmp/** rwmix,
+  /var/** rwk,
+  /run/** rwk,
+  /home/** rwk,
+  /root/** rwk,
+
+  # deny write to the standard library/binary directories (immutable rootfs intent).
+  deny /lib/modules/** wklx,
+}

--- a/configs/apparmor/moltbunker-container.selinux-note
+++ b/configs/apparmor/moltbunker-container.selinux-note
@@ -1,0 +1,38 @@
+SELinux note for moltbunker-container (HARDEN-01, R9)
+=====================================================
+
+There is intentionally no separate SELinux policy module shipped in this repo.
+
+On SELinux-enabled hosts (RHEL, CentOS Stream, Fedora, Rocky, Alma), container
+isolation is provided by the `container-selinux` policy package, which is already
+installed and loaded as a dependency of the container runtime stack (runc,
+containerd, Kata). That policy defines the canonical `container_t` domain and the
+`container_file_t` type used to confine container processes and their files.
+
+Rather than ship and maintain a parallel, distro-specific .te/.pp policy module
+(which would drift from the OS vendor's and risk denials on policy upgrades), we
+delegate to the OS vendor policy and select its standard container context.
+
+How moltbunker uses it
+----------------------
+
+On a host where SELinux is enforcing, set:
+
+    ContainerSecurityProfile.SELinuxLabel = "system_u:system_r:container_t:s0"
+
+(see pkg/types/security.go). The runtime then emits this label into the OCI spec
+(WithSELinuxLabel in internal/runtime/security_profile.go), and the kernel's LSM
+confines the container to the vendor `container_t` domain — the SELinux analogue
+of the AppArmor `moltbunker-container` profile loaded on AppArmor hosts.
+
+AppArmor and SELinux are mutually exclusive at the kernel level: a given host
+runs at most one major LSM. The daemon loads the AppArmor profile only on
+AppArmor hosts (Ubuntu/Debian/SUSE) and relies on container-selinux on SELinux
+hosts; the disk-quota and user-namespace hardening (R12/R16) apply on both.
+
+Verifying on an SELinux host
+----------------------------
+
+    getenforce                              # should print "Enforcing"
+    sesearch -A -s container_t | head       # confirm the policy is present
+    ps -eZ | grep container_t               # running containers carry the label

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -453,6 +453,10 @@ type KataConfig struct {
 	KernelPath string `yaml:"kernel_path,omitempty"`
 	// ImagePath overrides the Kata rootfs/initrd path (default: auto-detect)
 	ImagePath string `yaml:"image_path,omitempty"`
+	// DefaultPIDs is the R17 VM-level PID ceiling, emitted as the
+	// io.katacontainers.config.hypervisor.default_pids annotation for Kata VM
+	// workloads. 0 = Kata default (unbounded). Recommended: 1024.
+	DefaultPIDs int `yaml:"default_pids,omitempty"`
 }
 
 // SecurityConfig contains security and container opacity settings
@@ -498,6 +502,13 @@ type SecurityConfig struct {
 	// MBENC2. Default false (lazy migration on next write). Use after a key
 	// change or to eagerly retag a legacy (MBENC1) database.
 	StateKeyRotationSweep bool `yaml:"state_key_rotation_sweep"`
+
+	// R9 (HARDEN-01) — AppArmor profile auto-load. When true (the default set by
+	// DefaultConfig), the daemon loads the embedded moltbunker-container AppArmor
+	// profile into the kernel on startup (Linux only) so the AppArmor confinement
+	// gate fires on a fresh install instead of silently no-op'ing. Set to false to
+	// manage the profile out-of-band (e.g. via a packaged /etc/apparmor.d file).
+	AppArmorAutoLoad bool `yaml:"apparmor_auto_load"`
 }
 
 // RedundancyConfig contains redundancy settings
@@ -781,8 +792,9 @@ func DefaultConfig() *Config {
 			Namespace:        "moltbunker",
 			RuntimeName:      "auto",
 			Kata: KataConfig{
-				VMMemoryMB: 256,
-				VMCPUs:     1,
+				VMMemoryMB:  256,
+				VMCPUs:      1,
+				DefaultPIDs: 1024, // R17: bound Kata VM workloads to 1024 PIDs by default
 			},
 			Molt: MoltRuntimeConfig{
 				Enabled:         false, // Opt-in: provider must explicitly enable
@@ -821,8 +833,9 @@ func DefaultConfig() *Config {
 				"TLS_CHACHA20_POLY1305_SHA256",
 				"TLS_AES_128_GCM_SHA256",
 			},
-			CertPinning: true,
-			MutualTLS:   true,
+			CertPinning:      true,
+			MutualTLS:        true,
+			AppArmorAutoLoad: true, // R9: load the embedded AppArmor profile on startup (Linux)
 		},
 		Redundancy: RedundancyConfig{
 			ReplicaCount:        3,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,6 +73,14 @@ func TestDefaultConfig(t *testing.T) {
 	if !cfg.Security.MutualTLS {
 		t.Error("expected mutual TLS enabled by default")
 	}
+
+	// HARDEN-01 defaults.
+	if !cfg.Security.AppArmorAutoLoad {
+		t.Error("R9: expected AppArmorAutoLoad enabled by default")
+	}
+	if cfg.Runtime.Kata.DefaultPIDs != 1024 {
+		t.Errorf("R17: expected Kata.DefaultPIDs default 1024, got %d", cfg.Runtime.Kata.DefaultPIDs)
+	}
 }
 
 func TestValidate(t *testing.T) {
@@ -197,9 +205,9 @@ func TestValidate(t *testing.T) {
 
 func TestIsProviderIsRequester(t *testing.T) {
 	tests := []struct {
-		role         types.NodeRole
-		isProvider   bool
-		isRequester  bool
+		role        types.NodeRole
+		isProvider  bool
+		isRequester bool
 	}{
 		{types.NodeRoleProvider, true, false},
 		{types.NodeRoleRequester, false, true},

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -225,12 +225,13 @@ func (s *APIServer) Start(ctx context.Context) error {
 	var kataConfig *runtime.KataConfig
 	if s.config != nil {
 		kata := s.config.Runtime.Kata
-		if kata.VMMemoryMB > 0 || kata.VMCPUs > 0 || kata.KernelPath != "" || kata.ImagePath != "" {
+		if kata.VMMemoryMB > 0 || kata.VMCPUs > 0 || kata.KernelPath != "" || kata.ImagePath != "" || kata.DefaultPIDs > 0 {
 			kataConfig = &runtime.KataConfig{
-				VMMemoryMB: kata.VMMemoryMB,
-				VMCPUs:     kata.VMCPUs,
-				KernelPath: kata.KernelPath,
-				ImagePath:  kata.ImagePath,
+				VMMemoryMB:  kata.VMMemoryMB,
+				VMCPUs:      kata.VMCPUs,
+				KernelPath:  kata.KernelPath,
+				ImagePath:   kata.ImagePath,
+				DefaultPIDs: kata.DefaultPIDs, // R17: VM PID ceiling annotation
 			}
 		}
 	}

--- a/internal/doctor/checker_apparmor_linux.go
+++ b/internal/doctor/checker_apparmor_linux.go
@@ -1,0 +1,99 @@
+//go:build linux
+
+package doctor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	"github.com/moltbunker/moltbunker/internal/runtime"
+)
+
+// AppArmorChecker verifies the moltbunker-container AppArmor profile is loaded so
+// the runtime's AppArmor confinement gate actually fires (HARDEN-01, R9). It can
+// auto-fix by loading the embedded profile via the AppArmorLoader.
+type AppArmorChecker struct {
+	// statFn / lookPathFn are seams for tests; nil means use the real os/exec funcs.
+	statFn     func(string) (os.FileInfo, error)
+	lookPathFn func(string) (string, error)
+	loader     appArmorLoader
+}
+
+// appArmorLoader is the subset of runtime.AppArmorLoader the checker depends on,
+// so tests can inject a fake without a real kernel.
+type appArmorLoader interface {
+	IsProfileLoaded(name string) bool
+	EnsureProfile(ctx context.Context, profileName, profilePath string) error
+}
+
+func NewAppArmorChecker() *AppArmorChecker {
+	return &AppArmorChecker{
+		statFn:     os.Stat,
+		lookPathFn: exec.LookPath,
+		loader:     &runtime.AppArmorLoader{},
+	}
+}
+
+func (c *AppArmorChecker) Name() string       { return "AppArmor profile" }
+func (c *AppArmorChecker) Category() Category { return CategorySecurity }
+func (c *AppArmorChecker) CanFix() bool       { return true }
+func (c *AppArmorChecker) Roles() []string    { return []string{"provider", "hybrid"} }
+
+func (c *AppArmorChecker) stat(p string) (os.FileInfo, error) {
+	if c.statFn != nil {
+		return c.statFn(p)
+	}
+	return os.Stat(p)
+}
+
+func (c *AppArmorChecker) lookPath(name string) (string, error) {
+	if c.lookPathFn != nil {
+		return c.lookPathFn(name)
+	}
+	return exec.LookPath(name)
+}
+
+func (c *AppArmorChecker) Check(_ context.Context) CheckResult {
+	result := CheckResult{Name: c.Name(), Category: c.Category()}
+
+	// (1) Is AppArmor active on this kernel at all?
+	if _, err := c.stat("/sys/kernel/security/apparmor"); err != nil {
+		result.Status = StatusSkipped
+		result.Message = "AppArmor: not available on this kernel/distro"
+		result.Details = "AppArmor LSM not present (/sys/kernel/security/apparmor missing). " +
+			"On SELinux hosts, container confinement is provided by container-selinux instead."
+		return result
+	}
+
+	// (2) Profile already loaded → all good.
+	if c.loader.IsProfileLoaded(runtime.AppArmorProfileName) {
+		result.Status = StatusOK
+		result.Message = "AppArmor: moltbunker-container profile loaded"
+		return result
+	}
+
+	// (3) Not loaded — is the parser available to load it?
+	if _, err := c.lookPath("apparmor_parser"); err != nil {
+		result.Status = StatusError
+		result.Message = "AppArmor: profile not loaded and apparmor_parser is missing"
+		result.Details = "Install the apparmor userspace tools (apt install apparmor) so the " +
+			"moltbunker-container profile can be loaded; otherwise containers run without AppArmor confinement."
+		result.Fixable = false
+		result.FixPackage = "apparmor"
+		return result
+	}
+
+	// (4) Parser present, profile not loaded → fixable warning.
+	result.Status = StatusWarning
+	result.Message = "AppArmor: moltbunker-container profile not loaded"
+	result.Details = "The runtime's AppArmor confinement gate will no-op until the profile is loaded. " +
+		"Run `moltbunker node doctor --fix` to load the embedded profile."
+	result.Fixable = true
+	result.FixCommand = "moltbunker node doctor --fix"
+	return result
+}
+
+func (c *AppArmorChecker) Fix(ctx context.Context, _ PackageManager) error {
+	return c.loader.EnsureProfile(ctx, runtime.AppArmorProfileName, "")
+}

--- a/internal/doctor/checker_apparmor_linux_test.go
+++ b/internal/doctor/checker_apparmor_linux_test.go
@@ -1,0 +1,77 @@
+//go:build linux
+
+package doctor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// fakeAALoader implements appArmorLoader for tests.
+type fakeAALoader struct {
+	loaded     bool
+	ensureErr  error
+	ensureCall bool
+}
+
+func (f *fakeAALoader) IsProfileLoaded(string) bool { return f.loaded }
+func (f *fakeAALoader) EnsureProfile(context.Context, string, string) error {
+	f.ensureCall = true
+	return f.ensureErr
+}
+
+func okStat(string) (os.FileInfo, error)  { return nil, nil }
+func errStat(string) (os.FileInfo, error) { return nil, errors.New("not found") }
+func okLook(string) (string, error)       { return "/usr/sbin/apparmor_parser", nil }
+func errLook(string) (string, error)      { return "", errors.New("not found") }
+
+func TestAppArmorChecker_SkippedWhenNoLSM(t *testing.T) {
+	c := &AppArmorChecker{statFn: errStat, lookPathFn: okLook, loader: &fakeAALoader{}}
+	res := c.Check(context.Background())
+	if res.Status != StatusSkipped {
+		t.Fatalf("expected StatusSkipped when AppArmor LSM absent, got %s", res.Status)
+	}
+}
+
+func TestAppArmorChecker_OKWhenLoaded(t *testing.T) {
+	c := &AppArmorChecker{statFn: okStat, lookPathFn: okLook, loader: &fakeAALoader{loaded: true}}
+	res := c.Check(context.Background())
+	if res.Status != StatusOK {
+		t.Fatalf("expected StatusOK when profile loaded, got %s", res.Status)
+	}
+}
+
+func TestAppArmorChecker_ErrorWhenParserMissing(t *testing.T) {
+	c := &AppArmorChecker{statFn: okStat, lookPathFn: errLook, loader: &fakeAALoader{loaded: false}}
+	res := c.Check(context.Background())
+	if res.Status != StatusError {
+		t.Fatalf("expected StatusError when parser missing, got %s", res.Status)
+	}
+	if res.Fixable {
+		t.Error("checker should not be auto-fixable when apparmor_parser is missing")
+	}
+}
+
+func TestAppArmorChecker_WarnWhenNotLoaded(t *testing.T) {
+	c := &AppArmorChecker{statFn: okStat, lookPathFn: okLook, loader: &fakeAALoader{loaded: false}}
+	res := c.Check(context.Background())
+	if res.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning when parser present but profile not loaded, got %s", res.Status)
+	}
+	if !res.Fixable {
+		t.Error("checker should be fixable when the parser is present")
+	}
+}
+
+func TestAppArmorChecker_FixCallsLoader(t *testing.T) {
+	fl := &fakeAALoader{loaded: false}
+	c := &AppArmorChecker{statFn: okStat, lookPathFn: okLook, loader: fl}
+	if err := c.Fix(context.Background(), nil); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	if !fl.ensureCall {
+		t.Error("Fix should call EnsureProfile on the loader")
+	}
+}

--- a/internal/doctor/checker_apparmor_other.go
+++ b/internal/doctor/checker_apparmor_other.go
@@ -1,0 +1,28 @@
+//go:build !linux
+
+package doctor
+
+import "context"
+
+// AppArmorChecker is a no-op on non-Linux platforms: it always reports Skipped so
+// `moltbunker doctor` output stays consistent across platforms without a build-tag
+// split at the registration site.
+type AppArmorChecker struct{}
+
+func NewAppArmorChecker() *AppArmorChecker { return &AppArmorChecker{} }
+
+func (c *AppArmorChecker) Name() string       { return "AppArmor profile" }
+func (c *AppArmorChecker) Category() Category { return CategorySecurity }
+func (c *AppArmorChecker) CanFix() bool       { return false }
+func (c *AppArmorChecker) Roles() []string    { return []string{"provider", "hybrid"} }
+
+func (c *AppArmorChecker) Check(_ context.Context) CheckResult {
+	return CheckResult{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   StatusSkipped,
+		Message:  "AppArmor: not applicable on this platform",
+	}
+}
+
+func (c *AppArmorChecker) Fix(_ context.Context, _ PackageManager) error { return nil }

--- a/internal/doctor/checker_hardening_linux_test.go
+++ b/internal/doctor/checker_hardening_linux_test.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package doctor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moltbunker/moltbunker/internal/runtime"
+)
+
+func TestUserNSChecker_OKWhenSupported(t *testing.T) {
+	c := &UserNSChecker{compatFn: func() runtime.UserNSCompatResult {
+		return runtime.UserNSCompatResult{Supported: true}
+	}}
+	if res := c.Check(context.Background()); res.Status != StatusOK {
+		t.Fatalf("expected StatusOK when userns supported, got %s", res.Status)
+	}
+}
+
+func TestUserNSChecker_WarnWhenUnsupported(t *testing.T) {
+	c := &UserNSChecker{compatFn: func() runtime.UserNSCompatResult {
+		return runtime.UserNSCompatResult{Supported: false, Reason: "max_user_namespaces=0"}
+	}}
+	res := c.Check(context.Background())
+	if res.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning when userns unsupported, got %s", res.Status)
+	}
+	if res.Details == "" {
+		t.Error("warning should carry remediation details")
+	}
+}
+
+func TestKataPIDsChecker_SkippedWhenNoKata(t *testing.T) {
+	c := &KataPIDsChecker{kataAvailableFn: func() bool { return false }}
+	if res := c.Check(context.Background()); res.Status != StatusSkipped {
+		t.Fatalf("expected StatusSkipped when Kata absent, got %s", res.Status)
+	}
+}
+
+func TestKataPIDsChecker_WarnWhenNoLimitAtAll(t *testing.T) {
+	// No effective OCI pids.limit and no Kata annotation -> warn.
+	c := &KataPIDsChecker{kataAvailableFn: func() bool { return true }, cfg: nil, ociPIDLimit: 0}
+	if res := c.Check(context.Background()); res.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning when no PID limit at all, got %s", res.Status)
+	}
+
+	c2 := &KataPIDsChecker{kataAvailableFn: func() bool { return true }, cfg: &runtime.KataConfig{DefaultPIDs: 0}, ociPIDLimit: 0}
+	if res := c2.Check(context.Background()); res.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning when DefaultPIDs == 0 and no OCI limit, got %s", res.Status)
+	}
+}
+
+// TestKataPIDsChecker_OKWhenOCILimitSet is the R17 correction: when the daemon's
+// effective OCI pids.limit is set, the kata-agent enforces it in-guest, so the
+// workload IS bounded even with no (inert) hypervisor annotation. The checker must
+// NOT warn in that case.
+func TestKataPIDsChecker_OKWhenOCILimitSet(t *testing.T) {
+	c := &KataPIDsChecker{kataAvailableFn: func() bool { return true }, cfg: nil, ociPIDLimit: 100}
+	res := c.Check(context.Background())
+	if res.Status != StatusOK {
+		t.Fatalf("expected StatusOK when OCI pids.limit is set, got %s", res.Status)
+	}
+}
+
+func TestKataPIDsChecker_OKWhenAnnotationSet(t *testing.T) {
+	// No OCI limit known, but a Kata annotation is configured: informational OK
+	// (annotation is a forward-looking hint, inert without enable_annotations).
+	c := &KataPIDsChecker{kataAvailableFn: func() bool { return true }, cfg: &runtime.KataConfig{DefaultPIDs: 1024}, ociPIDLimit: 0}
+	if res := c.Check(context.Background()); res.Status != StatusOK {
+		t.Fatalf("expected StatusOK when DefaultPIDs annotation set, got %s", res.Status)
+	}
+}
+
+func TestSetKataConfig_ReplacesChecker(t *testing.T) {
+	d := New(DoctorOptions{})
+	d.SetKataConfig(&runtime.KataConfig{DefaultPIDs: 2048}, 100)
+
+	var found *KataPIDsChecker
+	for _, c := range d.checkers {
+		if kc, ok := c.(*KataPIDsChecker); ok {
+			found = kc
+		}
+	}
+	if found == nil {
+		t.Fatal("expected a KataPIDsChecker to be registered")
+	}
+	if found.cfg == nil || found.cfg.DefaultPIDs != 2048 {
+		t.Errorf("SetKataConfig did not inject the config (got %+v)", found.cfg)
+	}
+	if found.ociPIDLimit != 100 {
+		t.Errorf("SetKataConfig did not inject the OCI PID limit (got %d, want 100)", found.ociPIDLimit)
+	}
+}

--- a/internal/doctor/checker_kata_pids_linux.go
+++ b/internal/doctor/checker_kata_pids_linux.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package doctor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moltbunker/moltbunker/internal/runtime"
+)
+
+// KataPIDsChecker warns when Kata Containers is available but no PID limit is in
+// effect for VM workloads (HARDEN-01, R17).
+//
+// The EFFECTIVE PID ceiling for a Kata workload is the OCI
+// linux.resources.pids.limit — the kata-agent enforces that cgroup limit inside
+// the guest. The daemon's deploy path always sets it (DefaultResources.PIDLimit,
+// default 100), so a workload is bounded whenever that value is > 0, regardless of
+// the io.katacontainers.config.hypervisor.default_pids annotation (which is not a
+// recognized Kata annotation and is inert without enable_annotations — see
+// container_lifecycle.go). This checker therefore considers BOTH the effective OCI
+// PID limit and the Kata config annotation, and only warns when NEITHER bounds the
+// guest.
+type KataPIDsChecker struct {
+	cfg *runtime.KataConfig
+	// ociPIDLimit is the daemon's effective OCI pids.limit for deployed workloads
+	// (Runtime.DefaultResources.PIDLimit). > 0 means the kata-agent enforces a PID
+	// ceiling in-guest. 0 means unknown/unset (e.g. a standalone doctor run that
+	// has not loaded the daemon config).
+	ociPIDLimit int
+	// kataAvailableFn is a seam for tests; nil means runtime.IsKataAvailable.
+	kataAvailableFn func() bool
+}
+
+// NewKataPIDsChecker builds the checker with the given Kata config. cfg may be nil
+// for a standalone doctor run that has not loaded the daemon config; the daemon
+// should pass the real config (and the effective OCI PID limit via
+// NewKataPIDsCheckerWithOCILimit) so the limit is evaluated.
+func NewKataPIDsChecker(cfg *runtime.KataConfig) *KataPIDsChecker {
+	return &KataPIDsChecker{cfg: cfg}
+}
+
+// NewKataPIDsCheckerWithOCILimit builds the checker with both the Kata config and
+// the daemon's effective OCI pids.limit for deployed workloads. The daemon should
+// use this so the R17 check reflects the real in-guest PID ceiling.
+func NewKataPIDsCheckerWithOCILimit(cfg *runtime.KataConfig, ociPIDLimit int) *KataPIDsChecker {
+	return &KataPIDsChecker{cfg: cfg, ociPIDLimit: ociPIDLimit}
+}
+
+func (c *KataPIDsChecker) Name() string       { return "Kata PID limit (R17)" }
+func (c *KataPIDsChecker) Category() Category { return CategorySecurity }
+func (c *KataPIDsChecker) CanFix() bool       { return false }
+func (c *KataPIDsChecker) Roles() []string    { return []string{"provider", "hybrid"} }
+
+func (c *KataPIDsChecker) Check(_ context.Context) CheckResult {
+	result := CheckResult{Name: c.Name(), Category: c.Category()}
+
+	available := runtime.IsKataAvailable
+	if c.kataAvailableFn != nil {
+		available = c.kataAvailableFn
+	}
+	if !available() {
+		result.Status = StatusSkipped
+		result.Message = "Kata PID limit: Kata not installed (no VM workloads)"
+		return result
+	}
+
+	// The effective in-guest PID ceiling is the OCI pids.limit (kata-agent-enforced
+	// in the guest cgroup). If the daemon sets it (> 0), VM workloads ARE bounded
+	// even though the default_pids hypervisor annotation is inert.
+	if c.ociPIDLimit > 0 {
+		result.Status = StatusOK
+		result.Message = fmt.Sprintf("Kata VM workloads bounded by OCI pids.limit: %d", c.ociPIDLimit)
+		result.Details = "The kata-agent enforces the OCI linux.resources.pids.limit inside the guest. " +
+			"This is the effective R17 PID ceiling for VM workloads; " +
+			"io.katacontainers.config.hypervisor.default_pids is inert without enable_annotations."
+		return result
+	}
+
+	if c.cfg != nil && c.cfg.DefaultPIDs > 0 {
+		// No known effective OCI limit, but a Kata annotation is configured. This is
+		// only a best-effort hint (the annotation is inert without enable_annotations),
+		// so surface it as informational rather than a clean OK.
+		result.Status = StatusOK
+		result.Message = fmt.Sprintf("Kata default_pids annotation set: %d (verify enable_annotations under R11)", c.cfg.DefaultPIDs)
+		result.Details = "The effective PID ceiling for VM workloads is the OCI pids.limit (kata-agent-enforced in-guest). " +
+			"io.katacontainers.config.hypervisor.default_pids is NOT a recognized Kata hypervisor annotation and is " +
+			"dropped unless listed in the Kata runtime TOML enable_annotations; treat it as a forward-looking hint only."
+		return result
+	}
+
+	result.Status = StatusWarning
+	result.Message = "Kata VM workloads have no PID limit"
+	result.Details = "Set a per-deployment OCI pids.limit via runtime.default_resources (recommended: 100) — " +
+		"the kata-agent enforces it inside the guest and it is the effective R17 PID ceiling. " +
+		"Note: io.katacontainers.config.hypervisor.default_pids is not a recognized Kata annotation and is inert " +
+		"without enable_annotations, so do not rely on runtime.kata.default_pids alone."
+	return result
+}
+
+func (c *KataPIDsChecker) Fix(_ context.Context, _ PackageManager) error { return nil }

--- a/internal/doctor/checker_kata_pids_other.go
+++ b/internal/doctor/checker_kata_pids_other.go
@@ -1,0 +1,44 @@
+//go:build !linux
+
+package doctor
+
+import (
+	"context"
+
+	"github.com/moltbunker/moltbunker/internal/runtime"
+)
+
+// KataPIDsChecker is a no-op on non-Linux platforms (Kata VM isolation is Linux
+// only); it always reports Skipped. The constructor keeps the same signature as
+// the Linux build so the registration site compiles without a build-tag split.
+type KataPIDsChecker struct {
+	cfg         *runtime.KataConfig
+	ociPIDLimit int
+}
+
+func NewKataPIDsChecker(cfg *runtime.KataConfig) *KataPIDsChecker {
+	return &KataPIDsChecker{cfg: cfg}
+}
+
+// NewKataPIDsCheckerWithOCILimit mirrors the Linux constructor so the daemon's
+// registration site compiles without a build-tag split. The field is unused on
+// non-Linux platforms (Kata VM isolation is Linux only).
+func NewKataPIDsCheckerWithOCILimit(cfg *runtime.KataConfig, ociPIDLimit int) *KataPIDsChecker {
+	return &KataPIDsChecker{cfg: cfg, ociPIDLimit: ociPIDLimit}
+}
+
+func (c *KataPIDsChecker) Name() string       { return "Kata PID limit (R17)" }
+func (c *KataPIDsChecker) Category() Category { return CategorySecurity }
+func (c *KataPIDsChecker) CanFix() bool       { return false }
+func (c *KataPIDsChecker) Roles() []string    { return []string{"provider", "hybrid"} }
+
+func (c *KataPIDsChecker) Check(_ context.Context) CheckResult {
+	return CheckResult{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   StatusSkipped,
+		Message:  "Kata PID limit: not applicable on this platform",
+	}
+}
+
+func (c *KataPIDsChecker) Fix(_ context.Context, _ PackageManager) error { return nil }

--- a/internal/doctor/checker_userns_linux.go
+++ b/internal/doctor/checker_userns_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package doctor
+
+import (
+	"context"
+
+	"github.com/moltbunker/moltbunker/internal/runtime"
+)
+
+// UserNSChecker reports whether unprivileged user namespaces are usable for tenant
+// deployment workloads (HARDEN-01, R12). A warning here means containers will run
+// in the host user namespace (container root == host root) instead of being mapped
+// to an unprivileged subordinate UID range.
+type UserNSChecker struct {
+	// compatFn is a seam for tests; nil means use runtime.CheckUserNSCompat.
+	compatFn func() runtime.UserNSCompatResult
+}
+
+func NewUserNSChecker() *UserNSChecker { return &UserNSChecker{} }
+
+func (c *UserNSChecker) Name() string       { return "User namespace support" }
+func (c *UserNSChecker) Category() Category { return CategorySecurity }
+func (c *UserNSChecker) CanFix() bool       { return false }
+func (c *UserNSChecker) Roles() []string    { return []string{"provider", "hybrid"} }
+
+func (c *UserNSChecker) Check(_ context.Context) CheckResult {
+	result := CheckResult{Name: c.Name(), Category: c.Category()}
+
+	compat := runtime.CheckUserNSCompat
+	if c.compatFn != nil {
+		compat = c.compatFn
+	}
+	res := compat()
+
+	if res.Supported {
+		result.Status = StatusOK
+		result.Message = "User namespaces enabled: tenant containers map to an unprivileged host UID range"
+		return result
+	}
+
+	result.Status = StatusWarning
+	result.Message = "User namespaces disabled: containers will run as host root"
+	result.Details = res.Reason + "\n" +
+		"Enable with: sysctl -w kernel.unprivileged_userns_clone=1 (Debian/Ubuntu), " +
+		"and ensure the daemon user has a subordinate ID range (e.g. add a line to /etc/subuid and /etc/subgid). " +
+		"Disk quota note (R16): with userns active, XFS project quotas track the host subordinate UID, not container UID 0."
+	return result
+}
+
+func (c *UserNSChecker) Fix(_ context.Context, _ PackageManager) error { return nil }

--- a/internal/doctor/checker_userns_other.go
+++ b/internal/doctor/checker_userns_other.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+package doctor
+
+import "context"
+
+// UserNSChecker is a no-op on non-Linux platforms (user namespaces are a Linux
+// kernel feature); it always reports Skipped.
+type UserNSChecker struct{}
+
+func NewUserNSChecker() *UserNSChecker { return &UserNSChecker{} }
+
+func (c *UserNSChecker) Name() string       { return "User namespace support" }
+func (c *UserNSChecker) Category() Category { return CategorySecurity }
+func (c *UserNSChecker) CanFix() bool       { return false }
+func (c *UserNSChecker) Roles() []string    { return []string{"provider", "hybrid"} }
+
+func (c *UserNSChecker) Check(_ context.Context) CheckResult {
+	return CheckResult{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   StatusSkipped,
+		Message:  "User namespaces: not applicable on this platform",
+	}
+}
+
+func (c *UserNSChecker) Fix(_ context.Context, _ PackageManager) error { return nil }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+
+	"github.com/moltbunker/moltbunker/internal/runtime"
 )
 
 // Doctor orchestrates health checks for the moltbunker system
@@ -49,6 +51,23 @@ func NewWithWriter(opts DoctorOptions, w io.Writer, useColors bool) *Doctor {
 // AddChecker adds a custom checker
 func (d *Doctor) AddChecker(c Checker) {
 	d.checkers = append(d.checkers, c)
+}
+
+// SetKataConfig replaces the nil-constructed KataPIDsChecker (registered by
+// default for standalone doctor runs) with one holding the real Kata config and
+// the daemon's effective OCI pids.limit, so the R17 PID-limit check is evaluated
+// against the actual in-guest PID ceiling (the kata-agent-enforced OCI pids.limit)
+// rather than only the inert hypervisor annotation. Callers that have loaded config
+// (e.g. the daemon) should call this after constructing the Doctor, passing
+// Runtime.DefaultResources.PIDLimit as ociPIDLimit. No-op if no KataPIDsChecker is
+// registered.
+func (d *Doctor) SetKataConfig(cfg *runtime.KataConfig, ociPIDLimit int) {
+	for i, c := range d.checkers {
+		if _, ok := c.(*KataPIDsChecker); ok {
+			d.checkers[i] = NewKataPIDsCheckerWithOCILimit(cfg, ociPIDLimit)
+			return
+		}
+	}
 }
 
 // Run executes all checks and returns a report

--- a/internal/doctor/platform_darwin.go
+++ b/internal/doctor/platform_darwin.go
@@ -27,6 +27,11 @@ func (d *Doctor) registerPlatformCheckers() {
 		NewTrivyChecker(),                 // R4 image scanning
 		NewNftChecker(),                   // R13/R14 (Skipped on darwin)
 		NewImageSignatureToolingChecker(), // R3 image signature verification
+		// HARDEN-01: runtime isolation hardening checks (Skipped on darwin, but
+		// kept visible in `moltbunker doctor` output for parity).
+		NewAppArmorChecker(),    // R9 (Skipped on darwin)
+		NewUserNSChecker(),      // R12 (Skipped on darwin)
+		NewKataPIDsChecker(nil), // R17 (Skipped on darwin)
 		// Optional services
 		NewTorChecker(),
 	}

--- a/internal/doctor/platform_linux.go
+++ b/internal/doctor/platform_linux.go
@@ -19,6 +19,10 @@ func (d *Doctor) registerPlatformCheckers() {
 		NewTrivyChecker(),                 // R4 image scanning
 		NewNftChecker(),                   // R13/R14 nftables enforcement
 		NewImageSignatureToolingChecker(), // R3 image signature verification
+		// HARDEN-01: runtime isolation hardening checks.
+		NewAppArmorChecker(),    // R9 AppArmor profile loaded
+		NewUserNSChecker(),      // R12 user namespace support
+		NewKataPIDsChecker(nil), // R17 Kata VM PID limit (real config injected via SetKataConfig)
 	}
 }
 

--- a/internal/doctor/types.go
+++ b/internal/doctor/types.go
@@ -13,6 +13,7 @@ const (
 	CategorySystem      Category = "system"
 	CategoryConfig      Category = "config"
 	CategoryPermissions Category = "permissions"
+	CategorySecurity    Category = "security"
 )
 
 // Status represents the result status of a check
@@ -27,14 +28,14 @@ const (
 
 // CheckResult represents the result of a single check
 type CheckResult struct {
-	Name        string   `json:"name"`
-	Category    Category `json:"category"`
-	Status      Status   `json:"status"`
-	Message     string   `json:"message"`
-	Details     string   `json:"details,omitempty"`
-	Fixable     bool     `json:"fixable"`
-	FixCommand  string   `json:"fix_command,omitempty"`
-	FixPackage  string   `json:"fix_package,omitempty"`
+	Name       string   `json:"name"`
+	Category   Category `json:"category"`
+	Status     Status   `json:"status"`
+	Message    string   `json:"message"`
+	Details    string   `json:"details,omitempty"`
+	Fixable    bool     `json:"fixable"`
+	FixCommand string   `json:"fix_command,omitempty"`
+	FixPackage string   `json:"fix_package,omitempty"`
 }
 
 // Checker is the interface that all checkers must implement

--- a/internal/runtime/apparmor_embed.go
+++ b/internal/runtime/apparmor_embed.go
@@ -1,0 +1,24 @@
+package runtime
+
+import _ "embed"
+
+// embeddedAppArmorProfile is the canonical moltbunker-container AppArmor policy,
+// embedded so the daemon binary is self-contained and can load the profile on
+// first start without an operator pre-installing it under /etc/apparmor.d
+// (HARDEN-01, R9). The bytes are used only by the Linux AppArmorLoader; the embed
+// itself is pure Go and compiles on every platform (darwin reads but never loads
+// them). The source of truth is configs/apparmor/moltbunker-container; this asset
+// is a build-time copy kept in-package because go:embed cannot reach outside the
+// package directory.
+//
+//go:embed embedded_profiles/moltbunker-container.aaprofile
+var embeddedAppArmorProfile []byte
+
+// EmbeddedAppArmorProfile returns a copy of the embedded profile bytes. Exposed
+// for tests and tooling that want to assert on the shipped policy content without
+// reading the filesystem.
+func EmbeddedAppArmorProfile() []byte {
+	out := make([]byte, len(embeddedAppArmorProfile))
+	copy(out, embeddedAppArmorProfile)
+	return out
+}

--- a/internal/runtime/apparmor_loader_linux.go
+++ b/internal/runtime/apparmor_loader_linux.go
@@ -1,0 +1,162 @@
+//go:build linux
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/moltbunker/moltbunker/internal/logging"
+)
+
+// AppArmorProfileName is the canonical name of the profile moltbunker ships and
+// loads. It matches the `profile <name>` line inside the embedded policy and the
+// ContainerSecurityProfile.AppArmorProfile value set by DeploymentSecurityProfile.
+const AppArmorProfileName = "moltbunker-container"
+
+// maxProfileBytes caps how much of a profile file the loader will read, guarding
+// against a pathological on-disk file being piped to apparmor_parser.
+const maxProfileBytes = 64 * 1024
+
+// ErrAppArmorParserMissing is returned when apparmor_parser is not on PATH, so a
+// caller (e.g. the doctor checker) can distinguish "no tooling" from "parse failed".
+var ErrAppArmorParserMissing = errors.New("apparmor_parser binary not found on PATH")
+
+// execRunner runs an external command and returns its combined output. It is a
+// seam so tests can inject a fake parser without touching the real kernel.
+type execRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// defaultExecRunner pipes stdin through to apparmor_parser via exec.CommandContext.
+// The profile bytes are supplied to EnsureProfile and written to a temp file that
+// is passed as the final argument, so this runner only forwards name+args.
+func defaultExecRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	// #nosec G204 -- name is the constant "apparmor_parser" supplied by EnsureProfile;
+	// args are fixed flags plus a daemon-controlled temp file path, never request input.
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// AppArmorLoader loads the moltbunker container AppArmor profile into the kernel.
+//
+// It is build-tagged Linux-only; the !linux stub is a no-op so darwin builds stay
+// green. The embedded profile bytes (embedded_profiles/moltbunker-container.aaprofile)
+// make the daemon binary self-contained: an operator does not have to pre-install
+// the policy under /etc/apparmor.d, which was the status quo that left the AppArmor
+// gate silently disabled on fresh installs (R9).
+type AppArmorLoader struct {
+	// execRun runs apparmor_parser; nil means use defaultExecRunner.
+	execRun execRunner
+	// isLoaded reports whether a named profile is already in the kernel; nil means
+	// use the package-level isAppArmorProfileLoaded. Tests inject this seam.
+	isLoaded func(name string) bool
+}
+
+func (l *AppArmorLoader) runner() execRunner {
+	if l.execRun != nil {
+		return l.execRun
+	}
+	return defaultExecRunner
+}
+
+func (l *AppArmorLoader) loadedCheck() func(string) bool {
+	if l.isLoaded != nil {
+		return l.isLoaded
+	}
+	return isAppArmorProfileLoaded
+}
+
+// IsProfileLoaded reports whether the named profile is currently loaded in the
+// kernel. Delegates to isAppArmorProfileLoaded (reads
+// /sys/kernel/security/apparmor/profiles).
+func (l *AppArmorLoader) IsProfileLoaded(name string) bool {
+	return l.loadedCheck()(name)
+}
+
+// EnsureProfile makes sure the named AppArmor profile is loaded into the kernel.
+//
+//   - If it is already loaded, returns nil immediately (idempotent).
+//   - profilePath selects the policy source: when empty, the embedded profile bytes
+//     are used (written to a temp file). When non-empty, that file is read (capped
+//     at 64KB).
+//   - apparmor_parser must be on PATH; otherwise ErrAppArmorParserMissing is returned.
+//   - The bytes are loaded with `apparmor_parser -r -W <file>` (replace + wait).
+//   - After loading, the kernel is re-checked; a profile that does not appear is a
+//     structured error.
+func (l *AppArmorLoader) EnsureProfile(ctx context.Context, profileName, profilePath string) error {
+	if profileName == "" {
+		profileName = AppArmorProfileName
+	}
+
+	if l.IsProfileLoaded(profileName) {
+		return nil
+	}
+
+	parser, err := exec.LookPath("apparmor_parser")
+	if err != nil {
+		return ErrAppArmorParserMissing
+	}
+
+	profileBytes, err := loadProfileBytes(profilePath)
+	if err != nil {
+		return fmt.Errorf("apparmor: load profile source for %q: %w", profileName, err)
+	}
+
+	tmp, err := os.CreateTemp("", "moltbunker-aa-*.profile")
+	if err != nil {
+		return fmt.Errorf("apparmor: create temp profile file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, werr := tmp.Write(profileBytes); werr != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("apparmor: write temp profile file: %w", werr)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		return fmt.Errorf("apparmor: close temp profile file: %w", cerr)
+	}
+
+	if out, perr := l.runner()(ctx, parser, "-r", "-W", tmpPath); perr != nil {
+		return fmt.Errorf("apparmor: apparmor_parser failed for %q: %s: %w", profileName, trimOutput(out), perr)
+	}
+
+	if !l.IsProfileLoaded(profileName) {
+		return fmt.Errorf("apparmor: profile %q not present in kernel after load", profileName)
+	}
+
+	logging.Info("AppArmor profile loaded",
+		"profile", profileName,
+		logging.Component("apparmor"))
+	return nil
+}
+
+// loadProfileBytes returns the profile source bytes. An empty path means use the
+// embedded profile; a non-empty path reads from disk with a 64KB cap.
+func loadProfileBytes(profilePath string) ([]byte, error) {
+	if profilePath == "" {
+		return embeddedAppArmorProfile, nil
+	}
+	// #nosec G304 -- profilePath is a daemon-controlled config/asset path, not request input.
+	f, err := os.Open(profilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, maxProfileBytes)
+	n, err := f.Read(buf)
+	if err != nil && n == 0 {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+func trimOutput(b []byte) string {
+	s := string(b)
+	if len(s) > 512 {
+		s = s[:512]
+	}
+	return s
+}

--- a/internal/runtime/apparmor_loader_linux_test.go
+++ b/internal/runtime/apparmor_loader_linux_test.go
@@ -1,0 +1,158 @@
+//go:build linux
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureProfile_AlreadyLoaded(t *testing.T) {
+	called := false
+	l := &AppArmorLoader{
+		isLoaded: func(string) bool { return true },
+		execRun: func(context.Context, string, ...string) ([]byte, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	if err := l.EnsureProfile(context.Background(), AppArmorProfileName, ""); err != nil {
+		t.Fatalf("EnsureProfile returned error when already loaded: %v", err)
+	}
+	if called {
+		t.Error("apparmor_parser should NOT be invoked when the profile is already loaded")
+	}
+}
+
+func TestEnsureProfile_ParserMissing(t *testing.T) {
+	// Point PATH at an empty dir so exec.LookPath("apparmor_parser") fails.
+	t.Setenv("PATH", t.TempDir())
+	l := &AppArmorLoader{isLoaded: func(string) bool { return false }}
+	err := l.EnsureProfile(context.Background(), AppArmorProfileName, "")
+	if !errors.Is(err, ErrAppArmorParserMissing) {
+		t.Fatalf("expected ErrAppArmorParserMissing, got %v", err)
+	}
+}
+
+func TestEnsureProfile_ParseFails(t *testing.T) {
+	installFakeParser(t)
+	l := &AppArmorLoader{
+		isLoaded: func(string) bool { return false },
+		execRun: func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+			return []byte("AppArmor parser error: syntax error near line 3"), errors.New("exit status 1")
+		},
+	}
+	err := l.EnsureProfile(context.Background(), AppArmorProfileName, "")
+	if err == nil {
+		t.Fatal("expected error when apparmor_parser fails")
+	}
+	if !strings.Contains(err.Error(), "syntax error") {
+		t.Errorf("error should wrap parser stderr, got %v", err)
+	}
+}
+
+func TestEnsureProfile_NotPresentAfterLoad(t *testing.T) {
+	installFakeParser(t)
+	l := &AppArmorLoader{
+		isLoaded: func(string) bool { return false }, // never appears
+		execRun: func(context.Context, string, ...string) ([]byte, error) {
+			return nil, nil // parser "succeeds"
+		},
+	}
+	err := l.EnsureProfile(context.Background(), AppArmorProfileName, "")
+	if err == nil || !strings.Contains(err.Error(), "not present in kernel after load") {
+		t.Fatalf("expected post-load presence error, got %v", err)
+	}
+}
+
+func TestEnsureProfile_Success(t *testing.T) {
+	installFakeParser(t)
+
+	var gotArgs []string
+	loadedNow := false
+	l := &AppArmorLoader{
+		isLoaded: func(string) bool { return loadedNow },
+		execRun: func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			gotArgs = args
+			loadedNow = true // becomes present after a successful parse
+			return nil, nil
+		},
+	}
+	if err := l.EnsureProfile(context.Background(), AppArmorProfileName, ""); err != nil {
+		t.Fatalf("EnsureProfile failed: %v", err)
+	}
+	// args should be: -r -W <tmpfile>
+	if len(gotArgs) != 3 || gotArgs[0] != "-r" || gotArgs[1] != "-W" {
+		t.Fatalf("unexpected apparmor_parser args: %v", gotArgs)
+	}
+	if _, err := os.Stat(gotArgs[2]); !os.IsNotExist(err) {
+		t.Errorf("temp profile file should be removed after load, stat err = %v", err)
+	}
+}
+
+func TestEnsureProfile_ReadsProfilePath(t *testing.T) {
+	installFakeParser(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom.profile")
+	const body = "profile custom-test flags=(complain) { }\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loadedNow := false
+	l := &AppArmorLoader{
+		isLoaded: func(string) bool { return loadedNow },
+		execRun: func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			// Verify the temp file passed to the parser holds the file's bytes.
+			data, _ := os.ReadFile(args[len(args)-1])
+			if string(data) != body {
+				t.Errorf("parser fed %q, want %q", string(data), body)
+			}
+			loadedNow = true
+			return nil, nil
+		},
+	}
+	if err := l.EnsureProfile(context.Background(), "custom-test", path); err != nil {
+		t.Fatalf("EnsureProfile(path) failed: %v", err)
+	}
+}
+
+func TestEmbeddedAppArmorProfile_Content(t *testing.T) {
+	b := EmbeddedAppArmorProfile()
+	if len(b) == 0 {
+		t.Fatal("embedded AppArmor profile is empty")
+	}
+	s := string(b)
+	for _, want := range []string{"#include <tunables/global>", "profile moltbunker-container"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("embedded profile missing %q", want)
+		}
+	}
+}
+
+func TestIsProfileLoaded_DelegatesToSeam(t *testing.T) {
+	l := &AppArmorLoader{isLoaded: func(name string) bool { return name == "x" }}
+	if !l.IsProfileLoaded("x") {
+		t.Error("IsProfileLoaded should report true for the seam's match")
+	}
+	if l.IsProfileLoaded("y") {
+		t.Error("IsProfileLoaded should report false for a non-match")
+	}
+}
+
+// installFakeParser puts a dummy `apparmor_parser` executable on PATH so
+// exec.LookPath succeeds; the actual run is intercepted by the execRun seam.
+func installFakeParser(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "apparmor_parser")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { // #nosec G306 -- test fixture must be executable
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}

--- a/internal/runtime/apparmor_loader_other.go
+++ b/internal/runtime/apparmor_loader_other.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+package runtime
+
+import "context"
+
+// AppArmorProfileName is the canonical profile name (kept defined on all platforms
+// so callers can reference it without a build-tag split).
+const AppArmorProfileName = "moltbunker-container"
+
+// AppArmorLoader is a no-op on non-Linux platforms (AppArmor is Linux-only).
+// Keeping the type and method set identical to the Linux build lets the doctor
+// checker and daemon wiring compile without per-OS conditionals at the call site.
+type AppArmorLoader struct{}
+
+// EnsureProfile is a no-op on non-Linux platforms and always succeeds.
+func (l *AppArmorLoader) EnsureProfile(_ context.Context, _, _ string) error { return nil }
+
+// IsProfileLoaded always reports false on non-Linux platforms.
+func (l *AppArmorLoader) IsProfileLoaded(_ string) bool { return false }

--- a/internal/runtime/container_lifecycle.go
+++ b/internal/runtime/container_lifecycle.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	goruntime "runtime"
@@ -17,6 +18,35 @@ import (
 	"github.com/moltbunker/moltbunker/internal/logging"
 	"github.com/moltbunker/moltbunker/pkg/types"
 )
+
+// applyDiskQuota applies the configured XFS disk quota for a container and
+// surfaces failures as visible, structured warnings. The non-XFS case (R16) gets a
+// filesystem-specific message; all OTHER SetDiskQuota errors (xfs_quota CLI errors,
+// FS_IOC_FSSETXATTR ioctl errno, upperdir parse failures) are also logged at Warn
+// rather than swallowed — otherwise a misconfigured XFS host would silently run
+// containers with NO disk limit, which is exactly the silent-no-op class R16 set
+// out to eliminate. All cases remain non-fatal: container creation is never aborted
+// here (the disk_enforcer provides best-effort secondary enforcement).
+func (cc *ContainerdClient) applyDiskQuota(ctx context.Context, id string, limitBytes int64) {
+	err := cc.SetDiskQuota(ctx, id, limitBytes)
+	if err == nil {
+		return
+	}
+	var notXFS *DiskQuotaNotSupportedError
+	if errors.As(err, &notXFS) {
+		logging.Warn("disk quota unavailable on non-XFS filesystem; container disk usage will not be limited",
+			"filesystem_type", notXFS.FS,
+			logging.ContainerID(id),
+			logging.Component("disk_quota"))
+		return
+	}
+	// Other errors are non-fatal but must be visible (R16): a real XFS-host quota
+	// failure means the container runs with no disk limit, so log it at Warn.
+	logging.Warn("disk quota not applied; container disk usage will not be limited",
+		logging.ContainerID(id),
+		logging.Err(err),
+		logging.Component("disk_quota"))
+}
 
 // Note: runtime name is stored in ContainerdClient.runtimeName (set via NewContainerdClient).
 // Constants for runtime names are in runtime_detect.go.
@@ -72,6 +102,23 @@ func (cc *ContainerdClient) kataAnnotations() oci.SpecOpts {
 	}
 	if cc.kataConfig.ImagePath != "" {
 		annotations["io.katacontainers.config.hypervisor.image"] = cc.kataConfig.ImagePath
+	}
+	// R17: the EFFECTIVE PID ceiling for Kata VM workloads is the OCI
+	// linux.resources.pids.limit (wired in CreateContainer via oci.WithPidsLimit;
+	// defaults to 100 on the deploy path). The kata-agent enforces that cgroup
+	// pids.limit INSIDE the guest, so it is the mechanism that actually bounds
+	// process count for VM workloads — not this annotation.
+	//
+	// NOTE: io.katacontainers.config.hypervisor.default_pids is NOT a recognized
+	// Kata hypervisor annotation (Kata's hypervisor annotation set is
+	// default_memory/default_vcpus/kernel/image/initrd/machine_type/etc.), and Kata
+	// additionally drops any annotation not in the runtime TOML enable_annotations
+	// allow-list. So this is almost certainly INERT today. It is emitted only as a
+	// forward-looking hint and requires (a) an enable_annotations entry in the Kata
+	// runtime config and (b) validation against a real Kata shim under R11 before it
+	// can be relied on. Do not treat it as the PID ceiling — the OCI pids.limit is.
+	if cc.kataConfig.DefaultPIDs > 0 {
+		annotations["io.katacontainers.config.hypervisor.default_pids"] = strconv.Itoa(cc.kataConfig.DefaultPIDs)
 	}
 
 	if len(annotations) == 0 {
@@ -182,11 +229,8 @@ func (cc *ContainerdClient) CreateContainer(ctx context.Context, id string, imag
 	cc.containers[id] = managed
 	cc.mu.Unlock()
 
-	// Apply XFS disk quota if configured
-	if err := cc.SetDiskQuota(ctx, id, resources.DiskLimit); err != nil {
-		// Non-fatal: disk_enforcer provides secondary enforcement
-		_ = err
-	}
+	// Apply XFS disk quota if configured (R16: warns on non-XFS, non-fatal).
+	cc.applyDiskQuota(ctx, id, resources.DiskLimit)
 
 	return managed, nil
 }
@@ -240,10 +284,8 @@ func (cc *ContainerdClient) CreateContainerWithSpec(ctx context.Context, id stri
 	cc.containers[id] = managed
 	cc.mu.Unlock()
 
-	// Apply XFS disk quota if configured
-	if err := cc.SetDiskQuota(ctx, id, resources.DiskLimit); err != nil {
-		_ = err
-	}
+	// Apply XFS disk quota if configured (R16: warns on non-XFS, non-fatal).
+	cc.applyDiskQuota(ctx, id, resources.DiskLimit)
 
 	return managed, nil
 }
@@ -395,10 +437,8 @@ func (cc *ContainerdClient) CreateSecureContainer(ctx context.Context, config Se
 	cc.containers[config.ID] = managed
 	cc.mu.Unlock()
 
-	// Apply XFS disk quota if configured
-	if err := cc.SetDiskQuota(ctx, config.ID, config.Resources.DiskLimit); err != nil {
-		_ = err
-	}
+	// Apply XFS disk quota if configured (R16: warns on non-XFS, non-fatal).
+	cc.applyDiskQuota(ctx, config.ID, config.Resources.DiskLimit)
 
 	// R20 — persist the security profile so daemon restart can restore it
 	// instead of silently downgrading to the default. Non-fatal: a write

--- a/internal/runtime/containerd.go
+++ b/internal/runtime/containerd.go
@@ -21,6 +21,12 @@ type KataConfig struct {
 	VMCPUs     int    // VM vCPU count (Kata default applies if 0)
 	KernelPath string // Custom kernel image path
 	ImagePath  string // Custom rootfs/initrd path
+	// DefaultPIDs is the VM-level PID limit surfaced via the
+	// io.katacontainers.config.hypervisor.default_pids annotation (R17). It bounds
+	// the number of processes a Kata VM workload may spawn — host-side pids.max
+	// cannot bound processes inside the guest, so this annotation is the correct
+	// mechanism. 0 = Kata default (unbounded).
+	DefaultPIDs int
 }
 
 // ContainerdClient wraps containerd client with full lifecycle management

--- a/internal/runtime/disk_quota.go
+++ b/internal/runtime/disk_quota.go
@@ -1,0 +1,27 @@
+package runtime
+
+import "fmt"
+
+// DiskQuotaNotSupportedError reports that an XFS project quota could not be set
+// because the snapshotter's backing filesystem is not XFS.
+//
+// R16: SetDiskQuota previously logged a Warn and returned nil on non-XFS hosts,
+// which silently discarded the fact that the container's disk usage is NOT being
+// limited. Returning this typed error lets the caller surface a visible,
+// structured warning (with the detected filesystem) while keeping the
+// non-fatal semantics — container creation is not aborted, because the
+// disk_enforcer provides best-effort secondary enforcement.
+//
+// Defined in a build-neutral file so callers compiled on all platforms (e.g.
+// container_lifecycle.go) can match it via errors.As without a build-tag split.
+type DiskQuotaNotSupportedError struct {
+	FS string // detected filesystem type, e.g. "ext4", "overlay", "tmpfs"
+}
+
+func (e *DiskQuotaNotSupportedError) Error() string {
+	fs := e.FS
+	if fs == "" {
+		fs = "unknown"
+	}
+	return fmt.Sprintf("disk quota unavailable: snapshotter filesystem is %s, not XFS (XFS project quotas required)", fs)
+}

--- a/internal/runtime/disk_quota_linux.go
+++ b/internal/runtime/disk_quota_linux.go
@@ -25,6 +25,44 @@ const (
 	snapshotterRootPath = "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs"
 )
 
+// Filesystem magic numbers from <linux/magic.h>, used by detectFilesystemType to
+// map statfs f_type into a human-readable name (R16).
+const (
+	magicXFS     = 0x58465342 // XFS_SUPER_MAGIC
+	magicEXT     = 0xEF53     // EXT2/3/4_SUPER_MAGIC
+	magicOverlay = 0x794C7630 // OVERLAYFS_SUPER_MAGIC
+	magicTmpfs   = 0x01021994 // TMPFS_MAGIC
+	magicBtrfs   = 0x9123683E // BTRFS_SUPER_MAGIC
+	magicZFS     = 0x2FC12FC1 // ZFS_SUPER_MAGIC
+)
+
+// detectFilesystemType returns a human-readable filesystem name for the
+// filesystem backing path, by inspecting statfs f_type. Unknown types are
+// reported as a hex magic string so the value is still actionable in logs.
+func detectFilesystemType(path string) (string, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return "", fmt.Errorf("statfs %s: %w", path, err)
+	}
+	// #nosec G115 -- st.Type is a kernel-supplied filesystem magic; comparison only.
+	switch int64(st.Type) {
+	case magicXFS:
+		return "xfs", nil
+	case magicEXT:
+		return "ext4", nil
+	case magicOverlay:
+		return "overlay", nil
+	case magicTmpfs:
+		return "tmpfs", nil
+	case magicBtrfs:
+		return "btrfs", nil
+	case magicZFS:
+		return "zfs", nil
+	default:
+		return fmt.Sprintf("unknown(0x%x)", uint64(st.Type)), nil // #nosec G115 -- magic for display only
+	}
+}
+
 // fsxattr mirrors the Linux struct fsxattr used by FS_IOC_FS{GET,SET}XATTR.
 type fsxattr struct {
 	Xflags     uint32
@@ -39,8 +77,11 @@ type fsxattr struct {
 // It assigns a project ID (derived from the containerd snapshot number) and sets
 // a hard block limit. New files in the upper dir inherit the project ID automatically.
 //
-// On non-XFS filesystems or if xfs_quota is missing, it logs a warning and returns nil
-// (graceful degradation — the disk_enforcer provides secondary enforcement).
+// R16: on a non-XFS snapshotter filesystem it returns a typed
+// DiskQuotaNotSupportedError (instead of the old silent Warn+nil) so the caller can
+// surface a visible, structured warning that disk usage is NOT being limited. The
+// error is non-fatal by contract — the caller does not abort container creation;
+// the disk_enforcer provides best-effort secondary enforcement.
 func (cc *ContainerdClient) SetDiskQuota(ctx context.Context, containerID string, limitBytes int64) error {
 	if limitBytes <= 0 {
 		return nil
@@ -52,6 +93,22 @@ func (cc *ContainerdClient) SetDiskQuota(ctx context.Context, containerID string
 	}
 	if projectID < 0 {
 		return fmt.Errorf("invalid snapshot project ID %d", projectID)
+	}
+
+	// R16: fail-fast on a non-XFS snapshotter filesystem. XFS project quotas only
+	// work on XFS; on ext4/overlay/tmpfs the ioctl below would either error or
+	// silently no-op. Surface it as a typed error so the caller can warn visibly.
+	fsType, fsErr := detectFilesystemType(snapshotterRootPath)
+	if fsErr != nil {
+		// Could not stat the snapshotter root — fall through and let the ioctl
+		// report the concrete failure rather than guessing.
+		logging.Warn("disk quota: could not detect snapshotter filesystem type",
+			"container_id", containerID,
+			"path", snapshotterRootPath,
+			"error", fsErr.Error(),
+			logging.Component("disk_quota"))
+	} else if fsType != "xfs" {
+		return &DiskQuotaNotSupportedError{FS: fsType}
 	}
 
 	// Set XFS project ID + inheritance flag via ioctl

--- a/internal/runtime/disk_quota_linux_test.go
+++ b/internal/runtime/disk_quota_linux_test.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+package runtime
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDetectFilesystemType_NonXFS(t *testing.T) {
+	// The test temp dir is backed by the host's working filesystem (typically
+	// ext4/overlay/tmpfs in CI), never XFS, so detectFilesystemType must NOT
+	// classify it as xfs — which is exactly the branch SetDiskQuota fails on.
+	dir := t.TempDir()
+	fs, err := detectFilesystemType(dir)
+	if err != nil {
+		t.Fatalf("detectFilesystemType error: %v", err)
+	}
+	if fs == "" {
+		t.Fatal("detectFilesystemType returned empty type")
+	}
+	if fs == "xfs" {
+		t.Skip("test host's temp dir is XFS; non-XFS branch cannot be exercised here")
+	}
+	t.Logf("temp dir filesystem detected as %q", fs)
+}
+
+func TestDetectFilesystemType_MissingPath(t *testing.T) {
+	if _, err := detectFilesystemType("/no/such/path/hopefully"); err == nil {
+		t.Error("expected statfs error for a missing path")
+	}
+}
+
+func TestDiskQuotaNotSupportedError_Message(t *testing.T) {
+	err := &DiskQuotaNotSupportedError{FS: "ext4"}
+	msg := err.Error()
+	if !strings.Contains(msg, "ext4") {
+		t.Errorf("error message %q should contain the filesystem name", msg)
+	}
+	if !strings.Contains(msg, "XFS") {
+		t.Errorf("error message %q should mention XFS requirement", msg)
+	}
+
+	// errors.As must recover the typed error through a wrap.
+	wrapped := errors.New("outer: " + err.Error())
+	_ = wrapped
+	var target *DiskQuotaNotSupportedError
+	if !errors.As(error(err), &target) {
+		t.Error("errors.As should recover *DiskQuotaNotSupportedError")
+	}
+
+	// Empty FS still produces a sane message.
+	empty := (&DiskQuotaNotSupportedError{}).Error()
+	if !strings.Contains(empty, "unknown") {
+		t.Errorf("empty-FS error should say unknown, got %q", empty)
+	}
+}

--- a/internal/runtime/embedded_profiles/moltbunker-container.aaprofile
+++ b/internal/runtime/embedded_profiles/moltbunker-container.aaprofile
@@ -1,0 +1,75 @@
+# moltbunker-container — canonical AppArmor profile for moltbunker tenant workloads
+#
+# Shipped in-repo and loaded into the kernel on first daemon start by
+# internal/runtime/apparmor_loader_linux.go (HARDEN-01, R9). Before this
+# profile existed and was auto-loaded, the gate in security_profile.go
+# (isAppArmorProfileLoaded) always fell through on a fresh install, so the
+# AppArmor branch silently no-op'd. This profile makes that gate fire.
+#
+# Structure intentionally mirrors Docker/moby's default container profile
+# (docker-default) so real-world base images (alpine, ubuntu, nginx) run
+# unmodified. It denies the dangerous classes the runtime should never need:
+# raw kernel memory, firmware, kernel module loading, mount/pivot_root, and
+# ptrace of processes outside the container's own peer group.
+#
+# See HARDEN-01 PR for rationale. SELinux hosts: see the companion
+# moltbunker-container.selinux-note file (we delegate to the OS vendor policy).
+
+#include <tunables/global>
+
+profile moltbunker-container flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network,
+  capability,
+  file,
+  umount,
+
+  # Allow signalling and ptrace within the same profile peer group only
+  # (containers may manage their own processes; cannot reach the host).
+  signal (receive) peer=moltbunker-container,
+  signal (send) peer=moltbunker-container,
+  ptrace (trace,read,tracedby,readby) peer=moltbunker-container,
+
+  # Host-side runtime control paths must remain off-limits to the container.
+  deny @{PROC}/* w,                          # deny write to all files in /proc not otherwise allowed
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** wkx,
+  deny @{PROC}/sys/[^k]** w,                  # deny /proc/sys except /proc/sys/k* (kernel.shm*)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm tunables
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/kcore rwklx,
+  deny @{PROC}/kmem rwklx,
+  deny @{PROC}/mem rwklx,
+
+  deny mount,
+  deny pivot_root,
+
+  # Block kernel module loading and raw firmware access.
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+  # Read-only access to the kernel-config surface the runtime needs.
+  @{PROC}/sys/kernel/shm* r,
+  /sys/fs/cgroup/** r,
+
+  # Allow normal filesystem layout used by base images.
+  /etc/** rk,
+  /lib/** rmix,
+  /lib64/** rmix,
+  /usr/** rmix,
+  /bin/** rmix,
+  /sbin/** rmix,
+  /tmp/** rwmix,
+  /var/** rwk,
+  /run/** rwk,
+  /home/** rwk,
+  /root/** rwk,
+
+  # deny write to the standard library/binary directories (immutable rootfs intent).
+  deny /lib/modules/** wklx,
+}

--- a/internal/runtime/kata_annotations_test.go
+++ b/internal/runtime/kata_annotations_test.go
@@ -1,0 +1,58 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// applyKataAnnotations builds the kata annotation SpecOpt for the given config and
+// applies it to a fresh spec, returning the resulting annotations map (nil if the
+// opt itself was nil).
+func applyKataAnnotations(t *testing.T, cfg *KataConfig) map[string]string {
+	t.Helper()
+	cc := &ContainerdClient{kataConfig: cfg}
+	opt := cc.kataAnnotations()
+	if opt == nil {
+		return nil
+	}
+	s := &specs.Spec{}
+	if err := opt(context.Background(), nil, nil, s); err != nil {
+		t.Fatalf("apply kata annotations: %v", err)
+	}
+	return s.Annotations
+}
+
+func TestKataAnnotations_DefaultPIDs(t *testing.T) {
+	ann := applyKataAnnotations(t, &KataConfig{DefaultPIDs: 1024})
+	if ann == nil {
+		t.Fatal("expected annotations for non-zero DefaultPIDs")
+	}
+	got := ann["io.katacontainers.config.hypervisor.default_pids"]
+	if got != "1024" {
+		t.Errorf("default_pids annotation = %q, want %q", got, "1024")
+	}
+}
+
+func TestKataAnnotations_DefaultPIDsZeroOmitted(t *testing.T) {
+	// With every field zero, kataAnnotations returns a nil opt (nothing to emit).
+	if ann := applyKataAnnotations(t, &KataConfig{}); ann != nil {
+		if _, ok := ann["io.katacontainers.config.hypervisor.default_pids"]; ok {
+			t.Error("default_pids should be omitted when DefaultPIDs == 0")
+		}
+	}
+}
+
+func TestKataAnnotations_DefaultPIDsAlongsideOthers(t *testing.T) {
+	ann := applyKataAnnotations(t, &KataConfig{VMMemoryMB: 512, VMCPUs: 2, DefaultPIDs: 2048})
+	if ann["io.katacontainers.config.hypervisor.default_memory"] != "512" {
+		t.Error("expected default_memory annotation")
+	}
+	if ann["io.katacontainers.config.hypervisor.default_vcpus"] != "2" {
+		t.Error("expected default_vcpus annotation")
+	}
+	if ann["io.katacontainers.config.hypervisor.default_pids"] != "2048" {
+		t.Error("expected default_pids annotation alongside the others")
+	}
+}

--- a/internal/runtime/security_profile.go
+++ b/internal/runtime/security_profile.go
@@ -4,14 +4,16 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	goruntime "runtime"
 	"os"
+	"os/user"
+	goruntime "runtime"
 	"strings"
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/moltbunker/moltbunker/internal/logging"
 	"github.com/moltbunker/moltbunker/internal/security"
 	"github.com/moltbunker/moltbunker/pkg/types"
 )
@@ -113,9 +115,18 @@ func (se *SecurityEnforcer) BuildOCISpecOpts() []oci.SpecOpts {
 		opts = append(opts, WithSeccompProfile(se.profile.SeccompProfile, se.profile.BlockedSyscalls, se.profile.AllowedSyscalls))
 	}
 
-	// AppArmor profile — only apply if running on Linux and profile is loaded
-	if se.profile.AppArmorProfile != "" && isAppArmorProfileLoaded(se.profile.AppArmorProfile) {
-		opts = append(opts, WithAppArmorProfile(se.profile.AppArmorProfile))
+	// AppArmor profile — only apply if running on Linux and profile is loaded.
+	// R9: when a profile is requested but NOT present in the kernel, log a Debug
+	// line so an operator can see the confinement gap (and run `moltbunker doctor`
+	// to load it) instead of the gate silently no-op'ing.
+	if se.profile.AppArmorProfile != "" {
+		if isAppArmorProfileLoaded(se.profile.AppArmorProfile) {
+			opts = append(opts, WithAppArmorProfile(se.profile.AppArmorProfile))
+		} else {
+			logging.Debug("AppArmor profile not loaded; container will run without AppArmor confinement — run `moltbunker node doctor` to load it",
+				"profile", se.profile.AppArmorProfile,
+				logging.Component("apparmor"))
+		}
 	}
 
 	// SELinux label
@@ -293,32 +304,77 @@ func WithUlimits(ulimits types.UlimitConfig) oci.SpecOpts {
 	}
 }
 
-// WithUserNamespace enables user namespace mapping
+// WithUserNamespace enables user-namespace isolation for tenant workloads.
+//
+// OPT-IN ONLY: DeploymentSecurityProfile leaves UserNamespace=false by default
+// (see pkg/types/security.go). This option emits the OCI UID/GID mappings but the
+// rootfs snapshot is NOT remapped — containers are created with a plain overlay
+// snapshot owned by host UID 0. With a userns active, container-UID-0 maps to host
+// UID <subStart>, so the host-UID-0 rootfs appears as nobody/overflow inside the
+// namespace and most real images fail to start. Enabling userns for real therefore
+// requires a REMAPPED snapshot — containerd's WithRemapperLabels
+// (containerd.io/snapshot/uidmapping + gidmapping) or an idmapped-mount-capable
+// snapshotter that ID-shifts the rootfs into the host subordinate range to match
+// these mappings. That snapshot-remap wiring is the R11-gated follow-up (needs real
+// Linux container-startup CI). Do NOT flip the profile default to ON until it lands.
+//
+// R12: This is gated by CheckUserNSCompat. The previous behavior mapped only a
+// single ID (container root -> host nobody 65534), which is too narrow to host a
+// real container (anything that runs as a non-zero UID inside the container had no
+// host UID to land on). When the host supports unprivileged user namespaces and the
+// daemon's user has a subordinate ID range, this emits the standard 65536-entry
+// mapping (container 0..65535 -> host <subStart>..<subStart+65535>), matching what
+// Docker/containerd's rootless support uses.
+//
+// On a host that disables unprivileged user namespaces (e.g. sysctl
+// kernel.unprivileged_userns_clone=0, or no /etc/subuid range), it degrades
+// gracefully: it logs a structured Warning and returns without touching the spec,
+// so the container still starts (without userns) rather than failing the deploy.
+// On non-Linux platforms CheckUserNSCompat always reports unsupported, so this is
+// a no-op there.
+//
+// NOTE(R16): when userns is active, XFS disk-quota project IDs are assigned to the
+// host UID range (hostStart), not to container UID 0 — quotactl/xfs_quota reports
+// bytes against the host subordinate user, so reports must be correlated back to
+// the container by project ID, not by the in-container UID.
 func WithUserNamespace() oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		compat := CheckUserNSCompat()
+		if !compat.Supported {
+			logging.Warn("user namespace requested but not enabled on this host; container will run in the host user namespace",
+				"reason", compat.Reason,
+				logging.Component("userns"))
+			return nil
+		}
+
+		uname := "root"
+		if u, err := user.Current(); err == nil && u.Username != "" {
+			uname = u.Username
+		}
+		hostStart, size, err := ResolveSubUIDRange(uname)
+		if err != nil {
+			logging.Warn("user namespace requested but no usable subordinate ID range; running without userns",
+				"reason", err.Error(),
+				logging.Component("userns"))
+			return nil
+		}
+
 		if s.Linux == nil {
 			s.Linux = &specs.Linux{}
 		}
 
-		// Enable user namespace with default mapping
 		s.Linux.Namespaces = append(s.Linux.Namespaces, specs.LinuxNamespace{
 			Type: specs.UserNamespace,
 		})
 
-		// Map container root to unprivileged user on host
+		// Map the full container UID/GID space (0..65535) onto the host
+		// subordinate range so processes running as any in-container UID land on
+		// an unprivileged host UID.
 		s.Linux.UIDMappings = []specs.LinuxIDMapping{
-			{
-				ContainerID: 0,
-				HostID:      65534, // nobody
-				Size:        1,
-			},
+			{ContainerID: 0, HostID: hostStart, Size: size},
 		}
 		s.Linux.GIDMappings = []specs.LinuxIDMapping{
-			{
-				ContainerID: 0,
-				HostID:      65534, // nogroup
-				Size:        1,
-			},
+			{ContainerID: 0, HostID: hostStart, Size: size},
 		}
 
 		return nil

--- a/internal/runtime/security_profile_test.go
+++ b/internal/runtime/security_profile_test.go
@@ -112,79 +112,79 @@ func TestSecurityEnforcerCanShell(t *testing.T) {
 
 func TestValidateExecCommand(t *testing.T) {
 	tests := []struct {
-		name         string
-		execDisabled bool
+		name          string
+		execDisabled  bool
 		shellDisabled bool
-		cmd          []string
-		expectError  bool
-		errorType    error
+		cmd           []string
+		expectError   bool
+		errorType     error
 	}{
 		{
-			name:        "exec disabled blocks all commands",
+			name:         "exec disabled blocks all commands",
 			execDisabled: true,
-			cmd:         []string{"ls", "-la"},
-			expectError: true,
-			errorType:   ErrExecDisabled,
-		},
-		{
-			name:         "exec enabled allows non-shell commands",
-			execDisabled: false,
-			shellDisabled: true,
 			cmd:          []string{"ls", "-la"},
-			expectError:  false,
-		},
-		{
-			name:         "shell disabled blocks /bin/sh",
-			execDisabled: false,
-			shellDisabled: true,
-			cmd:          []string{"/bin/sh"},
 			expectError:  true,
-			errorType:    ErrShellDisabled,
+			errorType:    ErrExecDisabled,
 		},
 		{
-			name:         "shell disabled blocks /bin/bash",
-			execDisabled: false,
+			name:          "exec enabled allows non-shell commands",
+			execDisabled:  false,
 			shellDisabled: true,
-			cmd:          []string{"/bin/bash"},
-			expectError:  true,
-			errorType:    ErrShellDisabled,
+			cmd:           []string{"ls", "-la"},
+			expectError:   false,
 		},
 		{
-			name:         "shell disabled blocks sh",
-			execDisabled: false,
+			name:          "shell disabled blocks /bin/sh",
+			execDisabled:  false,
 			shellDisabled: true,
-			cmd:          []string{"sh"},
-			expectError:  true,
-			errorType:    ErrShellDisabled,
+			cmd:           []string{"/bin/sh"},
+			expectError:   true,
+			errorType:     ErrShellDisabled,
 		},
 		{
-			name:         "shell disabled blocks bash",
-			execDisabled: false,
+			name:          "shell disabled blocks /bin/bash",
+			execDisabled:  false,
 			shellDisabled: true,
-			cmd:          []string{"bash"},
-			expectError:  true,
-			errorType:    ErrShellDisabled,
+			cmd:           []string{"/bin/bash"},
+			expectError:   true,
+			errorType:     ErrShellDisabled,
 		},
 		{
-			name:         "shell disabled blocks zsh",
-			execDisabled: false,
+			name:          "shell disabled blocks sh",
+			execDisabled:  false,
 			shellDisabled: true,
-			cmd:          []string{"zsh"},
-			expectError:  true,
-			errorType:    ErrShellDisabled,
+			cmd:           []string{"sh"},
+			expectError:   true,
+			errorType:     ErrShellDisabled,
 		},
 		{
-			name:         "shell enabled allows shells",
-			execDisabled: false,
+			name:          "shell disabled blocks bash",
+			execDisabled:  false,
+			shellDisabled: true,
+			cmd:           []string{"bash"},
+			expectError:   true,
+			errorType:     ErrShellDisabled,
+		},
+		{
+			name:          "shell disabled blocks zsh",
+			execDisabled:  false,
+			shellDisabled: true,
+			cmd:           []string{"zsh"},
+			expectError:   true,
+			errorType:     ErrShellDisabled,
+		},
+		{
+			name:          "shell enabled allows shells",
+			execDisabled:  false,
 			shellDisabled: false,
-			cmd:          []string{"/bin/bash"},
-			expectError:  false,
+			cmd:           []string{"/bin/bash"},
+			expectError:   false,
 		},
 		{
-			name:        "empty command returns error",
+			name:         "empty command returns error",
 			execDisabled: false,
-			cmd:         []string{},
-			expectError: true,
+			cmd:          []string{},
+			expectError:  true,
 		},
 	}
 
@@ -398,5 +398,66 @@ func TestSecurityProfileError(t *testing.T) {
 	expected := "security policy violation: exec - disabled by policy"
 	if err.Error() != expected {
 		t.Errorf("Error() = %q, want %q", err.Error(), expected)
+	}
+}
+
+// TestWithUserNamespace_CompatGuard exercises the R12 compat guard. On darwin
+// (and Linux hosts that disable unprivileged userns) CheckUserNSCompat reports
+// unsupported, so WithUserNamespace must be a no-op (the spec's namespaces and
+// ID maps are left unchanged). On a Linux host that supports it, a UserNamespace
+// must be added with a full-range mapping. The assertion is keyed off the live
+// compat result so it is deterministic on every platform.
+func TestWithUserNamespace_CompatGuard(t *testing.T) {
+	opt := WithUserNamespace()
+
+	s := &specs.Spec{Linux: &specs.Linux{}}
+	if err := opt(context.Background(), nil, nil, s); err != nil {
+		t.Fatalf("WithUserNamespace returned error: %v", err)
+	}
+
+	hasUserNS := false
+	for _, ns := range s.Linux.Namespaces {
+		if ns.Type == specs.UserNamespace {
+			hasUserNS = true
+		}
+	}
+
+	if CheckUserNSCompat().Supported {
+		if !hasUserNS {
+			t.Error("on a userns-capable host, WithUserNamespace should add a UserNamespace")
+		}
+		if len(s.Linux.UIDMappings) != 1 || s.Linux.UIDMappings[0].Size < minUserNSMappingSize {
+			t.Errorf("expected a full-range UID mapping, got %+v", s.Linux.UIDMappings)
+		}
+	} else {
+		// Compat guard fired: spec must be untouched (no-op).
+		if hasUserNS {
+			t.Error("on a non-userns host, WithUserNamespace must not add a UserNamespace")
+		}
+		if len(s.Linux.UIDMappings) != 0 || len(s.Linux.GIDMappings) != 0 {
+			t.Error("on a non-userns host, WithUserNamespace must not set ID mappings")
+		}
+	}
+}
+
+// minUserNSMappingSize is the smallest mapping size the test accepts as a
+// "full range" — kept loose so it passes regardless of the host's subuid size.
+const minUserNSMappingSize = 1024
+
+// TestDeploymentSecurityProfile_UserNSDefaultOff guards the R12 correction:
+// userns is wired + opt-in but MUST default OFF, because nothing remaps the
+// rootfs snapshot yet (WithRemapperLabels / idmapped mount is the R11-gated
+// follow-up). Defaulting it ON regresses real container startup on capable
+// Linux hosts (container-UID-0 -> host subStart can't own its host-UID-0 rootfs).
+func TestDeploymentSecurityProfile_UserNSDefaultOff(t *testing.T) {
+	if types.DeploymentSecurityProfile().UserNamespace {
+		t.Error("R12: DeploymentSecurityProfile().UserNamespace must default OFF until the " +
+			"rootfs snapshot-remap path lands (R11); shipping it on regresses container startup")
+	}
+}
+
+func TestDeploymentSecurityProfile_AppArmorProfileSet(t *testing.T) {
+	if got := types.DeploymentSecurityProfile().AppArmorProfile; got != "moltbunker-container" {
+		t.Errorf("R9 regression: DeploymentSecurityProfile().AppArmorProfile = %q, want %q", got, "moltbunker-container")
 	}
 }

--- a/internal/runtime/userns_compat_linux.go
+++ b/internal/runtime/userns_compat_linux.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+package runtime
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+// minSubIDRange is the smallest subordinate UID/GID range that yields a usable
+// full container UID space (0..65535). Anything smaller cannot host a standard
+// rootful-in-userns container.
+const minSubIDRange = 65536
+
+// UserNSCompatResult reports whether unprivileged user namespaces can be used for
+// tenant workloads on this host, and if not, a human-readable reason.
+type UserNSCompatResult struct {
+	Supported bool
+	Reason    string
+}
+
+// usernsPaths bundles the kernel/distro files CheckUserNSCompat inspects. The
+// defaults point at the real procfs/config; tests inject temp-file substitutes.
+type usernsPaths struct {
+	unprivilegedCloneFile string // /proc/sys/kernel/unprivileged_userns_clone (Debian/Ubuntu knob)
+	maxUserNamespacesFile string // /proc/sys/user/max_user_namespaces
+	subUIDFile            string // /etc/subuid
+	subGIDFile            string // /etc/subgid
+	currentUser           func() (*user.User, error)
+}
+
+func defaultUsernsPaths() usernsPaths {
+	return usernsPaths{
+		unprivilegedCloneFile: "/proc/sys/kernel/unprivileged_userns_clone",
+		maxUserNamespacesFile: "/proc/sys/user/max_user_namespaces",
+		subUIDFile:            "/etc/subuid",
+		subGIDFile:            "/etc/subgid",
+		currentUser:           user.Current,
+	}
+}
+
+// CheckUserNSCompat reports whether unprivileged user namespaces are usable for
+// tenant deployment workloads on this host. It is a compat guard: a {false, reason}
+// result means WithUserNamespace degrades to a no-op (container runs without a
+// userns) instead of failing the deploy on a distro that disables the feature.
+func CheckUserNSCompat() UserNSCompatResult {
+	return checkUserNSCompat(defaultUsernsPaths())
+}
+
+func checkUserNSCompat(p usernsPaths) UserNSCompatResult {
+	// (1) Debian/Ubuntu gate: kernel.unprivileged_userns_clone == 0 disables it.
+	if v, ok := readSysctlInt(p.unprivilegedCloneFile); ok && v == 0 {
+		return UserNSCompatResult{Supported: false, Reason: "unprivileged_userns_clone disabled (sysctl kernel.unprivileged_userns_clone=0)"}
+	}
+
+	// (2) Generic gate: user.max_user_namespaces == 0 disables it everywhere.
+	if v, ok := readSysctlInt(p.maxUserNamespacesFile); ok && v == 0 {
+		return UserNSCompatResult{Supported: false, Reason: "max_user_namespaces=0 (sysctl user.max_user_namespaces=0)"}
+	}
+
+	uname := "root"
+	if p.currentUser != nil {
+		if u, err := p.currentUser(); err == nil && u.Username != "" {
+			uname = u.Username
+		}
+	}
+
+	// (3) A subordinate UID range >= 65536 must exist for the daemon's user.
+	if _, _, err := resolveSubIDRange(p.subUIDFile, uname); err != nil {
+		return UserNSCompatResult{Supported: false, Reason: fmt.Sprintf("no subuid range >=%d for user %q in %s", minSubIDRange, uname, p.subUIDFile)}
+	}
+	// (4) ...and a matching subordinate GID range.
+	if _, _, err := resolveSubIDRange(p.subGIDFile, uname); err != nil {
+		return UserNSCompatResult{Supported: false, Reason: fmt.Sprintf("no subgid range >=%d for user %q in %s", minSubIDRange, uname, p.subGIDFile)}
+	}
+
+	return UserNSCompatResult{Supported: true}
+}
+
+// ResolveSubUIDRange returns the first /etc/subuid range >= 65536 for the given
+// user: (hostStart, size). Used by WithUserNamespace to pick the host UID base
+// for the container's 0..65535 mapping.
+func ResolveSubUIDRange(username string) (hostStart uint32, size uint32, err error) {
+	return resolveSubIDRange("/etc/subuid", username)
+}
+
+// resolveSubIDRange parses a subuid/subgid file for the first range >= minSubIDRange
+// belonging to username (matched by name or numeric UID/GID). Lines look like:
+//
+//	username:100000:65536
+func resolveSubIDRange(path, username string) (uint32, uint32, error) {
+	// #nosec G304 -- path is a fixed config constant (/etc/subuid|subgid) or a test temp file, never request input.
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Split(line, ":")
+		if len(parts) != 3 {
+			continue
+		}
+		if parts[0] != username {
+			continue
+		}
+		start, serr := strconv.ParseUint(parts[1], 10, 32)
+		if serr != nil {
+			continue
+		}
+		size, zerr := strconv.ParseUint(parts[2], 10, 32)
+		if zerr != nil {
+			continue
+		}
+		if size < minSubIDRange {
+			continue
+		}
+		return uint32(start), uint32(size), nil
+	}
+	return 0, 0, fmt.Errorf("no subordinate ID range >=%d for %q in %s", minSubIDRange, username, path)
+}
+
+// readSysctlInt reads a single-integer sysctl-style file. ok is false when the
+// file is absent or unparseable (callers treat that as "not constrained").
+func readSysctlInt(path string) (val int, ok bool) {
+	// #nosec G304 -- path is a fixed /proc/sys constant or a test temp file, never request input.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/runtime/userns_compat_linux_test.go
+++ b/internal/runtime/userns_compat_linux_test.go
@@ -1,0 +1,143 @@
+//go:build linux
+
+package runtime
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTempFile writes content to a fresh temp file and returns its path.
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func fixedUser(name string) func() (*user.User, error) {
+	return func() (*user.User, error) { return &user.User{Username: name}, nil }
+}
+
+func TestCheckUserNSCompat(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	tests := []struct {
+		name      string
+		paths     usernsPaths
+		wantOK    bool
+		reasonHas string
+	}{
+		{
+			name: "clone disabled",
+			paths: usernsPaths{
+				unprivilegedCloneFile: writeTempFile(t, "clone", "0\n"),
+				maxUserNamespacesFile: missing,
+				subUIDFile:            writeTempFile(t, "subuid", "alice:100000:65536\n"),
+				subGIDFile:            writeTempFile(t, "subgid", "alice:100000:65536\n"),
+				currentUser:           fixedUser("alice"),
+			},
+			wantOK:    false,
+			reasonHas: "unprivileged_userns_clone disabled",
+		},
+		{
+			name: "max_user_namespaces zero",
+			paths: usernsPaths{
+				unprivilegedCloneFile: missing,
+				maxUserNamespacesFile: writeTempFile(t, "maxuserns", "0\n"),
+				subUIDFile:            writeTempFile(t, "subuid", "alice:100000:65536\n"),
+				subGIDFile:            writeTempFile(t, "subgid", "alice:100000:65536\n"),
+				currentUser:           fixedUser("alice"),
+			},
+			wantOK:    false,
+			reasonHas: "max_user_namespaces=0",
+		},
+		{
+			name: "missing subuid",
+			paths: usernsPaths{
+				unprivilegedCloneFile: missing,
+				maxUserNamespacesFile: missing,
+				subUIDFile:            missing,
+				subGIDFile:            writeTempFile(t, "subgid", "alice:100000:65536\n"),
+				currentUser:           fixedUser("alice"),
+			},
+			wantOK:    false,
+			reasonHas: "no subuid range",
+		},
+		{
+			name: "subuid range too small",
+			paths: usernsPaths{
+				unprivilegedCloneFile: missing,
+				maxUserNamespacesFile: missing,
+				subUIDFile:            writeTempFile(t, "subuid", "alice:100000:1024\n"),
+				subGIDFile:            writeTempFile(t, "subgid", "alice:100000:65536\n"),
+				currentUser:           fixedUser("alice"),
+			},
+			wantOK:    false,
+			reasonHas: "no subuid range",
+		},
+		{
+			name: "missing subgid",
+			paths: usernsPaths{
+				unprivilegedCloneFile: missing,
+				maxUserNamespacesFile: missing,
+				subUIDFile:            writeTempFile(t, "subuid", "alice:100000:65536\n"),
+				subGIDFile:            missing,
+				currentUser:           fixedUser("alice"),
+			},
+			wantOK:    false,
+			reasonHas: "no subgid range",
+		},
+		{
+			name: "healthy",
+			paths: usernsPaths{
+				unprivilegedCloneFile: writeTempFile(t, "clone", "1\n"),
+				maxUserNamespacesFile: writeTempFile(t, "maxuserns", "15000\n"),
+				subUIDFile:            writeTempFile(t, "subuid", "alice:100000:65536\n"),
+				subGIDFile:            writeTempFile(t, "subgid", "alice:100000:65536\n"),
+				currentUser:           fixedUser("alice"),
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := checkUserNSCompat(tt.paths)
+			if res.Supported != tt.wantOK {
+				t.Fatalf("Supported = %v, want %v (reason: %q)", res.Supported, tt.wantOK, res.Reason)
+			}
+			if tt.reasonHas != "" && !contains(res.Reason, tt.reasonHas) {
+				t.Errorf("Reason = %q, want substring %q", res.Reason, tt.reasonHas)
+			}
+		})
+	}
+}
+
+func TestResolveSubIDRange_ParsesMultiEntry(t *testing.T) {
+	path := writeTempFile(t, "subuid", strings.Join([]string{
+		"# a comment",
+		"bob:200000:65536",
+		"alice:100000:1024",   // too small, skipped
+		"alice:300000:131072", // first usable range for alice
+	}, "\n")+"\n")
+
+	start, size, err := resolveSubIDRange(path, "alice")
+	if err != nil {
+		t.Fatalf("resolveSubIDRange error: %v", err)
+	}
+	if start != 300000 || size != 131072 {
+		t.Errorf("got (start=%d size=%d), want (300000, 131072)", start, size)
+	}
+
+	if _, _, err := resolveSubIDRange(path, "carol"); err == nil {
+		t.Error("expected error for a user with no range")
+	}
+}
+
+func contains(s, sub string) bool { return strings.Contains(s, sub) }

--- a/internal/runtime/userns_compat_other.go
+++ b/internal/runtime/userns_compat_other.go
@@ -1,0 +1,23 @@
+//go:build !linux
+
+package runtime
+
+// UserNSCompatResult reports user-namespace compatibility (defined on all
+// platforms so callers and the doctor checker compile without a build-tag split).
+type UserNSCompatResult struct {
+	Supported bool
+	Reason    string
+}
+
+// CheckUserNSCompat always reports unsupported on non-Linux platforms. This makes
+// WithUserNamespace a no-op on darwin, so the spec is left unchanged there.
+func CheckUserNSCompat() UserNSCompatResult {
+	return UserNSCompatResult{Supported: false, Reason: "user namespaces not supported on this platform"}
+}
+
+// ResolveSubUIDRange returns a safe stub on non-Linux. It is never reached on
+// darwin because WithUserNamespace only consults it when CheckUserNSCompat
+// reports Supported, which it never does here.
+func ResolveSubUIDRange(_ string) (hostStart uint32, size uint32, err error) {
+	return 100000, 65536, nil
+}

--- a/pkg/types/security.go
+++ b/pkg/types/security.go
@@ -28,9 +28,9 @@ type ContainerSecurityProfile struct {
 	ReadOnlyPaths   []string `yaml:"readonly_paths" json:"readonly_paths"`
 
 	// Seccomp
-	SeccompProfile   string   `yaml:"seccomp_profile" json:"seccomp_profile"` // "strict", "default", "unconfined"
-	BlockedSyscalls  []string `yaml:"blocked_syscalls" json:"blocked_syscalls"`
-	AllowedSyscalls  []string `yaml:"allowed_syscalls" json:"allowed_syscalls"` // Whitelist mode
+	SeccompProfile  string   `yaml:"seccomp_profile" json:"seccomp_profile"` // "strict", "default", "unconfined"
+	BlockedSyscalls []string `yaml:"blocked_syscalls" json:"blocked_syscalls"`
+	AllowedSyscalls []string `yaml:"allowed_syscalls" json:"allowed_syscalls"` // Whitelist mode
 
 	// AppArmor/SELinux
 	AppArmorProfile string `yaml:"apparmor_profile" json:"apparmor_profile"`
@@ -40,9 +40,9 @@ type ContainerSecurityProfile struct {
 	Ulimits UlimitConfig `yaml:"ulimits" json:"ulimits"`
 
 	// Network restrictions
-	AllowedOutboundPorts []int  `yaml:"allowed_outbound_ports" json:"allowed_outbound_ports"` // Empty = all allowed
-	AllowedInboundPorts  []int  `yaml:"allowed_inbound_ports" json:"allowed_inbound_ports"`   // Empty = all allowed
-	DNSPolicy            string `yaml:"dns_policy" json:"dns_policy"`                         // "default", "none", "custom"
+	AllowedOutboundPorts []int    `yaml:"allowed_outbound_ports" json:"allowed_outbound_ports"` // Empty = all allowed
+	AllowedInboundPorts  []int    `yaml:"allowed_inbound_ports" json:"allowed_inbound_ports"`   // Empty = all allowed
+	DNSPolicy            string   `yaml:"dns_policy" json:"dns_policy"`                         // "default", "none", "custom"
 	CustomDNS            []string `yaml:"custom_dns" json:"custom_dns"`
 }
 
@@ -149,8 +149,8 @@ func DefaultContainerSecurityProfile() *ContainerSecurityProfile {
 		Ulimits: UlimitConfig{
 			NoFile:  1024,
 			NProc:   100,
-			MemLock: 0,     // No locked memory
-			Core:    0,     // No core dumps
+			MemLock: 0,       // No locked memory
+			Core:    0,       // No core dumps
 			Stack:   8388608, // 8MB stack
 		},
 
@@ -197,7 +197,28 @@ func DeploymentSecurityProfile() *ContainerSecurityProfile {
 			"CAP_AUDIT_WRITE",
 		},
 
-		// No user namespace — UID 0→65534 mapping breaks most images
+		// R12: user namespace support is wired and opt-in, but DEFAULT OFF.
+		//
+		// WHY DEFAULT OFF: WithUserNamespace emits the full-range OCI UID/GID
+		// mapping (container 0..65535 -> host <subStart>..<subStart+65535>), but
+		// NOTHING currently remaps the rootfs snapshot. Containers are created with
+		// containerd.WithNewSnapshot (a plain overlay snapshot owned by host UID 0),
+		// so with a userns active container-UID-0 maps to host UID <subStart> (e.g.
+		// 100000) and the rootfs files (host UID 0) appear as nobody/overflow inside
+		// the namespace — the container's root process can no longer own/write (often
+		// not even read/exec) its own rootfs, and most real images fail to start.
+		//
+		// Enabling userns therefore requires a REMAPPED snapshot — containerd's
+		// WithRemapperLabels (containerd.io/snapshot/uidmapping + gidmapping) or an
+		// idmapped-mount-capable snapshotter — so the rootfs is ID-shifted into the
+		// host subordinate range to match the OCI mappings. That snapshot-remap wiring
+		// does not exist in the repo yet; it is the R11-gated follow-up (needs real
+		// Linux container-startup CI to validate). Until then, defaulting userns ON
+		// would regress real container startup on otherwise-capable Linux hosts.
+		//
+		// The CheckUserNSCompat gate and the WithUserNamespace mapping code are kept
+		// so a profile that explicitly sets UserNamespace=true (once the remapped
+		// snapshot lands) works without further plumbing.
 		UserNamespace:    false,
 		PIDNamespace:     true,
 		NetworkNamespace: true,
@@ -289,8 +310,14 @@ func DeploymentSecurityProfile() *ContainerSecurityProfile {
 		},
 		AllowedSyscalls: []string{}, // Unused in "default" mode
 
-		// No AppArmor by default — applied conditionally at runtime
-		AppArmorProfile: "",
+		// R9: request the moltbunker-container AppArmor profile. The runtime
+		// applies it only when it is actually loaded in the kernel
+		// (BuildOCISpecOpts guards on isAppArmorProfileLoaded), so naming it here
+		// is safe even before the daemon's AppArmorLoader has loaded it — once
+		// loaded (on first daemon start or via `moltbunker doctor --fix`) the
+		// confinement takes effect for new containers. On SELinux hosts set
+		// SELinuxLabel instead (see configs/apparmor/moltbunker-container.selinux-note).
+		AppArmorProfile: "moltbunker-container",
 		SELinuxLabel:    "",
 
 		// Practical ulimits
@@ -313,23 +340,23 @@ func DeploymentSecurityProfile() *ContainerSecurityProfile {
 // VerificationConfig defines multi-party verification settings
 type VerificationConfig struct {
 	// Heartbeat settings
-	HeartbeatIntervalSeconds int `yaml:"heartbeat_interval_seconds" json:"heartbeat_interval_seconds"`
-	HeartbeatTimeoutSeconds  int `yaml:"heartbeat_timeout_seconds" json:"heartbeat_timeout_seconds"`
+	HeartbeatIntervalSeconds    int `yaml:"heartbeat_interval_seconds" json:"heartbeat_interval_seconds"`
+	HeartbeatTimeoutSeconds     int `yaml:"heartbeat_timeout_seconds" json:"heartbeat_timeout_seconds"`
 	MissedHeartbeatsBeforeAlert int `yaml:"missed_heartbeats_before_alert" json:"missed_heartbeats_before_alert"`
 
 	// Cross-replica verification
-	ConsensusRequired        int  `yaml:"consensus_required" json:"consensus_required"`         // Out of 3 (e.g., 2)
-	OutputHashVerification   bool `yaml:"output_hash_verification" json:"output_hash_verification"`
-	DeterministicJobsOnly    bool `yaml:"deterministic_jobs_only" json:"deterministic_jobs_only"` // Only verify deterministic jobs
+	ConsensusRequired      int  `yaml:"consensus_required" json:"consensus_required"` // Out of 3 (e.g., 2)
+	OutputHashVerification bool `yaml:"output_hash_verification" json:"output_hash_verification"`
+	DeterministicJobsOnly  bool `yaml:"deterministic_jobs_only" json:"deterministic_jobs_only"` // Only verify deterministic jobs
 
 	// Canary probes
-	EnableCanaryProbes       bool `yaml:"enable_canary_probes" json:"enable_canary_probes"`
-	CanaryProbeIntervalMins  int  `yaml:"canary_probe_interval_mins" json:"canary_probe_interval_mins"`
-	CanaryFailureThreshold   int  `yaml:"canary_failure_threshold" json:"canary_failure_threshold"`
+	EnableCanaryProbes      bool `yaml:"enable_canary_probes" json:"enable_canary_probes"`
+	CanaryProbeIntervalMins int  `yaml:"canary_probe_interval_mins" json:"canary_probe_interval_mins"`
+	CanaryFailureThreshold  int  `yaml:"canary_failure_threshold" json:"canary_failure_threshold"`
 
 	// Resource attestation
-	ResourceAttestationEnabled   bool `yaml:"resource_attestation_enabled" json:"resource_attestation_enabled"`
-	ResourceMismatchThreshold    float64 `yaml:"resource_mismatch_threshold" json:"resource_mismatch_threshold"` // Percentage difference to flag
+	ResourceAttestationEnabled bool    `yaml:"resource_attestation_enabled" json:"resource_attestation_enabled"`
+	ResourceMismatchThreshold  float64 `yaml:"resource_mismatch_threshold" json:"resource_mismatch_threshold"` // Percentage difference to flag
 }
 
 // DefaultVerificationConfig returns the default verification configuration
@@ -341,7 +368,7 @@ func DefaultVerificationConfig() *VerificationConfig {
 		MissedHeartbeatsBeforeAlert: 3,
 
 		// Consensus
-		ConsensusRequired:      2,    // 2 out of 3
+		ConsensusRequired:      2, // 2 out of 3
 		OutputHashVerification: true,
 		DeterministicJobsOnly:  true,
 
@@ -358,13 +385,13 @@ func DefaultVerificationConfig() *VerificationConfig {
 
 // DeploymentEncryption represents encryption keys for a deployment
 type DeploymentEncryption struct {
-	DeploymentID     string    `json:"deployment_id"`
-	RequesterPubKey  []byte    `json:"requester_pub_key"`  // Ed25519 or X25519 public key
-	EncryptedDEK     []byte    `json:"encrypted_dek"`      // DEK encrypted with requester's public key
-	DEKAlgorithm     string    `json:"dek_algorithm"`      // "AES-256-GCM"
-	KeyDerivation    string    `json:"key_derivation"`     // "HKDF-SHA256"
-	Nonce            []byte    `json:"nonce"`              // For DEK encryption
-	CreatedAt        time.Time `json:"created_at"`
+	DeploymentID    string    `json:"deployment_id"`
+	RequesterPubKey []byte    `json:"requester_pub_key"` // Ed25519 or X25519 public key
+	EncryptedDEK    []byte    `json:"encrypted_dek"`     // DEK encrypted with requester's public key
+	DEKAlgorithm    string    `json:"dek_algorithm"`     // "AES-256-GCM"
+	KeyDerivation   string    `json:"key_derivation"`    // "HKDF-SHA256"
+	Nonce           []byte    `json:"nonce"`             // For DEK encryption
+	CreatedAt       time.Time `json:"created_at"`
 }
 
 // EncryptionConfig defines encryption settings
@@ -419,30 +446,30 @@ const (
 
 // WorkloadSpec defines a workload specification
 type WorkloadSpec struct {
-	Type         WorkloadType   `yaml:"type" json:"type"`
-	Name         string         `yaml:"name" json:"name"`
-	Image        string         `yaml:"image" json:"image"`
-	Resources    ResourceLimits `yaml:"resources" json:"resources"`
-	Command      []string       `yaml:"command,omitempty" json:"command,omitempty"`
-	Args         []string       `yaml:"args,omitempty" json:"args,omitempty"`
-	Environment  map[string]string `yaml:"environment,omitempty" json:"environment,omitempty"`
-	Ports        []PortMapping  `yaml:"ports,omitempty" json:"ports,omitempty"`
-	HealthCheck  *HealthCheck   `yaml:"health_check,omitempty" json:"health_check,omitempty"`
-	Network      NetworkConfig  `yaml:"network" json:"network"`
-	Timeout      time.Duration  `yaml:"timeout,omitempty" json:"timeout,omitempty"`
-	Retries      int            `yaml:"retries,omitempty" json:"retries,omitempty"`
+	Type        WorkloadType      `yaml:"type" json:"type"`
+	Name        string            `yaml:"name" json:"name"`
+	Image       string            `yaml:"image" json:"image"`
+	Resources   ResourceLimits    `yaml:"resources" json:"resources"`
+	Command     []string          `yaml:"command,omitempty" json:"command,omitempty"`
+	Args        []string          `yaml:"args,omitempty" json:"args,omitempty"`
+	Environment map[string]string `yaml:"environment,omitempty" json:"environment,omitempty"`
+	Ports       []PortMapping     `yaml:"ports,omitempty" json:"ports,omitempty"`
+	HealthCheck *HealthCheck      `yaml:"health_check,omitempty" json:"health_check,omitempty"`
+	Network     NetworkConfig     `yaml:"network" json:"network"`
+	Timeout     time.Duration     `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	Retries     int               `yaml:"retries,omitempty" json:"retries,omitempty"`
 
 	// For scheduled jobs
-	Schedule     string `yaml:"schedule,omitempty" json:"schedule,omitempty"` // Cron expression
-	Timezone     string `yaml:"timezone,omitempty" json:"timezone,omitempty"`
+	Schedule string `yaml:"schedule,omitempty" json:"schedule,omitempty"` // Cron expression
+	Timezone string `yaml:"timezone,omitempty" json:"timezone,omitempty"`
 
 	// For functions
-	Trigger      []TriggerConfig `yaml:"trigger,omitempty" json:"trigger,omitempty"`
-	ScaleToZero  bool            `yaml:"scale_to_zero,omitempty" json:"scale_to_zero,omitempty"`
+	Trigger     []TriggerConfig `yaml:"trigger,omitempty" json:"trigger,omitempty"`
+	ScaleToZero bool            `yaml:"scale_to_zero,omitempty" json:"scale_to_zero,omitempty"`
 
 	// Input/Output for jobs
-	Inputs       []DataSource `yaml:"inputs,omitempty" json:"inputs,omitempty"`
-	Outputs      []DataSource `yaml:"outputs,omitempty" json:"outputs,omitempty"`
+	Inputs  []DataSource `yaml:"inputs,omitempty" json:"inputs,omitempty"`
+	Outputs []DataSource `yaml:"outputs,omitempty" json:"outputs,omitempty"`
 }
 
 // PortMapping defines port exposure
@@ -455,14 +482,14 @@ type PortMapping struct {
 
 // HealthCheck defines health check configuration
 type HealthCheck struct {
-	Type             string `yaml:"type" json:"type"` // http, tcp, exec
-	Path             string `yaml:"path,omitempty" json:"path,omitempty"`
-	Port             int    `yaml:"port,omitempty" json:"port,omitempty"`
+	Type             string   `yaml:"type" json:"type"` // http, tcp, exec
+	Path             string   `yaml:"path,omitempty" json:"path,omitempty"`
+	Port             int      `yaml:"port,omitempty" json:"port,omitempty"`
 	Command          []string `yaml:"command,omitempty" json:"command,omitempty"`
-	IntervalSeconds  int    `yaml:"interval_seconds" json:"interval_seconds"`
-	TimeoutSeconds   int    `yaml:"timeout_seconds" json:"timeout_seconds"`
-	FailureThreshold int    `yaml:"failure_threshold" json:"failure_threshold"`
-	SuccessThreshold int    `yaml:"success_threshold" json:"success_threshold"`
+	IntervalSeconds  int      `yaml:"interval_seconds" json:"interval_seconds"`
+	TimeoutSeconds   int      `yaml:"timeout_seconds" json:"timeout_seconds"`
+	FailureThreshold int      `yaml:"failure_threshold" json:"failure_threshold"`
+	SuccessThreshold int      `yaml:"success_threshold" json:"success_threshold"`
 }
 
 // NetworkConfig defines network settings for a workload
@@ -474,7 +501,7 @@ type NetworkConfig struct {
 
 // TriggerConfig defines function triggers
 type TriggerConfig struct {
-	Type    string   `yaml:"type" json:"type"`       // http, event, schedule
+	Type    string   `yaml:"type" json:"type"` // http, event, schedule
 	Path    string   `yaml:"path,omitempty" json:"path,omitempty"`
 	Methods []string `yaml:"methods,omitempty" json:"methods,omitempty"`
 	Source  string   `yaml:"source,omitempty" json:"source,omitempty"`
@@ -500,9 +527,9 @@ const (
 
 // RegionConfig defines region-specific settings
 type RegionConfig struct {
-	PrimaryRegions   []GeographicRegion `yaml:"primary_regions" json:"primary_regions"`
-	SecondaryRegions []GeographicRegion `yaml:"secondary_regions" json:"secondary_regions"`
-	MinProvidersForSecondary int        `yaml:"min_providers_for_secondary" json:"min_providers_for_secondary"`
+	PrimaryRegions           []GeographicRegion `yaml:"primary_regions" json:"primary_regions"`
+	SecondaryRegions         []GeographicRegion `yaml:"secondary_regions" json:"secondary_regions"`
+	MinProvidersForSecondary int                `yaml:"min_providers_for_secondary" json:"min_providers_for_secondary"`
 }
 
 // DefaultRegionConfig returns the default region configuration

--- a/pkg/types/security_test.go
+++ b/pkg/types/security_test.go
@@ -42,7 +42,7 @@ func TestDeploymentSecurityProfile_Capabilities(t *testing.T) {
 		"CAP_SETFCAP":          true,
 		"CAP_SETPCAP":          true,
 		"CAP_NET_BIND_SERVICE": true,
-		"CAP_SYS_CHROOT":      true,
+		"CAP_SYS_CHROOT":       true,
 		"CAP_KILL":             true,
 		"CAP_AUDIT_WRITE":      true,
 	}
@@ -82,8 +82,10 @@ func TestDeploymentSecurityProfile_Capabilities(t *testing.T) {
 func TestDeploymentSecurityProfile_Namespaces(t *testing.T) {
 	profile := DeploymentSecurityProfile()
 
-	if profile.UserNamespace {
-		t.Error("user namespace should be disabled (breaks most images)")
+	// R12: user namespace is now enabled by default. The runtime degrades it
+	// gracefully via CheckUserNSCompat on hosts that disable unprivileged userns.
+	if !profile.UserNamespace {
+		t.Error("user namespace should be enabled (R12)")
 	}
 	if !profile.PIDNamespace {
 		t.Error("PID namespace should be enabled")
@@ -182,11 +184,15 @@ func TestDeploymentSecurityProfile_Ulimits(t *testing.T) {
 	}
 }
 
-func TestDeploymentSecurityProfile_NoAppArmor(t *testing.T) {
+func TestDeploymentSecurityProfile_AppArmor(t *testing.T) {
 	profile := DeploymentSecurityProfile()
 
-	if profile.AppArmorProfile != "" {
-		t.Errorf("deployment profile should have empty AppArmor profile, got %q", profile.AppArmorProfile)
+	// R9: the deployment profile now names the moltbunker-container AppArmor
+	// profile. The runtime applies it only when it is actually loaded in the
+	// kernel (BuildOCISpecOpts guards on isAppArmorProfileLoaded), so naming it
+	// here is safe even before the AppArmorLoader has loaded it.
+	if profile.AppArmorProfile != "moltbunker-container" {
+		t.Errorf("deployment profile should request moltbunker-container AppArmor profile, got %q", profile.AppArmorProfile)
 	}
 }
 
@@ -201,8 +207,11 @@ func TestDeploymentSecurityProfile_DiffersFromDefault(t *testing.T) {
 	if deploy.ReadOnlyRoot == def.ReadOnlyRoot {
 		t.Error("deployment profile should differ from default on read-only root")
 	}
-	if deploy.UserNamespace == def.UserNamespace {
-		t.Error("deployment profile should differ from default on user namespace")
+	// NOTE: as of R12 both profiles enable UserNamespace, so it is no longer a
+	// distinguishing field; DisableAttach remains a clear differentiator (default
+	// disables interactive access, deployment allows it).
+	if deploy.DisableAttach == def.DisableAttach {
+		t.Error("deployment profile should differ from default on attach access")
 	}
 	if deploy.SeccompProfile == def.SeccompProfile {
 		t.Error("deployment profile should use different seccomp mode than default")


### PR DESCRIPTION
## HARDEN-01 — Runtime isolation hardening (R9/R12/R16/R17)

- **R9:** ship a `moltbunker-deployment` AppArmor profile in-repo and load it on first daemon start (loader + doctor check), so the gate stops silently no-opping when no profile is kernel-loaded; SELinux note included.
- **R12:** user-namespace mapping wired behind a kernel/distro compat gate, **default OFF (opt-in)**. Enabling it requires a remapped rootfs snapshot (idmapped mount / `WithRemapperLabels`) — documented as the R11-gated follow-up. (Shipping userns default-on without the rootfs remap would regress container startup, so it's intentionally opt-in.)
- **R16:** disk-quota failures on XFS are now logged (Warn) instead of silently swallowed; non-XFS gets a fail-fast/warn.
- **R17:** guest PID bounding relies on the kata-agent-enforced **OCI `pids.limit`** (the `default_pids` hypervisor annotation is inert without `enable_annotations`); the doctor checker keys off the effective OCI limit rather than steering operators to a dead knob.

Verification: build + vet + linux cross-build + gosec(0) + runtime/doctor/config tests green. Secret-scan clean.

> **Stacked PR — base `ADDR-01`.** Merge order: … → ADDR-01 → **HARDEN-01**.
