### PR TITLE
REL-01 Add release signing (cosign), SBOM, and installer integrity verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,38 @@ jobs:
           version: latest
           args: --timeout=5m
 
+  release-lint:
+    name: Release Config Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # Validate the GoReleaser config (schema + template syntax) without
+      # running a release. Catches misconfigured signs/sboms stanzas before a
+      # tag push ever reaches the keyless-signing path.
+      - name: GoReleaser check
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          # Pin must match the version used in release.yml so `check` validates
+          # against the exact tool that will run the release.
+          version: '~> v2.4'
+          args: check
+
+      # ShellCheck the release-integrity shell scripts. Catches POSIX
+      # portability issues and common bash pitfalls in the installer and the
+      # standalone verifier.
+      - name: ShellCheck install + verify scripts
+        uses: ludeeus/action-shellcheck@master
+        with:
+          severity: warning
+          scandir: ./scripts
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # id-token: write lets the runner mint a short-lived OIDC token, which
+    # cosign exchanges for an ephemeral Fulcio signing certificate (keyless
+    # signing — no private key is stored anywhere). contents: write is needed
+    # for GoReleaser to upload the release artifacts.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,14 +32,34 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # Installs the cosign CLI onto the runner PATH so the .goreleaser.yml
+      # `signs` stanza can keyless-sign checksums.txt.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Installs the syft CLI onto the runner PATH so the .goreleaser.yml
+      # `sboms` stanza can generate a CycloneDX SBOM per archive.
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: latest
+          # Pinned for reproducible releases. The config (incl. the brews and
+          # dockers stanzas) validates cleanly on this v2 line; floating on
+          # `latest` would break the release when upstream hard-removes a
+          # currently-deprecated property. Bump deliberately, re-running
+          # `goreleaser check` first.
+          version: '~> v2.4'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NOTE: cosign v2 (installed by cosign-installer@v3) does keyless
+          # signing and Rekor transparency-log upload by DEFAULT — the old
+          # COSIGN_EXPERIMENTAL=1 toggle was a cosign v1 flag and is a no-op on
+          # v2, so it is intentionally not set here. `sign-blob --bundle` records
+          # the Rekor inclusion proof in the bundle out of the box.
 
   docker:
     name: Docker

--- a/.gitignore
+++ b/.gitignore
@@ -180,8 +180,13 @@ notes/
 research/
 TODO.local.md
 
-# Deploy scripts and keys (contain private keys)
-scripts/
+# Deploy scripts and keys (contain private keys). Ignore the *contents* of
+# scripts/ (so deploy scripts + keys stay out), but allow-list the public
+# release-integrity scripts below (no secrets — keyless OIDC only).
+scripts/*
+!scripts/install.sh
+!scripts/install.ps1
+!scripts/verify-release.sh
 secrets/
 
 # Deployment config (local/generated, do not commit)
@@ -197,7 +202,9 @@ management/
 
 configs/
 
-docs/
+# Ignore docs/ contents (local notes), but allow-list committed user-facing docs.
+docs/*
+!docs/release-integrity.md
 
 # Bruno API collection (local testing only).
 # Scoped to the collection dir: a bare "api/" also ignored internal/api/ (Go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,13 @@
 version: 2
 project_name: moltbunker
 
+# NOTE (release-toolchain debt): the `archives.format`, `brews`, and `dockers`
+# stanzas below use properties deprecated upstream (slated for hard removal in a
+# later v2). This is why release.yml + the release-lint CI job pin GoReleaser to
+# `~> v2.4`. Migration path (archives.format -> formats, brews ->
+# homebrew_casks, dockers -> dockers_v2) and the Windows-archive blocker are
+# tracked in docs/release-integrity.md ("Known release-toolchain debt").
+
 before:
   hooks:
     - go mod tidy
@@ -99,8 +106,46 @@ checksum:
   name_template: 'checksums.txt'
   algorithm: sha256
 
+# Software Bill of Materials. syft generates a CycloneDX JSON SBOM per archive
+# artifact (the format mandated by most enterprise/government supply-chain
+# policies, e.g. CISA / EO 14028). Requires `syft` on PATH; goreleaser skips
+# this stanza in `--snapshot` builds when syft is absent.
+sboms:
+  - id: archive
+    artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.cdx.json"
+    cmd: syft
+    args:
+      - "$artifact"
+      - "--output"
+      - "cyclonedx-json=$document"
+
+# Keyless (Sigstore OIDC) signing of the checksums file. No private key is
+# created or stored: cosign requests a short-lived OIDC token from the GitHub
+# Actions runner (requires `id-token: write` in release.yml), exchanges it for
+# an ephemeral Fulcio certificate, signs, and records the event in the Rekor
+# transparency log. The resulting `checksums.txt.sigstore.json` bundle is a
+# fully public artifact containing the cert + Rekor inclusion proof — no secret.
+#
+# Only `checksums.txt` is signed (not every archive): the checksum file pins
+# every archive via SHA-256, so one bundle anchors the whole release. This is
+# the pattern used by Helm, kubectl, and ko. Requires `cosign` on PATH;
+# goreleaser skips this stanza in `--snapshot` builds when cosign is absent.
+signs:
+  - id: checksum
+    cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    artifacts: checksum
+    output: true
+    args:
+      - "sign-blob"
+      - "--yes"
+      - "--bundle=${signature}"
+      - "${artifact}"
+
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc

--- a/docs/release-integrity.md
+++ b/docs/release-integrity.md
@@ -1,0 +1,168 @@
+# Release integrity
+
+moltbunker releases are built and published by a GitHub Actions pipeline
+([`.github/workflows/release.yml`](../.github/workflows/release.yml)) driven by
+GoReleaser ([`.goreleaser.yml`](../.goreleaser.yml)). Every release carries the
+supply-chain artifacts you need to verify that the binary you downloaded is
+exactly the one we built — and that *we* built it.
+
+Each release attaches:
+
+| Artifact | What it is |
+|---|---|
+| `moltbunker_<version>_<os>_<arch>.tar.gz` / `.zip` | the release archive (binaries + README + LICENSE) |
+| `checksums.txt` | SHA-256 of every archive |
+| `checksums.txt.sigstore.json` | cosign **keyless** (Sigstore) signature bundle over `checksums.txt` |
+| `<archive>.cdx.json` | CycloneDX SBOM (software bill of materials) for that archive, produced by syft |
+
+The trust model is layered: the **SBOM** tells you what is inside; the
+**SHA-256 checksums** pin every archive; the **cosign bundle** proves the
+checksums file was produced by the moltbunker release workflow and nobody else.
+
+> The installers do steps 1 and 2 automatically. `scripts/install.sh` (Linux /
+> macOS) and `scripts/install.ps1` (Windows) verify the SHA-256 before moving
+> any binary into place, and additionally run `cosign verify-blob` when `cosign`
+> is on your PATH. The SHA-256 check is mandatory; the cosign check is best-effort
+> and only skipped (with a warning) if cosign is not installed.
+
+---
+
+## 1. SHA-256 checksum verification
+
+Download the archive and `checksums.txt` for your platform, then:
+
+```bash
+# Linux (GNU coreutils)
+sha256sum --ignore-missing -c checksums.txt
+
+# macOS (BSD)
+shasum -a 256 --ignore-missing -c checksums.txt
+```
+
+`--ignore-missing` lets you verify only the archive(s) you actually downloaded
+without failing on the others listed in `checksums.txt`. A passing line reads
+`moltbunker_<version>_<os>_<arch>.tar.gz: OK`.
+
+This defends against accidental corruption and CDN/cache poisoning. It does
+**not**, on its own, prove who produced the checksums file — that is what
+cosign adds.
+
+---
+
+## 2. cosign keyless signature verification
+
+moltbunker signs `checksums.txt` with [cosign](https://docs.sigstore.dev/) using
+**keyless** (Sigstore OIDC) signing. There is **no private key** anywhere: the
+GitHub Actions runner mints a short-lived OIDC token, exchanges it for an
+ephemeral Fulcio certificate bound to the release-workflow identity, signs, and
+records the event in the [Rekor](https://docs.sigstore.dev/logging/overview/)
+transparency log. The ephemeral key is discarded; only the public certificate
+and Rekor inclusion proof survive, inside `checksums.txt.sigstore.json`.
+
+Requires **cosign v2.0 or newer** (the `--bundle` flag and `.sigstore.json`
+bundle format are v2). Install:
+
+```bash
+# Linux / macOS (Homebrew)
+brew install cosign
+# or download from https://github.com/sigstore/cosign/releases
+```
+
+Verify:
+
+```bash
+cosign verify-blob checksums.txt \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/moltbunker/moltbunker/.github/workflows/release.yml@refs/tags/' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+The two `--certificate-*` flags are the trust anchor. They assert that the
+signing certificate was issued to the moltbunker release workflow
+(`release.yml`, on a tag ref) and that the identity was authenticated by
+GitHub's OIDC issuer. A successful run prints `Verified OK`.
+
+If verification succeeds, you have cryptographic proof that `checksums.txt` —
+and therefore every archive it pins — was produced by the moltbunker release
+pipeline and recorded in a public transparency log.
+
+---
+
+## 3. Inspect the SBOM
+
+Each archive has a companion CycloneDX JSON SBOM
+(`<archive>.cdx.json`). To list components:
+
+```bash
+# Pretty-print component names + versions with jq
+jq -r '.components[] | "\(.name) \(.version)"' moltbunker_<version>_linux_x86_64.tar.gz.cdx.json
+
+# Or scan/diff it with any CycloneDX-aware tool, e.g. grype:
+grype sbom:moltbunker_<version>_linux_x86_64.tar.gz.cdx.json
+```
+
+CycloneDX is the format mandated by most enterprise / government supply-chain
+policies (CISA, US EO 14028). It includes component hashes and `purl`
+identifiers for every Go dependency compiled into the binary.
+
+---
+
+## 4. One-shot re-verification
+
+The repo ships a standalone helper that does steps 1 + 2 for you against an
+already-downloaded archive:
+
+```bash
+# from the directory containing the downloaded archive(s)
+./scripts/verify-release.sh v1.2.3
+```
+
+It downloads only `checksums.txt` (and the cosign bundle) for the given tag,
+verifies the SHA-256 of every matching local archive, then runs
+`cosign verify-blob` if cosign is installed. It exits non-zero on any failure.
+
+---
+
+## Why keyless?
+
+A long-lived GPG/minisign key would require the maintainers to secure, rotate,
+and revoke a private key forever — and a leaked key silently forges every future
+release. Keyless signing eliminates the private key entirely: the signing
+identity *is* the GitHub Actions workflow, which is public and version-controlled,
+and every signature is independently logged in Rekor. To trust a release you only
+need to know the org + workflow path — both visible in this repository.
+
+---
+
+## Known release-toolchain debt (tracked follow-ups)
+
+These do not affect the integrity guarantees above, but they gate an *actual*
+`goreleaser release` run and the long-term maintainability of the pipeline.
+They are deliberately deferred (the integrity/signing work shipped without them)
+and tracked here so the deprecation horizon is visible.
+
+1. **GoReleaser pinned to `~> v2.4`.** Both `release.yml` and the `release-lint`
+   CI job pin the same `~> v2.4` so the config validates today, but this freezes
+   the toolchain on an aging v2 minor. Several stanzas in `.goreleaser.yml` are
+   already deprecated and slated for hard removal upstream (deprecated in
+   v2.16+): `archives.format` → `archives.formats`, `brews` →
+   `homebrew_casks`, `dockers` → `dockers_v2`. When upstream hard-removes them a
+   future bump breaks the release until they are migrated, and because the lint
+   job is pinned to the same `~> v2.4` it will stay green and will NOT surface
+   the break in advance.
+   - **TODO:** migrate the three stanzas, then unpin / bump the GoReleaser
+     version. Optionally add a *non-blocking* CI step that runs
+     `goreleaser check` against `latest` so the deprecation horizon is at least
+     visible before it becomes a hard break.
+
+2. **Windows archive cannot currently be produced.** The daemon and CLI depend
+   on Linux-only syscalls and do not compile for `GOOS=windows`, and the mixed
+   per-platform binary counts trip GoReleaser's "different count of binaries for
+   each platform" archive error. `scripts/install.ps1` therefore documents a
+   path that no real release can yet feed (both pre-existing; out of REL-01
+   scope).
+   - **TODO:** either drop `windows` from the build matrix in `.goreleaser.yml`,
+     or split archives per build-id so a real `goreleaser release` can run. Once
+     Windows archives actually ship, `install.ps1` should enumerate `*.exe` in
+     the extract dir rather than hardcoding the binary list (see the comment at
+     the install loop in `scripts/install.ps1`).

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,199 @@
+<#
+.SYNOPSIS
+  moltbunker installer for Windows.
+
+.DESCRIPTION
+  Supply-chain integrity: this script never trusts a raw binary blindly. It
+  downloads the release archive AND the signed checksums.txt, then:
+
+    1. (always, hard-required) verifies the archive's SHA-256 against
+       checksums.txt;
+    2. (best-effort) if cosign is on PATH, verifies that checksums.txt was
+       keyless-signed (Sigstore OIDC) by the moltbunker GitHub Actions release
+       workflow.
+
+  The SHA-256 check is mandatory and aborts on mismatch. The cosign check is
+  advisory. See docs/release-integrity.md.
+
+  NOTE: the release pipeline does not build a windows/arm64 archive
+  (.goreleaser.yml ignores goos=windows goarch=arm64), so only x86_64 (amd64)
+  is installable on Windows.
+
+.PARAMETER Version
+  Release tag to install, e.g. v1.2.3. Defaults to the latest release.
+
+.EXAMPLE
+  iwr -useb https://moltbunker.dev/install.ps1 | iex
+  .\install.ps1 -Version v1.2.3
+#>
+param(
+  [string]$Version = "",
+  [string]$InstallDir = "$env:LOCALAPPDATA\moltbunker\bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = if ($env:MOLTBUNKER_REPO) { $env:MOLTBUNKER_REPO } else { "moltbunker/moltbunker" }
+$GitHubApi = "https://api.github.com/repos/$Repo"
+$GitHubDl  = "https://github.com/$Repo/releases/download"
+
+# Public OIDC identity that signed checksums.txt — the trust anchor for keyless
+# verification. Do NOT change without coordinating with .github/workflows.
+$CertIdentityRegexp = "^https://github.com/$Repo/\.github/workflows/release\.yml@refs/tags/"
+$CertOidcIssuer     = "https://token.actions.githubusercontent.com"
+
+function Write-Info($msg) { Write-Host "==> $msg" -ForegroundColor Blue }
+function Write-Ok($msg)   { Write-Host "  ok $msg" -ForegroundColor Green }
+function Write-Warn($msg) { Write-Warning $msg }
+function Die($msg)        { Write-Error $msg; exit 1 }
+
+function Get-Arch {
+  # Only x86_64 archives are published for Windows (see note above).
+  $arch = (Get-CimInstance Win32_Processor | Select-Object -First 1).Architecture
+  switch ($arch) {
+    9 { return "x86_64" }   # x64
+    default {
+      Die "unsupported Windows architecture (only x86_64 release archives are published)"
+    }
+  }
+}
+
+function Resolve-Version {
+  if ($Version) { return $Version }
+  Write-Info "Resolving latest release"
+  $rel = Invoke-RestMethod -Uri "$GitHubApi/releases/latest" -Headers @{ "User-Agent" = "moltbunker-install" }
+  if (-not $rel.tag_name) { Die "could not resolve latest release tag" }
+  return $rel.tag_name
+}
+
+# Winget fast-path: if a moltbunker winget package is available, prefer it.
+function Try-Winget {
+  if ($env:MOLTBUNKER_NO_WINGET) { return $false }
+  if (-not (Get-Command winget -ErrorAction SilentlyContinue)) { return $false }
+  Write-Info "winget detected — attempting winget install (set MOLTBUNKER_NO_WINGET=1 to force direct download)"
+  try {
+    winget install --id moltbunker.moltbunker --accept-source-agreements --accept-package-agreements -e
+    if ($LASTEXITCODE -eq 0) {
+      Write-Ok "installed via winget"
+      return $true
+    }
+  } catch {
+    Write-Warn "winget install failed; falling back to verified direct download"
+  }
+  return $false
+}
+
+function DownloadAndVerify {
+  $arch = Get-Arch
+  $tag = Resolve-Version
+  $ver = $tag.TrimStart('v')
+
+  $archive   = "moltbunker_${ver}_windows_${arch}.zip"
+  $archiveUrl = "$GitHubDl/$tag/$archive"
+  $checksumsUrl = "$GitHubDl/$tag/checksums.txt"
+  $bundleUrl    = "$GitHubDl/$tag/checksums.txt.sigstore.json"
+
+  $work = Join-Path $env:TEMP ("moltbunker-install-" + [System.Guid]::NewGuid().ToString("N"))
+  New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+  try {
+    Write-Info "Installing moltbunker $tag (windows/$arch)"
+
+    $archivePath   = Join-Path $work $archive
+    $checksumsPath = Join-Path $work "checksums.txt"
+
+    Write-Info "Downloading $archive"
+    Invoke-WebRequest -Uri $archiveUrl -OutFile $archivePath -UseBasicParsing
+
+    Write-Info "Downloading checksums.txt"
+    Invoke-WebRequest -Uri $checksumsUrl -OutFile $checksumsPath -UseBasicParsing
+
+    # ── Step 1: SHA-256 (hard-required) ──
+    Write-Info "Verifying SHA-256 checksum"
+    $expectedLine = (Get-Content $checksumsPath | Where-Object { $_ -match [regex]::Escape($archive) + '$' } | Select-Object -First 1)
+    if (-not $expectedLine) {
+      Die "archive $archive not listed in checksums.txt (wrong version/platform?)"
+    }
+    $expected = ($expectedLine -split '\s+')[0].ToLower()
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $archivePath).Hash.ToLower()
+    if ($actual -ne $expected) {
+      Die "SHA-256 checksum verification FAILED for $archive (expected $expected, got $actual) — refusing to install"
+    }
+    Write-Ok "checksum verified"
+
+    # ── Step 2: cosign keyless ──
+    # When cosign IS present, the signature is MANDATORY: a missing/404'd
+    # bundle is a hard failure, not a silent downgrade to checksum-only.
+    # Otherwise an attacker who can serve a tampered checksums.txt could also
+    # 404 the bundle to strip the cosign check, and the SHA-256 would then
+    # validate against the ATTACKER's checksums.txt. Mirrors install.sh /
+    # verify-release.sh. Set MOLTBUNKER_SKIP_COSIGN=1 to explicitly opt out.
+    if ((Get-Command cosign -ErrorAction SilentlyContinue) -and (-not $env:MOLTBUNKER_SKIP_COSIGN)) {
+      Write-Info "Verifying cosign signature on checksums.txt"
+      $bundlePath = Join-Path $work "checksums.txt.sigstore.json"
+      try {
+        Invoke-WebRequest -Uri $bundleUrl -OutFile $bundlePath -UseBasicParsing
+      } catch {
+        Die "cosign present but cosign bundle download failed ($bundleUrl) — refusing to install (set MOLTBUNKER_SKIP_COSIGN=1 to override)"
+      }
+      & cosign verify-blob $checksumsPath `
+        --bundle $bundlePath `
+        --certificate-identity-regexp $CertIdentityRegexp `
+        --certificate-oidc-issuer $CertOidcIssuer | Out-Null
+      if ($LASTEXITCODE -ne 0) {
+        Die "cosign signature verification FAILED — refusing to install"
+      }
+      Write-Ok "cosign signature verified (keyless / Sigstore)"
+    } elseif (Get-Command cosign -ErrorAction SilentlyContinue) {
+      Write-Warn "cosign found but MOLTBUNKER_SKIP_COSIGN is set — skipping signature verification."
+      Write-Warn "SHA-256 integrity is verified, but signature provenance is NOT."
+    } else {
+      Write-Warn "cosign not found on PATH — skipping signature verification."
+      Write-Warn "SHA-256 integrity is verified, but signature provenance is not."
+    }
+
+    # ── Step 3: extract + install ──
+    Write-Info "Extracting archive"
+    $extract = Join-Path $work "extract"
+    Expand-Archive -Path $archivePath -DestinationPath $extract -Force
+
+    if (-not (Test-Path $InstallDir)) {
+      New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    # Install whatever .exe binaries the archive actually contains, rather than
+    # a hardcoded list — mirrors install.sh's loop. Today the Windows archive
+    # ships moltbunker.exe + moltbunker-daemon.exe only (api is linux/darwin,
+    # exec-agent is linux), but this stays correct if that set ever changes.
+    $installed = 0
+    foreach ($srcBin in (Get-ChildItem -Path $extract -Filter "*.exe" -File)) {
+      Write-Info "Installing $($srcBin.Name) -> $InstallDir\$($srcBin.Name)"
+      Copy-Item -Path $srcBin.FullName -Destination (Join-Path $InstallDir $srcBin.Name) -Force
+      $installed++
+    }
+    if ($installed -eq 0) { Die "no moltbunker binaries found in the archive" }
+    Write-Ok "installed $installed binaries to $InstallDir"
+
+    # Add InstallDir to the user PATH if not already present.
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -notlike "*$InstallDir*") {
+      [Environment]::SetEnvironmentVariable("Path", "$userPath;$InstallDir", "User")
+      Write-Info "Added $InstallDir to your user PATH (restart your shell to pick it up)"
+    }
+  }
+  finally {
+    if (Test-Path $work) { Remove-Item -Path $work -Recurse -Force -ErrorAction SilentlyContinue }
+  }
+}
+
+if (-not (Try-Winget)) {
+  DownloadAndVerify
+}
+
+Write-Host ""
+Write-Host "moltbunker installed."
+Write-Host "  moltbunker --help            # CLI"
+Write-Host "  moltbunker-daemon --help     # node daemon"
+Write-Host ""
+Write-Host "To re-verify a release, see:"
+Write-Host "  https://github.com/moltbunker/moltbunker/blob/main/docs/release-integrity.md"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+#
+# moltbunker installer (Linux / macOS).
+#
+# Supply-chain integrity: this script NEVER trusts a raw binary blindly. Every
+# install path downloads the release archive AND the signed checksums.txt, then:
+#
+#   1. (always, hard-required) verifies the archive's SHA-256 against the
+#      checksums.txt that ships with the release;
+#   2. (best-effort) if `cosign` is on PATH, verifies that checksums.txt itself
+#      was keyless-signed (Sigstore OIDC) by the moltbunker GitHub Actions
+#      release workflow, anchoring the whole release to a public identity.
+#
+# The SHA-256 check is mandatory and aborts on mismatch. The cosign check is
+# conditionally mandatory: if `cosign` is on PATH it MUST succeed (a missing or
+# unverifiable signature bundle aborts the install — set MOLTBUNKER_SKIP_COSIGN=1
+# to opt out), so an attacker cannot 404 the bundle to strip signature checking
+# and downgrade you to attacker-controlled checksums. A host WITHOUT cosign still
+# gets integrity against corruption / CDN cache poisoning, the most common attack
+# vector. Install cosign to also defend against a compromised release page. See
+# docs/release-integrity.md.
+#
+# Usage:
+#   curl -fsSL https://moltbunker.dev/install.sh | bash
+#   ./install.sh                 # latest release
+#   VERSION=v1.2.3 ./install.sh  # pin a version
+#
+set -euo pipefail
+
+# ─── Configuration ──────────────────────────────────────────────────────────
+
+REPO="${MOLTBUNKER_REPO:-moltbunker/moltbunker}"
+INSTALL_DIR="${MOLTBUNKER_INSTALL_DIR:-/usr/local/bin}"
+GITHUB_API="https://api.github.com/repos/${REPO}"
+GITHUB_DL="https://github.com/${REPO}/releases/download"
+
+# The cosign identity that signed checksums.txt. This is the OIDC claim path of
+# the release workflow — public, version-controlled, and the trust anchor for
+# keyless verification. Do NOT change without coordinating with .github.
+CERT_IDENTITY_REGEXP="^https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/"
+CERT_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+
+# ─── Output helpers ───────────────────────────────────────────────────────────
+
+info()  { printf '\033[0;34m==>\033[0m %s\n' "$*"; }
+warn()  { printf '\033[0;33mwarning:\033[0m %s\n' "$*" >&2; }
+ok()    { printf '\033[0;32m  ok\033[0m %s\n' "$*"; }
+die()   { printf '\033[0;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ─── Platform detection ───────────────────────────────────────────────────────
+
+detect_os() {
+  local os
+  os="$(uname -s)"
+  case "${os}" in
+    Linux)  echo "linux" ;;
+    Darwin) echo "darwin" ;;
+    *)      die "unsupported OS: ${os} (moltbunker supports Linux and macOS)" ;;
+  esac
+}
+
+# Maps `uname -m` to the GoReleaser archive arch token. The .goreleaser.yml
+# name_template rewrites amd64 -> x86_64; everything else passes through.
+detect_arch() {
+  local arch
+  arch="$(uname -m)"
+  case "${arch}" in
+    x86_64|amd64) echo "x86_64" ;;
+    arm64|aarch64) echo "arm64" ;;
+    *) die "unsupported architecture: ${arch} (moltbunker supports x86_64 and arm64)" ;;
+  esac
+}
+
+# ─── Dependency checks ────────────────────────────────────────────────────────
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+# Selects a SHA-256 checker. GNU coreutils ships `sha256sum`; macOS ships
+# `shasum`. Both support the `-c` (check-against-list) mode we rely on.
+sha256_check() {
+  # $1 = checksum list file (already filtered to the target archive line)
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$1"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "$1"
+  else
+    die "no SHA-256 tool found (need sha256sum or shasum)"
+  fi
+}
+
+# Picks a downloader. curl preferred; wget fallback.
+download() {
+  # $1 = url, $2 = output path
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$2" "$1"
+  else
+    die "no downloader found (need curl or wget)"
+  fi
+}
+
+# ─── Version resolution ───────────────────────────────────────────────────────
+
+resolve_version() {
+  if [ -n "${VERSION:-}" ]; then
+    echo "${VERSION}"
+    return
+  fi
+  local tmp tag
+  tmp="$(mktemp)"
+  download "${GITHUB_API}/releases/latest" "${tmp}" \
+    || die "could not reach GitHub API to resolve the latest release"
+  # Extract "tag_name": "vX.Y.Z" without requiring jq.
+  tag="$(grep -m1 '"tag_name"' "${tmp}" | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+  rm -f "${tmp}"
+  [ -n "${tag}" ] || die "could not parse latest release tag from GitHub API"
+  echo "${tag}"
+}
+
+# ─── Core: download + verify + install ────────────────────────────────────────
+
+download_and_verify() {
+  local os arch tag version
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  tag="$(resolve_version)"
+  # GoReleaser archive names use the version WITHOUT the leading "v".
+  version="${tag#v}"
+
+  local archive="moltbunker_${version}_${os}_${arch}.tar.gz"
+  local archive_url="${GITHUB_DL}/${tag}/${archive}"
+  local checksums_url="${GITHUB_DL}/${tag}/checksums.txt"
+  local bundle_url="${GITHUB_DL}/${tag}/checksums.txt.sigstore.json"
+
+  local workdir
+  workdir="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand workdir now, intentionally.
+  trap "rm -rf '${workdir}'" EXIT
+
+  info "Installing moltbunker ${tag} (${os}/${arch})"
+
+  info "Downloading ${archive}"
+  download "${archive_url}" "${workdir}/${archive}" \
+    || die "failed to download archive: ${archive_url}"
+
+  info "Downloading checksums.txt"
+  download "${checksums_url}" "${workdir}/checksums.txt" \
+    || die "failed to download checksums.txt"
+
+  # ── Step 1: SHA-256 (hard-required) ──
+  info "Verifying SHA-256 checksum"
+  # Filter checksums.txt to ONLY the line for our archive, so the -c mode
+  # neither fails on (nor verifies) the other archives we did not download.
+  grep " ${archive}\$" "${workdir}/checksums.txt" > "${workdir}/checksums.filtered" \
+    || die "archive ${archive} not listed in checksums.txt (wrong version/platform?)"
+  (
+    cd "${workdir}"
+    sha256_check "checksums.filtered"
+  ) || die "SHA-256 checksum verification FAILED for ${archive} — refusing to install"
+  ok "checksum verified"
+
+  # ── Step 2: cosign keyless ──
+  # When cosign IS present, the signature is MANDATORY: a missing/404'd bundle
+  # is a hard failure, not a silent downgrade to checksum-only. Otherwise an
+  # attacker who can serve a tampered checksums.txt (compromised release page /
+  # CDN MITM) could also 404 the bundle to strip the cosign check entirely, and
+  # the SHA-256 would then validate against the ATTACKER's checksums.txt — the
+  # exact threat this script's header claims to defend against. This mirrors
+  # verify-release.sh's hard-fail posture. Set MOLTBUNKER_SKIP_COSIGN=1 to
+  # explicitly opt out (e.g. air-gapped re-install of an already-trusted tag).
+  if command -v cosign >/dev/null 2>&1 && [ -z "${MOLTBUNKER_SKIP_COSIGN:-}" ]; then
+    info "Verifying cosign signature on checksums.txt"
+    download "${bundle_url}" "${workdir}/checksums.txt.sigstore.json" \
+      || die "cosign present but cosign bundle download failed (${bundle_url}) — refusing to install (set MOLTBUNKER_SKIP_COSIGN=1 to override)"
+    if cosign verify-blob "${workdir}/checksums.txt" \
+      --bundle "${workdir}/checksums.txt.sigstore.json" \
+      --certificate-identity-regexp "${CERT_IDENTITY_REGEXP}" \
+      --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" >/dev/null 2>&1; then
+      ok "cosign signature verified (keyless / Sigstore)"
+    else
+      die "cosign signature verification FAILED — refusing to install"
+    fi
+  elif command -v cosign >/dev/null 2>&1; then
+    warn "cosign found but MOLTBUNKER_SKIP_COSIGN is set — skipping signature verification."
+    warn "SHA-256 integrity is verified, but signature provenance is NOT."
+  else
+    warn "cosign not found on PATH — skipping signature verification."
+    warn "SHA-256 integrity is verified, but signature provenance is not."
+    warn "Install cosign and run scripts/verify-release.sh to fully verify."
+  fi
+
+  # ── Step 3: extract + install ──
+  info "Extracting archive"
+  tar -xzf "${workdir}/${archive}" -C "${workdir}" \
+    || die "failed to extract ${archive}"
+
+  install_binaries "${workdir}"
+}
+
+install_binaries() {
+  local src="$1"
+  local sudo=""
+  # If we cannot write to INSTALL_DIR, escalate with sudo (if present).
+  if [ ! -w "${INSTALL_DIR}" ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo=sudo
+    else
+      die "cannot write to ${INSTALL_DIR} and sudo is not available; set MOLTBUNKER_INSTALL_DIR to a writable path"
+    fi
+  fi
+
+  local installed=0 bin
+  for bin in moltbunker moltbunker-daemon moltbunker-api exec-agent; do
+    if [ -f "${src}/${bin}" ]; then
+      info "Installing ${bin} -> ${INSTALL_DIR}/${bin}"
+      ${sudo} install -m 0755 "${src}/${bin}" "${INSTALL_DIR}/${bin}" \
+        || die "failed to install ${bin}"
+      installed=$((installed + 1))
+    fi
+  done
+  [ "${installed}" -gt 0 ] || die "no moltbunker binaries found in the archive"
+  ok "installed ${installed} binary/binaries to ${INSTALL_DIR}"
+}
+
+# ─── macOS Homebrew fast-path ─────────────────────────────────────────────────
+
+try_homebrew() {
+  # Homebrew is the preferred macOS UX. The tap formula is verified by
+  # Homebrew's own checksum mechanism, so it satisfies our integrity bar.
+  if [ "$(detect_os)" = "darwin" ] && command -v brew >/dev/null 2>&1 \
+     && [ -z "${MOLTBUNKER_NO_BREW:-}" ]; then
+    info "Homebrew detected — installing via tap (set MOLTBUNKER_NO_BREW=1 to force direct download)"
+    brew tap moltbunker/homebrew-tap 2>/dev/null || true
+    if brew install moltbunker; then
+      ok "installed via Homebrew"
+      return 0
+    fi
+    warn "brew install failed; falling back to verified direct download"
+  fi
+  return 1
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  need_cmd tar
+  if try_homebrew; then
+    exit 0
+  fi
+  download_and_verify
+  cat <<'EOF'
+
+moltbunker installed.
+
+  moltbunker --help            # CLI
+  moltbunker-daemon --help     # node daemon
+
+To re-verify a release at any time (incl. cosign signature provenance), see:
+  https://github.com/moltbunker/moltbunker/blob/main/docs/release-integrity.md
+EOF
+}
+
+main "$@"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# verify-release.sh — standalone verification of a downloaded moltbunker release.
+#
+# Use this when you have already downloaded one or more release archives (or
+# want to re-verify after installing cosign). It downloads ONLY the release's
+# checksums.txt (and the cosign bundle) for the given version, then:
+#
+#   1. (hard-required) verifies the SHA-256 of every local archive file in the
+#      current directory that matches the given version;
+#   2. (if cosign is on PATH) verifies the keyless Sigstore signature on
+#      checksums.txt against the moltbunker release-workflow OIDC identity.
+#
+# Exits 0 only if all attempted checks pass. See docs/release-integrity.md.
+#
+# Usage:
+#   ./verify-release.sh v1.2.3          # verify archives in CWD against v1.2.3
+#   ./verify-release.sh v1.2.3 /tmp/dl  # verify archives in /tmp/dl
+#
+set -euo pipefail
+
+REPO="${MOLTBUNKER_REPO:-moltbunker/moltbunker}"
+GITHUB_DL="https://github.com/${REPO}/releases/download"
+CERT_IDENTITY_REGEXP="^https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/"
+CERT_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+
+info()  { printf '\033[0;34m==>\033[0m %s\n' "$*"; }
+warn()  { printf '\033[0;33mwarning:\033[0m %s\n' "$*" >&2; }
+ok()    { printf '\033[0;32m  ok\033[0m %s\n' "$*"; }
+die()   { printf '\033[0;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat >&2 <<EOF
+usage: $0 <version> [directory]
+
+  <version>    release tag, e.g. v1.2.3
+  [directory]  directory holding the downloaded archives (default: .)
+EOF
+  exit 2
+}
+
+download() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$2" "$1"
+  else
+    die "no downloader found (need curl or wget)"
+  fi
+}
+
+sha256_check() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$1"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "$1"
+  else
+    die "no SHA-256 tool found (need sha256sum or shasum)"
+  fi
+}
+
+main() {
+  [ "$#" -ge 1 ] || usage
+  local tag="$1"
+  local dir="${2:-.}"
+  local version="${tag#v}"
+
+  [ -d "${dir}" ] || die "directory not found: ${dir}"
+
+  local workdir
+  workdir="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand workdir now, intentionally.
+  trap "rm -rf '${workdir}'" EXIT
+
+  info "Fetching checksums.txt for ${tag}"
+  download "${GITHUB_DL}/${tag}/checksums.txt" "${workdir}/checksums.txt" \
+    || die "failed to download checksums.txt for ${tag}"
+
+  # ── SHA-256 of every matching local archive ──
+  local matched=0 line fname
+  : > "${workdir}/to_check.txt"
+  while IFS= read -r line; do
+    # checksums.txt lines look like: "<hex>  moltbunker_<version>_<os>_<arch>.tar.gz"
+    fname="${line##* }"
+    case "${fname}" in
+      moltbunker_"${version}"_*) ;;
+      *) continue ;;
+    esac
+    if [ -f "${dir}/${fname}" ]; then
+      echo "${line}" >> "${workdir}/to_check.txt"
+      matched=$((matched + 1))
+    fi
+  done < "${workdir}/checksums.txt"
+
+  [ "${matched}" -gt 0 ] \
+    || die "no local archives for ${tag} found in ${dir} (looked for moltbunker_${version}_*)"
+
+  info "Verifying SHA-256 for ${matched} local archive(s)"
+  (
+    cd "${dir}"
+    sha256_check "${workdir}/to_check.txt"
+  ) || die "SHA-256 verification FAILED"
+  ok "all ${matched} archive(s) match checksums.txt"
+
+  # ── cosign keyless signature on checksums.txt ──
+  if command -v cosign >/dev/null 2>&1; then
+    info "Verifying cosign signature on checksums.txt"
+    download "${GITHUB_DL}/${tag}/checksums.txt.sigstore.json" \
+      "${workdir}/checksums.txt.sigstore.json" \
+      || die "failed to download cosign bundle for ${tag}"
+    cosign verify-blob "${workdir}/checksums.txt" \
+      --bundle "${workdir}/checksums.txt.sigstore.json" \
+      --certificate-identity-regexp "${CERT_IDENTITY_REGEXP}" \
+      --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" \
+      || die "cosign signature verification FAILED"
+    ok "cosign signature verified (keyless / Sigstore)"
+  else
+    warn "cosign not found on PATH — skipped signature verification."
+    warn "SHA-256 integrity is confirmed; install cosign to also verify provenance."
+  fi
+
+  ok "release ${tag} verified"
+}
+
+main "$@"


### PR DESCRIPTION
## REL-01 — Release supply-chain integrity

- **cosign keyless (OIDC) signing** of release binaries + a generated `checksums.txt` + **syft SBOM** in `.goreleaser.yml`/`release.yml` — no private signing keys in source.
- `install.sh` + `install.ps1` verify the checksum, and when `cosign` is present the signature bundle is now **mandatory** (hard-fail, `MOLTBUNKER_SKIP_COSIGN=1` opt-out) — closes a signature-stripping downgrade where a 404'd bundle silently fell back to attacker-controllable checksum-only. Adds `scripts/verify-release.sh` + `docs/release-integrity.md`.
- No deploy/publish — pipeline definition only.

Verification: `go build` + `shellcheck` + YAML parse green. Secret-scan clean.

> **Base `main`** (independent — no file overlap with other PRs).
