### PR TITLE
EDGE-02 Add custom-hostname ACME, edge-provider role gating, operator takedown

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
@@ -26,6 +27,7 @@ import (
 	"github.com/moltbunker/moltbunker/internal/config"
 	"github.com/moltbunker/moltbunker/internal/crawl"
 	"github.com/moltbunker/moltbunker/internal/daemon"
+	"github.com/moltbunker/moltbunker/internal/edge"
 	"github.com/moltbunker/moltbunker/internal/identity"
 	"github.com/moltbunker/moltbunker/internal/ingress"
 	"github.com/moltbunker/moltbunker/internal/logging"
@@ -39,6 +41,7 @@ import (
 	"github.com/moltbunker/moltbunker/internal/threat"
 	"github.com/moltbunker/moltbunker/internal/tunnel"
 	"github.com/moltbunker/moltbunker/internal/util"
+	"github.com/moltbunker/moltbunker/pkg/types"
 )
 
 // Build-time version information (set via -ldflags)
@@ -462,6 +465,10 @@ func main() {
 	// Ingress nodes: start HTTP reverse proxy for subdomain routing
 	var ingressProxy *ingress.Proxy
 	var ingressHealthChecker *ingress.HealthChecker
+	// EDGE-02 operator surfaces, created in the ingress block and mounted on the
+	// HTTP API server below (declared here so both blocks can see them).
+	var customDomainAdmin *ingress.CustomDomainHandler
+	var takedownBlocklist *tunnel.Blocklist
 	if cfg.Node.Provider.IngressEnabled {
 		cm := apiServer.GetContainerManager()
 		if cm != nil && cm.GossipProtocol() != nil {
@@ -482,6 +489,15 @@ func main() {
 			tunnelClient := tunnel.NewClient(tunnelDialer)
 			resolver := ingress.NewResolver(gossipAdapter, gossipAdapter) // implements both GossipReader and SubdomainResolver
 			ingressProxy = ingress.NewProxy(resolver, tunnelClient, ingressDomain)
+
+			// EDGE-02: operator takedown kill-switch. Created here (not in the
+			// reverse-tunnel block) and wired into the ingress proxy itself so a
+			// takedown is enforced on EVERY request — the forward-tunnel serving
+			// path and verified custom hosts included — not just on reverse-tunnel
+			// registration/stream-open. The same instance is also handed to the
+			// reverse server below and exposed via the admin API.
+			takedownBlocklist = tunnel.NewBlocklist()
+			ingressProxy.SetBlocklist(takedownBlocklist)
 
 			// Wire the L7 edge middleware (WAF + per-tenant abuse limits + edge
 			// metrics) into the ingress request path. Default-safe: WAF in
@@ -522,6 +538,34 @@ func main() {
 				}
 				email := cfg.Node.Provider.IngressACMEEmail
 				autoTLS := ingress.NewAutoTLSConfig(certDir, ingressDomain, email, resolver)
+
+				// EDGE-02: BYO custom-hostname ACME. When enabled, build the
+				// ownership store + DNS verifier, let hostPolicy issue LE certs
+				// for verified custom hosts, and route them via the proxy. The
+				// verification HMAC secret is generated in memory (not persisted)
+				// — a restart invalidates outstanding challenges, which is fine
+				// since customers simply re-trigger verification.
+				if cfg.Node.Provider.CustomDomain.Enabled {
+					ttl := time.Duration(cfg.Node.Provider.CustomDomain.OwnershipTTLHours) * time.Hour
+					cdStore := ingress.NewDomainOwnershipStore(ttl)
+					cdSecret := make([]byte, 32)
+					if _, randErr := rand.Read(cdSecret); randErr != nil {
+						logging.Error("custom-domain HMAC secret generation failed",
+							logging.Err(randErr), logging.Component("ingress"))
+					} else {
+						method := ingress.VerifyMethod(cfg.Node.Provider.CustomDomain.VerifyMethod)
+						verifier := ingress.NewDomainVerifier(method, ingressDomain, cdSecret, nil)
+						autoTLS.SetCustomDomains(cdStore)
+						ingressProxy.SetCustomDomains(cdStore)
+						customDomainAdmin = ingress.NewDomainVerifyHandler(
+							verifier, cdStore, cdSecret, ingressDomain,
+							cfg.Node.Provider.CustomDomain.MaxDomainsPerDeployment)
+						logging.Info("BYO custom-domain ACME enabled",
+							"verify_method", string(verifier.Method()),
+							logging.Component("ingress"))
+					}
+				}
+
 				ingressTLSCfg = autoTLS.TLSConfig()
 				logging.Info("ingress auto-TLS enabled (Let's Encrypt)",
 					"cert_dir", certDir,
@@ -608,6 +652,58 @@ func main() {
 						if cfg.Node.Provider.ReverseTunnelMaxConns > 0 {
 							revOpts = append(revOpts, tunnel.WithMaxConns(cfg.Node.Provider.ReverseTunnelMaxConns))
 						}
+
+						// EDGE-02: hand the same operator takedown kill-switch
+						// (created with the ingress proxy above) to the reverse
+						// tunnel server, so a block is enforced on the reverse
+						// registration/stream-open path in addition to the
+						// proxy-level forward-path enforcement.
+						if takedownBlocklist == nil {
+							takedownBlocklist = tunnel.NewBlocklist()
+						}
+						revOpts = append(revOpts, tunnel.WithBlocklist(takedownBlocklist))
+
+						// EDGE-02: edge-provider role gate. Pluggable: "config"
+						// uses a NodeID allowlist (works with no contract); "onchain"
+						// uses the BunkerEdgeRegistry via the payment service. The
+						// gate only fires for nodes that declare EdgeCapabilities,
+						// so container providers are unaffected.
+						if cfg.Node.Provider.EdgeRole.Enabled {
+							edgeCfg := edge.Config{
+								Mode:           edge.Mode(cfg.Node.Provider.EdgeRole.Mode),
+								AllowedNodeIDs: cfg.Node.Provider.EdgeRole.AllowedNodeIDs,
+								MinTier:        cfg.Node.Provider.EdgeRole.MinStakeTier,
+							}
+							var edgeReader edge.EdgeRegistryReader
+							if edgeCfg.Mode == edge.ModeOnChain && cfg.Node.Provider.EdgeRole.RegistryAddr != "" {
+								if bc := paymentSvc.BaseClient(); bc != nil {
+									if reader, rErr := payment.NewEdgeRegistryContract(bc, common.HexToAddress(cfg.Node.Provider.EdgeRole.RegistryAddr)); rErr != nil {
+										logging.Warn("edge registry contract unavailable; falling back to config allowlist",
+											logging.Err(rErr), logging.Component("edge"))
+									} else {
+										edgeReader = reader
+									}
+								}
+							}
+							edgeChecker := edge.NewEdgeTierChecker(edgeCfg, edgeReader)
+							edgeRegistry := edge.NewEdgeRegistry()
+							revOpts = append(revOpts,
+								tunnel.WithEdgeRegistry(edgeRegistry),
+								tunnel.WithEdgeTierChecker(func(nodeID, walletAddr string) (bool, error) {
+									checkCtx, checkCancel := context.WithTimeout(ctx, 5*time.Second)
+									defer checkCancel()
+									var nid types.NodeID
+									if b, decErr := hex.DecodeString(nodeID); decErr == nil && len(b) == len(nid) {
+										copy(nid[:], b)
+									}
+									return edgeChecker.IsEdgeAuthorized(checkCtx, nid, common.HexToAddress(walletAddr))
+								}),
+							)
+							logging.Info("edge-provider role gate enabled",
+								"mode", cfg.Node.Provider.EdgeRole.Mode,
+								logging.Component("edge"))
+						}
+
 						reverseServer := tunnel.NewReverseServer(revListener, revOpts...)
 						ingressProxy.SetReverseStreamOpener(reverseServer)
 						util.SafeGoWithName("reverse-tunnel-server", func() {
@@ -782,6 +878,21 @@ func main() {
 		httpAPIServer.SetAdminStore(api.NewAdminMetadataStore(filepath.Join(cfg.Daemon.DataDir, "admin_metadata.json")))
 		httpAPIServer.SetPolicyStore(api.NewPolicyStore(filepath.Join(cfg.Daemon.DataDir, "admin_policies.json")))
 		httpAPIServer.SetCatalogStore(api.NewCatalogStore(filepath.Join(cfg.Daemon.DataDir, "catalog.json")))
+
+		// EDGE-02: mount the operator surfaces behind admin auth. The
+		// custom-domain verify API persists ownership proofs; the takedown
+		// blocklist lets an operator block an abusive subdomain at ingress.
+		if customDomainAdmin != nil {
+			httpAPIServer.SetExtraAdminHandler("/v1/ingress/custom-domain/", customDomainAdmin)
+			logging.Info("custom-domain verification API mounted",
+				"path", "/v1/ingress/custom-domain/", logging.Component("ingress"))
+		}
+		if takedownBlocklist != nil {
+			httpAPIServer.SetExtraAdminHandler("/v1/ingress/blocklist",
+				tunnel.NewBlocklistAdminHandler(takedownBlocklist))
+			logging.Info("takedown blocklist API mounted",
+				"path", "/v1/ingress/blocklist", logging.Component("ingress"))
+		}
 
 		// ── P0 Services ──
 

--- a/contracts/src/BunkerEdgeRegistry.sol
+++ b/contracts/src/BunkerEdgeRegistry.sol
@@ -1,0 +1,553 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @notice Minimal read interface to BunkerStaking. Only `stakedAmount` is
+///         decoded from `getProviderInfo`; the remaining tuple fields are
+///         ignored so this contract never couples to the full ProviderInfo
+///         struct ABI. `slash` routes edge-provider penalties to the existing
+///         stake (no duplicate token custody).
+interface IBunkerStaking {
+    /// @dev Returns the full provider tuple; callers destructure only the
+    ///      leading `stakedAmount`. The trailing fields are intentionally
+    ///      decoded as their concrete types so the ABI selector matches.
+    function getProviderInfo(address provider)
+        external
+        view
+        returns (
+            uint128 stakedAmount,
+            uint128 totalUnbonding,
+            address beneficiary,
+            uint48 registeredAt,
+            bool active,
+            bytes32 nodeId,
+            bytes32 region,
+            uint64 capabilities,
+            bool frozen
+        );
+
+    /// @dev Slash a provider's stake. Requires SLASHER_ROLE on BunkerStaking,
+    ///      which must be granted to this contract during deployment setup.
+    function slash(address provider, uint256 amount) external;
+}
+
+/// @title BunkerEdgeRegistry
+/// @author Moltbunker
+/// @notice On-chain source of truth for edge-provider registration under
+///         Approach A (tiered edge nodes terminate TLS + run the L7 WAF).
+///         Edge providers must already hold a minimum BUNKER stake in the
+///         existing BunkerStaking contract, then register their static edge
+///         metadata here. They are slashing-eligible for SLA violations; the
+///         penalty is routed back to BunkerStaking.slash so it hits the same
+///         stake — no duplicate token custody.
+/// @dev Additive contract. Zero changes to BunkerStaking, BunkerRegistry, or any
+///      other deployed contract. Reuses the BunkerStaking conventions verbatim:
+///      OpenZeppelin v5 base set, SLASHER_ROLE, snapshotted appeal window
+///      (H-21/H-22 pattern), and the `slashingEnabled` monitor-mode gate.
+contract BunkerEdgeRegistry is Ownable2Step, AccessControl, ReentrancyGuard, Pausable {
+    // ──────────────────────────────────────────────
+    //  Constants
+    // ──────────────────────────────────────────────
+
+    /// @notice Contract version.
+    string public constant VERSION = "1.0.0";
+
+    /// @notice Role identifier for authorized slashers.
+    bytes32 public constant SLASHER_ROLE = keccak256("SLASHER_ROLE");
+
+    /// @notice Lower bound for minStakeForEdge (BunkerStaking Starter minimum, 1 M BUNKER).
+    uint256 public constant MIN_EDGE_STAKE_FLOOR = 1_000_000e18;
+
+    /// @notice Upper bound for minStakeForEdge (BunkerStaking Platinum minimum, 1 B BUNKER).
+    uint256 public constant MIN_EDGE_STAKE_CEILING = 1_000_000_000e18;
+
+    /// @notice Lower bound for the appeal window (12 hours).
+    uint256 public constant APPEAL_WINDOW_FLOOR = 12 hours;
+
+    /// @notice Upper bound for the appeal window (14 days).
+    uint256 public constant APPEAL_WINDOW_CEILING = 14 days;
+
+    // ──────────────────────────────────────────────
+    //  Configurable Parameters
+    // ──────────────────────────────────────────────
+
+    /// @notice Minimum BUNKER stake (in BunkerStaking) required to register as an
+    ///         edge provider. Default 50 M BUNKER — between Silver (10 M) and Gold
+    ///         (100 M) to create a meaningful edge-only capital hurdle.
+    uint256 public minStakeForEdge = 50_000_000e18;
+
+    /// @notice Appeal window for edge-slash proposals (default 48 hours).
+    uint256 public appealWindow = 48 hours;
+
+    /// @notice Whether slashing execution is enabled. When false, proposals can
+    ///         still be created (monitor mode) but execution reverts.
+    bool public slashingEnabled;
+
+    // ──────────────────────────────────────────────
+    //  Types
+    // ──────────────────────────────────────────────
+
+    /// @notice Static, on-chain edge-provider metadata. The fixed-size leading
+    ///         fields pack into two slots (32 + 32 + 6 + 1 + 1 bytes).
+    struct EdgeProviderInfo {
+        bytes32 nodeId; // SHA256 of the provider's Ed25519 public key
+        bytes32 region; // Geographic region identifier
+        uint48 registeredAt; // Block timestamp at registration
+        bool active; // Whether the provider is currently registered
+        bool frozen; // Whether the provider is frozen (emergency response)
+        string endpointURL; // Public TLS-terminating edge endpoint
+        bytes tlsPubkeyHash; // Hash of the edge node's TLS public key
+    }
+
+    /// @notice An edge-slash proposal subject to an appeal window.
+    struct EdgeSlashProposal {
+        address provider;
+        uint128 amount;
+        uint48 proposedAt;
+        bool executed;
+        bool appealed;
+        bool resolved;
+        uint256 appealWindowSnapshot; // Snapshot of appealWindow at proposal time
+        string reason;
+    }
+
+    // ──────────────────────────────────────────────
+    //  State
+    // ──────────────────────────────────────────────
+
+    /// @notice Read-only reference to the BunkerStaking contract (stake source of truth).
+    IBunkerStaking public immutable stakingContract;
+
+    /// @notice Edge-provider state by address.
+    mapping(address => EdgeProviderInfo) public edgeProviders;
+
+    /// @notice Reverse lookup from edge node ID to edge-provider address.
+    mapping(bytes32 => address) public nodeIdToEdgeProvider;
+
+    /// @notice Total number of edge-slash proposals created.
+    uint256 public slashProposalCount;
+
+    /// @notice Edge-slash proposals by ID.
+    mapping(uint256 => EdgeSlashProposal) public slashProposals;
+
+    // ──────────────────────────────────────────────
+    //  Errors
+    // ──────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InsufficientStake(uint256 actual, uint256 required);
+    error InsufficientSlashableBalance(uint256 amount, uint256 slashable);
+    error AlreadyRegistered(address provider);
+    error NotActive(address provider);
+    error NodeIdAlreadyClaimed(bytes32 nodeId);
+    error ProviderIsFrozen(address provider);
+    error SlashingNotEnabled();
+    error InvalidProposalId(uint256 proposalId);
+    error ProposalAlreadyExecuted(uint256 proposalId);
+    error AppealWindowNotElapsed(uint256 proposalId);
+    error AppealWindowElapsed(uint256 proposalId);
+    error ProposalAppealed(uint256 proposalId);
+    error ProposalNotAppealed(uint256 proposalId);
+    error ProposalAlreadyResolved(uint256 proposalId);
+    error NotProposalProvider(uint256 proposalId, address caller);
+    error InvalidMinStake(uint256 minStake);
+    error InvalidAppealWindow();
+
+    // ──────────────────────────────────────────────
+    //  Events
+    // ──────────────────────────────────────────────
+
+    /// @notice Emitted when an edge provider registers.
+    event EdgeProviderRegistered(address indexed provider, bytes32 nodeId, bytes32 region);
+
+    /// @notice Emitted when an edge provider deregisters.
+    event EdgeProviderDeregistered(address indexed provider);
+
+    /// @notice Emitted when an edge provider is frozen by the slasher.
+    event EdgeProviderFrozen(address indexed provider, address indexed by);
+
+    /// @notice Emitted when an edge provider is unfrozen by the owner.
+    event EdgeProviderUnfrozen(address indexed provider);
+
+    /// @notice Emitted when an edge provider updates its endpoint metadata.
+    event EdgeEndpointUpdated(address indexed provider, string endpointURL);
+
+    /// @notice Emitted when an edge-slash proposal is created.
+    event EdgeSlashProposed(
+        uint256 indexed proposalId, address indexed provider, uint256 amount, string reason
+    );
+
+    /// @notice Emitted when an edge-slash proposal is executed.
+    event EdgeSlashExecuted(uint256 indexed proposalId, address indexed provider, uint256 amount);
+
+    /// @notice Emitted when an edge provider appeals a slash proposal.
+    event EdgeSlashAppealed(uint256 indexed proposalId, address indexed provider);
+
+    /// @notice Emitted when an edge-slash appeal is resolved.
+    event EdgeAppealResolved(uint256 indexed proposalId, bool upheld);
+
+    /// @notice Emitted when the minimum edge stake threshold is updated.
+    event MinStakeUpdated(uint256 oldMinStake, uint256 newMinStake);
+
+    /// @notice Emitted when the appeal window is updated.
+    event AppealWindowUpdated(uint256 newWindow);
+
+    /// @notice Emitted when slashing is enabled or disabled.
+    event SlashingEnabledUpdated(bool enabled);
+
+    // ──────────────────────────────────────────────
+    //  Constructor
+    // ──────────────────────────────────────────────
+
+    /// @param _stakingContract Address of the deployed BunkerStaking contract.
+    /// @param _initialOwner Admin wallet address.
+    constructor(address _stakingContract, address _initialOwner) Ownable(_initialOwner) {
+        if (_stakingContract == address(0) || _initialOwner == address(0)) revert ZeroAddress();
+
+        stakingContract = IBunkerStaking(_stakingContract);
+
+        // Grant DEFAULT_ADMIN_ROLE to owner for managing SLASHER_ROLE.
+        _grantRole(DEFAULT_ADMIN_ROLE, _initialOwner);
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Edge-Provider Registration
+    // ──────────────────────────────────────────────
+
+    /// @notice Register as an edge provider. Requires an active BunkerStaking
+    ///         stake at least equal to `minStakeForEdge`.
+    /// @param nodeId SHA256 of the edge node's Ed25519 public key (must be unique).
+    /// @param region Geographic region identifier.
+    /// @param endpointURL Public TLS-terminating edge endpoint.
+    /// @param tlsPubkeyHash Hash of the edge node's TLS public key.
+    function registerEdgeProvider(
+        bytes32 nodeId,
+        bytes32 region,
+        string calldata endpointURL,
+        bytes calldata tlsPubkeyHash
+    ) external nonReentrant whenNotPaused {
+        EdgeProviderInfo storage info = edgeProviders[msg.sender];
+        if (info.active) revert AlreadyRegistered(msg.sender);
+        if (info.frozen) revert ProviderIsFrozen(msg.sender);
+        if (nodeId != bytes32(0) && nodeIdToEdgeProvider[nodeId] != address(0)) {
+            revert NodeIdAlreadyClaimed(nodeId);
+        }
+
+        _requireMinStake(msg.sender);
+
+        info.nodeId = nodeId;
+        info.region = region;
+        info.endpointURL = endpointURL;
+        info.tlsPubkeyHash = tlsPubkeyHash;
+        info.registeredAt = uint48(block.timestamp);
+        info.active = true;
+
+        if (nodeId != bytes32(0)) {
+            nodeIdToEdgeProvider[nodeId] = msg.sender;
+        }
+
+        emit EdgeProviderRegistered(msg.sender, nodeId, region);
+    }
+
+    /// @notice Self-deregister as an edge provider. Sets active=false, clears the
+    ///         nodeId mapping so the node ID can be re-claimed, and wipes the
+    ///         endpoint metadata so getEdgeProviderInfo never returns stale
+    ///         routing data for a deregistered provider. `frozen` is intentionally
+    ///         preserved so a frozen provider cannot escape the freeze by
+    ///         deregistering and re-registering.
+    function deregisterEdgeProvider() external nonReentrant {
+        EdgeProviderInfo storage info = edgeProviders[msg.sender];
+        if (!info.active) revert NotActive(msg.sender);
+
+        info.active = false;
+        if (info.nodeId != bytes32(0)) {
+            delete nodeIdToEdgeProvider[info.nodeId];
+            info.nodeId = bytes32(0);
+        }
+        info.region = bytes32(0);
+        delete info.endpointURL;
+        delete info.tlsPubkeyHash;
+
+        emit EdgeProviderDeregistered(msg.sender);
+    }
+
+    /// @notice Update the endpoint metadata for an active edge provider.
+    /// @param endpointURL New public edge endpoint.
+    /// @param tlsPubkeyHash New TLS public key hash.
+    function updateEndpoint(string calldata endpointURL, bytes calldata tlsPubkeyHash) external {
+        EdgeProviderInfo storage info = edgeProviders[msg.sender];
+        if (!info.active) revert NotActive(msg.sender);
+        if (info.frozen) revert ProviderIsFrozen(msg.sender);
+
+        info.endpointURL = endpointURL;
+        info.tlsPubkeyHash = tlsPubkeyHash;
+
+        emit EdgeEndpointUpdated(msg.sender, endpointURL);
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Graduated Emergency Response
+    // ──────────────────────────────────────────────
+
+    /// @notice Freeze an edge provider. A frozen provider cannot update its
+    ///         endpoint and is reported as inactive to consumers.
+    /// @param provider The edge provider to freeze.
+    function freezeEdgeProvider(address provider) external onlyRole(SLASHER_ROLE) {
+        EdgeProviderInfo storage info = edgeProviders[provider];
+        if (!info.active) revert NotActive(provider);
+
+        info.frozen = true;
+
+        emit EdgeProviderFrozen(provider, msg.sender);
+    }
+
+    /// @notice Unfreeze a previously frozen edge provider.
+    /// @param provider The edge provider to unfreeze.
+    function unfreezeEdgeProvider(address provider) external onlyOwner {
+        EdgeProviderInfo storage info = edgeProviders[provider];
+        info.frozen = false;
+
+        emit EdgeProviderUnfrozen(provider);
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Edge-Slash Proposal & Appeal System
+    // ──────────────────────────────────────────────
+
+    /// @notice Propose slashing an edge provider's stake. Subject to the appeal
+    ///         window snapshotted at proposal time.
+    /// @dev Least-privilege: the registry holds SLASHER_ROLE on BunkerStaking, so
+    ///      it must only ever propose slashes against providers it actually
+    ///      governs — i.e. registered, active edge providers. The active check
+    ///      prevents this contract from being used to slash arbitrary BunkerStaking
+    ///      stakers who never opted into the edge role. As a defensive pre-check
+    ///      (mirroring BunkerStaking.proposeSlash, H-05) the amount is also
+    ///      validated against the provider's current slashable balance
+    ///      (stakedAmount + totalUnbonding) at propose time; this is informational
+    ///      only — executeEdgeSlash relies on BunkerStaking's own re-validation at
+    ///      execution time for the binding check.
+    /// @param provider The edge provider to propose slashing.
+    /// @param amount Amount to slash (wei).
+    /// @param reason Human-readable reason for the slash.
+    /// @return proposalId The ID of the created proposal.
+    function proposeEdgeSlash(address provider, uint128 amount, string calldata reason)
+        external
+        onlyRole(SLASHER_ROLE)
+        returns (uint256 proposalId)
+    {
+        if (provider == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        if (!edgeProviders[provider].active) revert NotActive(provider);
+
+        // Defensive pre-check: reject proposals that exceed the provider's
+        // current slashable balance in BunkerStaking. Decodes stakedAmount +
+        // totalUnbonding from the existing getProviderInfo tuple (no new
+        // BunkerStaking surface coupled).
+        (uint128 stakedAmount, uint128 totalUnbonding,,,,,,,) =
+            stakingContract.getProviderInfo(provider);
+        uint256 slashable = uint256(stakedAmount) + uint256(totalUnbonding);
+        if (uint256(amount) > slashable) {
+            revert InsufficientSlashableBalance(uint256(amount), slashable);
+        }
+
+        proposalId = slashProposalCount++;
+        slashProposals[proposalId] = EdgeSlashProposal({
+            provider: provider,
+            amount: amount,
+            proposedAt: uint48(block.timestamp),
+            executed: false,
+            appealed: false,
+            resolved: false,
+            appealWindowSnapshot: appealWindow,
+            reason: reason
+        });
+
+        emit EdgeSlashProposed(proposalId, provider, amount, reason);
+    }
+
+    /// @notice Execute an edge-slash proposal after the appeal window has elapsed.
+    /// @dev Routes the slash to BunkerStaking.slash, which requires this contract
+    ///      to hold SLASHER_ROLE on BunkerStaking (granted at deployment setup).
+    /// @param proposalId The proposal to execute.
+    function executeEdgeSlash(uint256 proposalId) external onlyRole(SLASHER_ROLE) nonReentrant {
+        if (!slashingEnabled) revert SlashingNotEnabled();
+        EdgeSlashProposal storage proposal = _getValidProposal(proposalId);
+        if (proposal.executed) revert ProposalAlreadyExecuted(proposalId);
+        if (proposal.appealed) revert ProposalAppealed(proposalId);
+
+        uint256 windowEnd = uint256(proposal.proposedAt) + proposal.appealWindowSnapshot;
+        if (block.timestamp < windowEnd) revert AppealWindowNotElapsed(proposalId);
+
+        proposal.executed = true;
+
+        stakingContract.slash(proposal.provider, proposal.amount);
+
+        emit EdgeSlashExecuted(proposalId, proposal.provider, proposal.amount);
+    }
+
+    /// @notice Appeal an edge-slash proposal during the appeal window.
+    /// @dev Only the targeted provider can appeal.
+    /// @param proposalId The proposal to appeal.
+    function appealEdgeSlash(uint256 proposalId) external {
+        EdgeSlashProposal storage proposal = _getValidProposal(proposalId);
+        if (proposal.executed) revert ProposalAlreadyExecuted(proposalId);
+        if (proposal.appealed) revert ProposalAppealed(proposalId);
+        if (msg.sender != proposal.provider) {
+            revert NotProposalProvider(proposalId, msg.sender);
+        }
+
+        uint256 windowEnd = uint256(proposal.proposedAt) + proposal.appealWindowSnapshot;
+        if (block.timestamp >= windowEnd) revert AppealWindowElapsed(proposalId);
+
+        proposal.appealed = true;
+
+        emit EdgeSlashAppealed(proposalId, proposal.provider);
+    }
+
+    /// @notice Resolve an appealed edge-slash proposal.
+    /// @dev Only the owner can resolve. If upheld, the slash is executed.
+    /// @param proposalId The proposal to resolve.
+    /// @param uphold True to uphold the slash (execute it), false to dismiss.
+    function resolveEdgeSlashAppeal(uint256 proposalId, bool uphold)
+        external
+        onlyOwner
+        nonReentrant
+    {
+        EdgeSlashProposal storage proposal = _getValidProposal(proposalId);
+        if (!proposal.appealed) revert ProposalNotAppealed(proposalId);
+        if (proposal.resolved) revert ProposalAlreadyResolved(proposalId);
+        if (proposal.executed) revert ProposalAlreadyExecuted(proposalId);
+
+        proposal.resolved = true;
+
+        if (uphold) {
+            if (!slashingEnabled) revert SlashingNotEnabled();
+            proposal.executed = true;
+
+            stakingContract.slash(proposal.provider, proposal.amount);
+
+            emit EdgeSlashExecuted(proposalId, proposal.provider, proposal.amount);
+        }
+
+        emit EdgeAppealResolved(proposalId, uphold);
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Admin
+    // ──────────────────────────────────────────────
+
+    /// @notice Update the minimum BUNKER stake required to register as an edge
+    ///         provider. Bounded by the BunkerStaking Starter and Platinum minima.
+    /// @param newMinStake New minimum stake (wei).
+    function setMinStakeForEdge(uint256 newMinStake) external onlyOwner {
+        if (newMinStake < MIN_EDGE_STAKE_FLOOR || newMinStake > MIN_EDGE_STAKE_CEILING) {
+            revert InvalidMinStake(newMinStake);
+        }
+        uint256 old = minStakeForEdge;
+        minStakeForEdge = newMinStake;
+
+        emit MinStakeUpdated(old, newMinStake);
+    }
+
+    /// @notice Adjust the appeal window for edge-slash proposals.
+    /// @param newWindow New window in seconds (12 hours min, 14 days max).
+    function setAppealWindow(uint256 newWindow) external onlyOwner {
+        if (newWindow < APPEAL_WINDOW_FLOOR || newWindow > APPEAL_WINDOW_CEILING) {
+            revert InvalidAppealWindow();
+        }
+        appealWindow = newWindow;
+
+        emit AppealWindowUpdated(newWindow);
+    }
+
+    /// @notice Enable or disable slashing execution. When disabled, proposals can
+    ///         still be created for monitoring but execution reverts.
+    /// @param enabled True to enable slashing, false for monitor mode.
+    function setSlashingEnabled(bool enabled) external onlyOwner {
+        slashingEnabled = enabled;
+
+        emit SlashingEnabledUpdated(enabled);
+    }
+
+    /// @notice Pause edge-provider registration and updates (emergency).
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Unpause edge-provider registration and updates.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    // ──────────────────────────────────────────────
+    //  External: Views
+    // ──────────────────────────────────────────────
+
+    /// @notice Returns true if the provider is registered, active, and not frozen.
+    /// @param provider The edge-provider address to check.
+    /// @return active True when the address can serve edge traffic.
+    function isActiveEdgeProvider(address provider) external view returns (bool active) {
+        EdgeProviderInfo storage info = edgeProviders[provider];
+        return info.active && !info.frozen;
+    }
+
+    /// @notice Returns the full edge-provider metadata struct.
+    /// @param provider The edge-provider address to look up.
+    /// @return info The provider's registration metadata.
+    function getEdgeProviderInfo(address provider)
+        external
+        view
+        returns (EdgeProviderInfo memory info)
+    {
+        return edgeProviders[provider];
+    }
+
+    /// @notice Returns an edge-slash proposal by ID.
+    /// @param proposalId The proposal ID.
+    /// @return proposal The edge-slash proposal.
+    function getEdgeSlashProposal(uint256 proposalId)
+        external
+        view
+        returns (EdgeSlashProposal memory proposal)
+    {
+        return slashProposals[proposalId];
+    }
+
+    // ──────────────────────────────────────────────
+    //  Internal
+    // ──────────────────────────────────────────────
+
+    /// @dev Sync DEFAULT_ADMIN_ROLE when ownership is transferred (mirrors M-05
+    ///      in BunkerStaking).
+    function _transferOwnership(address newOwner) internal virtual override {
+        address oldOwner = owner();
+        super._transferOwnership(newOwner);
+        _revokeRole(DEFAULT_ADMIN_ROLE, oldOwner);
+        _grantRole(DEFAULT_ADMIN_ROLE, newOwner);
+    }
+
+    /// @dev Reverts unless the address holds at least `minStakeForEdge` staked in
+    ///      BunkerStaking. Reads storage (not pause-guarded), so the check still
+    ///      works while BunkerStaking is paused.
+    function _requireMinStake(address provider) internal view {
+        (uint128 stakedAmount,,,,,,,,) = stakingContract.getProviderInfo(provider);
+        if (uint256(stakedAmount) < minStakeForEdge) {
+            revert InsufficientStake(uint256(stakedAmount), minStakeForEdge);
+        }
+    }
+
+    /// @dev Validate a proposal ID and return the storage reference.
+    function _getValidProposal(uint256 proposalId)
+        internal
+        view
+        returns (EdgeSlashProposal storage)
+    {
+        if (proposalId >= slashProposalCount) revert InvalidProposalId(proposalId);
+        return slashProposals[proposalId];
+    }
+}

--- a/contracts/src/interfaces/IEdgeRegistry.sol
+++ b/contracts/src/interfaces/IEdgeRegistry.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title IEdgeRegistry
+/// @author Moltbunker
+/// @notice Minimal read-only interface for the BunkerEdgeRegistry, consumed by
+///         EDGE-02 (the daemon reverse-tunnel stake gate) and by the daemon Go
+///         bindings. The daemon's `EdgeRegistryReader` wraps these two functions
+///         so it never has to import the full contract ABI.
+interface IEdgeRegistry {
+    /// @notice Static, on-chain edge-provider metadata.
+    /// @dev Mirrored from BunkerEdgeRegistry so consumers can depend on the
+    ///      interface alone. The fixed-size leading fields pack into two slots.
+    struct EdgeProviderInfo {
+        bytes32 nodeId; // SHA256 of the provider's Ed25519 public key
+        bytes32 region; // Geographic region identifier
+        uint48 registeredAt; // Block timestamp at registration
+        bool active; // Whether the provider is currently registered
+        bool frozen; // Whether the provider is frozen (emergency response)
+        string endpointURL; // Public TLS-terminating edge endpoint
+        bytes tlsPubkeyHash; // Hash of the edge node's TLS public key
+    }
+
+    /// @notice Returns true if the provider is registered, active, and not frozen.
+    /// @param provider The edge-provider address to check.
+    /// @return active True when the address can serve edge traffic.
+    function isActiveEdgeProvider(address provider) external view returns (bool active);
+
+    /// @notice Returns the full edge-provider metadata struct.
+    /// @param provider The edge-provider address to look up.
+    /// @return info The provider's registration metadata.
+    function getEdgeProviderInfo(address provider)
+        external
+        view
+        returns (EdgeProviderInfo memory info);
+}

--- a/contracts/test/BunkerEdgeRegistry.t.sol
+++ b/contracts/test/BunkerEdgeRegistry.t.sol
@@ -1,0 +1,1055 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/BunkerToken.sol";
+import "../src/BunkerStaking.sol";
+import "../src/BunkerEdgeRegistry.sol";
+
+contract BunkerEdgeRegistryTest is Test {
+    BunkerToken public token;
+    BunkerStaking public staking;
+    BunkerEdgeRegistry public registry;
+
+    address public owner = makeAddr("owner");
+    address public treasury = makeAddr("treasury");
+    address public slasher = makeAddr("slasher");
+    address public edge1 = makeAddr("edge1");
+    address public edge2 = makeAddr("edge2");
+    address public lowStaker = makeAddr("lowStaker");
+    address public stranger = makeAddr("stranger");
+
+    // BunkerStaking tier minimums (mirrored from BunkerStaking constructor).
+    uint256 constant STARTER_MIN = 1_000_000e18;
+    uint256 constant SILVER_MIN = 10_000_000e18;
+    uint256 constant GOLD_MIN = 100_000_000e18;
+    uint256 constant PLATINUM_MIN = 1_000_000_000e18;
+
+    // BunkerEdgeRegistry defaults.
+    uint256 constant DEFAULT_MIN_EDGE_STAKE = 50_000_000e18;
+    uint256 constant DEFAULT_APPEAL_WINDOW = 48 hours;
+
+    bytes32 constant NODE_ID_1 = keccak256("edge1-node");
+    bytes32 constant NODE_ID_2 = keccak256("edge2-node");
+    bytes32 constant REGION_US = bytes32("us-east");
+    bytes32 constant REGION_EU = bytes32("eu-west");
+
+    string constant ENDPOINT_1 = "https://edge1.moltbunker.dev";
+    bytes constant TLS_HASH_1 = hex"0011223344556677";
+
+    function setUp() public {
+        vm.startPrank(owner);
+        token = new BunkerToken(owner);
+        staking = new BunkerStaking(address(token), treasury, owner);
+
+        // Grant slasher role on staking and enable slashing so routed slashes work.
+        staking.grantRole(staking.SLASHER_ROLE(), slasher);
+        staking.setSlashingEnabled(true);
+
+        // Mint enough for the edge providers to clear the 50 M threshold.
+        token.mint(edge1, 200_000_000e18);
+        token.mint(edge2, 200_000_000e18);
+        token.mint(lowStaker, 200_000_000e18);
+        vm.stopPrank();
+
+        // edge1 stakes 50 M (exactly at the edge threshold).
+        vm.startPrank(edge1);
+        token.approve(address(staking), type(uint256).max);
+        staking.stake(DEFAULT_MIN_EDGE_STAKE);
+        vm.stopPrank();
+
+        // edge2 stakes 100 M (comfortably above the threshold).
+        vm.startPrank(edge2);
+        token.approve(address(staking), type(uint256).max);
+        staking.stake(100_000_000e18);
+        vm.stopPrank();
+
+        // lowStaker stakes only 10 M (below the 50 M edge threshold).
+        vm.startPrank(lowStaker);
+        token.approve(address(staking), type(uint256).max);
+        staking.stake(SILVER_MIN);
+        vm.stopPrank();
+
+        // Deploy the edge registry and wire up the slasher role.
+        vm.startPrank(owner);
+        registry = new BunkerEdgeRegistry(address(staking), owner);
+        registry.grantRole(registry.SLASHER_ROLE(), slasher);
+
+        // Grant the registry SLASHER_ROLE on BunkerStaking so routed slashes work.
+        staking.grantRole(staking.SLASHER_ROLE(), address(registry));
+        vm.stopPrank();
+    }
+
+    // ================================================================
+    //  1. CONSTRUCTOR
+    // ================================================================
+
+    function test_constructor_setsStakingContract() public view {
+        assertEq(address(registry.stakingContract()), address(staking));
+    }
+
+    function test_constructor_setsOwner() public view {
+        assertEq(registry.owner(), owner);
+    }
+
+    function test_constructor_grantsDefaultAdminRole() public view {
+        assertTrue(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), owner));
+    }
+
+    function test_constructor_defaultMinStake() public view {
+        assertEq(registry.minStakeForEdge(), DEFAULT_MIN_EDGE_STAKE);
+    }
+
+    function test_constructor_defaultAppealWindow() public view {
+        assertEq(registry.appealWindow(), DEFAULT_APPEAL_WINDOW);
+    }
+
+    function test_constructor_slashingDisabledByDefault() public view {
+        assertFalse(registry.slashingEnabled());
+    }
+
+    function test_constructor_version() public view {
+        assertEq(registry.VERSION(), "1.0.0");
+    }
+
+    function test_constructor_revertsZeroStaking() public {
+        vm.prank(owner);
+        vm.expectRevert(BunkerEdgeRegistry.ZeroAddress.selector);
+        new BunkerEdgeRegistry(address(0), owner);
+    }
+
+    function test_constructor_revertsZeroOwner() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(bytes4(keccak256("OwnableInvalidOwner(address)")), address(0))
+        );
+        new BunkerEdgeRegistry(address(staking), address(0));
+    }
+
+    function test_constants() public view {
+        assertEq(registry.SLASHER_ROLE(), keccak256("SLASHER_ROLE"));
+        assertEq(registry.MIN_EDGE_STAKE_FLOOR(), STARTER_MIN);
+        assertEq(registry.MIN_EDGE_STAKE_CEILING(), PLATINUM_MIN);
+        assertEq(registry.APPEAL_WINDOW_FLOOR(), 12 hours);
+        assertEq(registry.APPEAL_WINDOW_CEILING(), 14 days);
+    }
+
+    // ================================================================
+    //  2. registerEdgeProvider
+    // ================================================================
+
+    function test_register_happyPath() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(edge1);
+        assertEq(info.nodeId, NODE_ID_1);
+        assertEq(info.region, REGION_US);
+        assertEq(info.endpointURL, ENDPOINT_1);
+        assertEq(info.tlsPubkeyHash, TLS_HASH_1);
+        assertTrue(info.active);
+        assertFalse(info.frozen);
+        assertGt(info.registeredAt, 0);
+    }
+
+    function test_register_emitsEvent() public {
+        vm.prank(edge1);
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeProviderRegistered(edge1, NODE_ID_1, REGION_US);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_register_setsNodeIdMapping() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        assertEq(registry.nodeIdToEdgeProvider(NODE_ID_1), edge1);
+    }
+
+    function test_register_secondTimeReverts() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.AlreadyRegistered.selector, edge1)
+        );
+        registry.registerEdgeProvider(NODE_ID_2, REGION_EU, ENDPOINT_1, TLS_HASH_1);
+        vm.stopPrank();
+    }
+
+    function test_register_duplicateNodeIdReverts() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(edge2);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.NodeIdAlreadyClaimed.selector, NODE_ID_1)
+        );
+        registry.registerEdgeProvider(NODE_ID_1, REGION_EU, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_register_insufficientStakeReverts() public {
+        vm.prank(lowStaker);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BunkerEdgeRegistry.InsufficientStake.selector, SILVER_MIN, DEFAULT_MIN_EDGE_STAKE
+            )
+        );
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_register_noStakeReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BunkerEdgeRegistry.InsufficientStake.selector, 0, DEFAULT_MIN_EDGE_STAKE
+            )
+        );
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_register_exactThresholdSucceeds() public {
+        // edge1 stakes exactly 50 M — must be allowed.
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_register_worksWhileStakingPaused() public {
+        // getProviderInfo reads storage and is not pause-guarded, so the stake
+        // check must still pass while BunkerStaking is paused (risk #1).
+        vm.prank(owner);
+        staking.pause();
+
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_register_zeroNodeIdSkipsMapping() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(bytes32(0), REGION_US, ENDPOINT_1, TLS_HASH_1);
+        // A zero node ID does not claim the mapping (so it stays re-usable).
+        assertEq(registry.nodeIdToEdgeProvider(bytes32(0)), address(0));
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_register_revertsWhenPaused() public {
+        vm.prank(owner);
+        registry.pause();
+
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("EnforcedPause()"))));
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    // ================================================================
+    //  3. deregisterEdgeProvider
+    // ================================================================
+
+    function test_deregister_happyPath() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(edge1);
+        assertFalse(info.active);
+        assertEq(info.nodeId, bytes32(0));
+        assertEq(registry.nodeIdToEdgeProvider(NODE_ID_1), address(0));
+    }
+
+    function test_deregister_clearsMetadata() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+
+        // No stale routing metadata must remain after deregistration.
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(edge1);
+        assertFalse(info.active);
+        assertEq(info.nodeId, bytes32(0));
+        assertEq(info.region, bytes32(0));
+        assertEq(info.endpointURL, "");
+        assertEq(info.tlsPubkeyHash, hex"");
+    }
+
+    function test_deregister_emitsEvent() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.expectEmit(true, false, false, false, address(registry));
+        emit BunkerEdgeRegistry.EdgeProviderDeregistered(edge1);
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+    }
+
+    function test_deregister_notActiveReverts() public {
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.deregisterEdgeProvider();
+    }
+
+    function test_deregister_twiceReverts() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.deregisterEdgeProvider();
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+    }
+
+    function test_deregister_allowsNodeIdReclaim() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.deregisterEdgeProvider();
+        vm.stopPrank();
+
+        // edge2 can now claim the released node ID.
+        vm.prank(edge2);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_EU, ENDPOINT_1, TLS_HASH_1);
+        assertEq(registry.nodeIdToEdgeProvider(NODE_ID_1), edge2);
+    }
+
+    // ================================================================
+    //  4. updateEndpoint
+    // ================================================================
+
+    function test_updateEndpoint_happyPath() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        registry.updateEndpoint("https://new.edge.dev", hex"aabbcc");
+        vm.stopPrank();
+
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(edge1);
+        assertEq(info.endpointURL, "https://new.edge.dev");
+        assertEq(info.tlsPubkeyHash, hex"aabbcc");
+    }
+
+    function test_updateEndpoint_emitsEvent() public {
+        vm.startPrank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeEndpointUpdated(edge1, "https://new.edge.dev");
+        registry.updateEndpoint("https://new.edge.dev", hex"aabbcc");
+        vm.stopPrank();
+    }
+
+    function test_updateEndpoint_notActiveReverts() public {
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.updateEndpoint("https://x.dev", hex"00");
+    }
+
+    function test_updateEndpoint_frozenReverts() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProviderIsFrozen.selector, edge1));
+        registry.updateEndpoint("https://x.dev", hex"00");
+    }
+
+    // ================================================================
+    //  5. freeze / unfreeze
+    // ================================================================
+
+    function test_freeze_bySlasher() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        assertTrue(registry.getEdgeProviderInfo(edge1).frozen);
+        assertFalse(registry.isActiveEdgeProvider(edge1)); // frozen => not active to consumers
+    }
+
+    function test_freeze_emitsEvent() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(slasher);
+        vm.expectEmit(true, true, false, false, address(registry));
+        emit BunkerEdgeRegistry.EdgeProviderFrozen(edge1, slasher);
+        registry.freezeEdgeProvider(edge1);
+    }
+
+    function test_freeze_nonSlasherReverts() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        bytes32 slasherRole = registry.SLASHER_ROLE();
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("AccessControlUnauthorizedAccount(address,bytes32)")),
+                stranger,
+                slasherRole
+            )
+        );
+        registry.freezeEdgeProvider(edge1);
+    }
+
+    function test_freeze_notActiveReverts() public {
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.freezeEdgeProvider(edge1);
+    }
+
+    function test_unfreeze_byOwner() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        vm.prank(owner);
+        registry.unfreezeEdgeProvider(edge1);
+
+        assertFalse(registry.getEdgeProviderInfo(edge1).frozen);
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_unfreeze_emitsEvent() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        vm.prank(owner);
+        vm.expectEmit(true, false, false, false, address(registry));
+        emit BunkerEdgeRegistry.EdgeProviderUnfrozen(edge1);
+        registry.unfreezeEdgeProvider(edge1);
+    }
+
+    function test_unfreeze_nonOwnerReverts() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.unfreezeEdgeProvider(edge1);
+    }
+
+    function test_frozenProviderCannotReregister() public {
+        vm.prank(edge1);
+        registry.registerEdgeProvider(NODE_ID_1, REGION_US, ENDPOINT_1, TLS_HASH_1);
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+
+        // deregister first so 'active' is false, then re-register is blocked by frozen.
+        vm.startPrank(edge1);
+        registry.deregisterEdgeProvider();
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProviderIsFrozen.selector, edge1));
+        registry.registerEdgeProvider(NODE_ID_2, REGION_EU, ENDPOINT_1, TLS_HASH_1);
+        vm.stopPrank();
+    }
+
+    // ================================================================
+    //  6. proposeEdgeSlash
+    // ================================================================
+
+    function _register(address who, bytes32 nodeId, bytes32 region) internal {
+        vm.prank(who);
+        registry.registerEdgeProvider(nodeId, region, ENDPOINT_1, TLS_HASH_1);
+    }
+
+    function test_propose_happyPath() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        assertEq(id, 0);
+        assertEq(registry.slashProposalCount(), 1);
+
+        BunkerEdgeRegistry.EdgeSlashProposal memory p = registry.getEdgeSlashProposal(id);
+        assertEq(p.provider, edge1);
+        assertEq(p.amount, 1_000_000e18);
+        assertEq(p.reason, "downtime");
+        assertEq(p.appealWindowSnapshot, DEFAULT_APPEAL_WINDOW);
+        assertFalse(p.executed);
+        assertFalse(p.appealed);
+    }
+
+    function test_propose_emitsEvent() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(slasher);
+        vm.expectEmit(true, true, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeSlashProposed(0, edge1, 1_000_000e18, "downtime");
+        registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+    }
+
+    function test_propose_snapshotsAppealWindow() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        // Change the appeal window AFTER the proposal — snapshot must hold the old value.
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(owner);
+        registry.setAppealWindow(14 days);
+
+        assertEq(registry.getEdgeSlashProposal(id).appealWindowSnapshot, DEFAULT_APPEAL_WINDOW);
+    }
+
+    function test_propose_nonSlasherReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        bytes32 slasherRole = registry.SLASHER_ROLE();
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("AccessControlUnauthorizedAccount(address,bytes32)")),
+                stranger,
+                slasherRole
+            )
+        );
+        registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+    }
+
+    function test_propose_zeroAmountReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(slasher);
+        vm.expectRevert(BunkerEdgeRegistry.ZeroAmount.selector);
+        registry.proposeEdgeSlash(edge1, 0, "downtime");
+    }
+
+    function test_propose_zeroProviderReverts() public {
+        vm.prank(slasher);
+        vm.expectRevert(BunkerEdgeRegistry.ZeroAddress.selector);
+        registry.proposeEdgeSlash(address(0), 1_000_000e18, "downtime");
+    }
+
+    function test_propose_nonRegisteredProviderReverts() public {
+        // edge2 has plenty of BunkerStaking stake but never registered as an edge
+        // provider. The registry holds SLASHER_ROLE on BunkerStaking, so it must
+        // not be usable to propose slashes against stakers it does not govern.
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge2));
+        registry.proposeEdgeSlash(edge2, 1_000_000e18, "downtime");
+    }
+
+    function test_propose_deregisteredProviderReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(edge1);
+        registry.deregisterEdgeProvider();
+
+        // Once deregistered the provider is no longer active, so proposing a slash
+        // against it must revert even though its BunkerStaking stake persists.
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.NotActive.selector, edge1));
+        registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+    }
+
+    function test_propose_exceedingSlashableBalanceReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        // edge1 has exactly DEFAULT_MIN_EDGE_STAKE (50 M) staked and nothing
+        // unbonding, so the slashable balance is 50 M. A proposal for more must
+        // revert at propose time (defensive pre-check mirroring BunkerStaking H-05).
+        uint256 slashable = staking.getSlashableBalance(edge1);
+        assertEq(slashable, DEFAULT_MIN_EDGE_STAKE);
+
+        vm.prank(slasher);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BunkerEdgeRegistry.InsufficientSlashableBalance.selector,
+                slashable + 1,
+                slashable
+            )
+        );
+        registry.proposeEdgeSlash(edge1, uint128(slashable + 1), "downtime");
+    }
+
+    function test_propose_atSlashableBalanceSucceeds() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        uint256 slashable = staking.getSlashableBalance(edge1);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, uint128(slashable), "full slash");
+        assertEq(registry.getEdgeSlashProposal(id).amount, slashable);
+    }
+
+    // ================================================================
+    //  7. executeEdgeSlash
+    // ================================================================
+
+    function test_execute_slashingDisabledReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+
+        // registry.slashingEnabled defaults to false.
+        vm.expectRevert(BunkerEdgeRegistry.SlashingNotEnabled.selector);
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+    }
+
+    function test_execute_windowNotElapsedReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.AppealWindowNotElapsed.selector, id)
+        );
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+    }
+
+    function test_execute_happyPath_callsStakingSlash() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        uint256 slashAmount = 1_000_000e18;
+        uint256 stakedBefore = staking.getProviderInfo(edge1).stakedAmount;
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, uint128(slashAmount), "downtime");
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+
+        vm.expectEmit(true, true, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeSlashExecuted(id, edge1, slashAmount);
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+
+        // The slash actually hit BunkerStaking stake.
+        uint256 stakedAfter = staking.getProviderInfo(edge1).stakedAmount;
+        assertEq(stakedBefore - stakedAfter, slashAmount);
+        assertTrue(registry.getEdgeSlashProposal(id).executed);
+    }
+
+    function test_execute_twiceReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+        registry.executeEdgeSlash(id);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAlreadyExecuted.selector, id)
+        );
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+    }
+
+    function test_execute_appealedReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAppealed.selector, id));
+        registry.executeEdgeSlash(id);
+    }
+
+    function test_execute_invalidProposalIdReverts() public {
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+        vm.prank(slasher);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.InvalidProposalId.selector, 99));
+        registry.executeEdgeSlash(99);
+    }
+
+    // ================================================================
+    //  8. appealEdgeSlash
+    // ================================================================
+
+    function test_appeal_byTargetedProvider() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(edge1);
+        vm.expectEmit(true, true, false, false, address(registry));
+        emit BunkerEdgeRegistry.EdgeSlashAppealed(id, edge1);
+        registry.appealEdgeSlash(id);
+
+        assertTrue(registry.getEdgeSlashProposal(id).appealed);
+    }
+
+    function test_appeal_nonProviderReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BunkerEdgeRegistry.NotProposalProvider.selector, id, stranger
+            )
+        );
+        registry.appealEdgeSlash(id);
+    }
+
+    function test_appeal_afterWindowReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+        vm.prank(edge1);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.AppealWindowElapsed.selector, id));
+        registry.appealEdgeSlash(id);
+    }
+
+    function test_appeal_twiceReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.startPrank(edge1);
+        registry.appealEdgeSlash(id);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAppealed.selector, id));
+        registry.appealEdgeSlash(id);
+        vm.stopPrank();
+    }
+
+    function test_appeal_executedReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.startPrank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.warp(block.timestamp + DEFAULT_APPEAL_WINDOW + 1);
+        registry.executeEdgeSlash(id);
+        vm.stopPrank();
+
+        vm.prank(edge1);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAlreadyExecuted.selector, id)
+        );
+        registry.appealEdgeSlash(id);
+    }
+
+    // ================================================================
+    //  9. resolveEdgeSlashAppeal
+    // ================================================================
+
+    function test_resolve_upheldExecutesSlash() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        uint256 slashAmount = 1_000_000e18;
+        uint256 stakedBefore = staking.getProviderInfo(edge1).stakedAmount;
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, uint128(slashAmount), "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.prank(owner);
+        vm.expectEmit(true, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.EdgeAppealResolved(id, true);
+        registry.resolveEdgeSlashAppeal(id, true);
+
+        uint256 stakedAfter = staking.getProviderInfo(edge1).stakedAmount;
+        assertEq(stakedBefore - stakedAfter, slashAmount);
+        assertTrue(registry.getEdgeSlashProposal(id).executed);
+        assertTrue(registry.getEdgeSlashProposal(id).resolved);
+    }
+
+    function test_resolve_dismissedDoesNotSlash() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        uint256 stakedBefore = staking.getProviderInfo(edge1).stakedAmount;
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.prank(owner);
+        registry.resolveEdgeSlashAppeal(id, false);
+
+        uint256 stakedAfter = staking.getProviderInfo(edge1).stakedAmount;
+        assertEq(stakedBefore, stakedAfter); // no slash applied
+        assertFalse(registry.getEdgeSlashProposal(id).executed);
+        assertTrue(registry.getEdgeSlashProposal(id).resolved);
+    }
+
+    function test_resolve_nonOwnerReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.resolveEdgeSlashAppeal(id, true);
+    }
+
+    function test_resolve_notAppealedReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(BunkerEdgeRegistry.ProposalNotAppealed.selector, id));
+        registry.resolveEdgeSlashAppeal(id, true);
+    }
+
+    function test_resolve_twiceReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        vm.startPrank(owner);
+        registry.resolveEdgeSlashAppeal(id, false);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.ProposalAlreadyResolved.selector, id)
+        );
+        registry.resolveEdgeSlashAppeal(id, false);
+        vm.stopPrank();
+    }
+
+    function test_resolve_upheldWhileSlashingDisabledReverts() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(owner);
+        registry.setSlashingEnabled(true);
+
+        vm.prank(slasher);
+        uint256 id = registry.proposeEdgeSlash(edge1, 1_000_000e18, "downtime");
+        vm.prank(edge1);
+        registry.appealEdgeSlash(id);
+
+        // Disable slashing before resolving — upheld must revert.
+        vm.startPrank(owner);
+        registry.setSlashingEnabled(false);
+        vm.expectRevert(BunkerEdgeRegistry.SlashingNotEnabled.selector);
+        registry.resolveEdgeSlashAppeal(id, true);
+        vm.stopPrank();
+    }
+
+    // ================================================================
+    //  10. setMinStakeForEdge / setAppealWindow / setSlashingEnabled
+    // ================================================================
+
+    function test_setMinStake_byOwner() public {
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.MinStakeUpdated(DEFAULT_MIN_EDGE_STAKE, GOLD_MIN);
+        registry.setMinStakeForEdge(GOLD_MIN);
+        assertEq(registry.minStakeForEdge(), GOLD_MIN);
+    }
+
+    function test_setMinStake_nonOwnerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.setMinStakeForEdge(GOLD_MIN);
+    }
+
+    function test_setMinStake_belowFloorReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.InvalidMinStake.selector, STARTER_MIN - 1)
+        );
+        registry.setMinStakeForEdge(STARTER_MIN - 1);
+    }
+
+    function test_setMinStake_aboveCeilingReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(BunkerEdgeRegistry.InvalidMinStake.selector, PLATINUM_MIN + 1)
+        );
+        registry.setMinStakeForEdge(PLATINUM_MIN + 1);
+    }
+
+    function test_setMinStake_atFloorSucceeds() public {
+        vm.prank(owner);
+        registry.setMinStakeForEdge(STARTER_MIN);
+        assertEq(registry.minStakeForEdge(), STARTER_MIN);
+    }
+
+    function test_setMinStake_atCeilingSucceeds() public {
+        vm.prank(owner);
+        registry.setMinStakeForEdge(PLATINUM_MIN);
+        assertEq(registry.minStakeForEdge(), PLATINUM_MIN);
+    }
+
+    function test_setAppealWindow_byOwner() public {
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.AppealWindowUpdated(7 days);
+        registry.setAppealWindow(7 days);
+        assertEq(registry.appealWindow(), 7 days);
+    }
+
+    function test_setAppealWindow_belowFloorReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(BunkerEdgeRegistry.InvalidAppealWindow.selector);
+        registry.setAppealWindow(12 hours - 1);
+    }
+
+    function test_setAppealWindow_aboveCeilingReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(BunkerEdgeRegistry.InvalidAppealWindow.selector);
+        registry.setAppealWindow(14 days + 1);
+    }
+
+    function test_setAppealWindow_nonOwnerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.setAppealWindow(7 days);
+    }
+
+    function test_setSlashingEnabled_byOwner() public {
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit BunkerEdgeRegistry.SlashingEnabledUpdated(true);
+        registry.setSlashingEnabled(true);
+        assertTrue(registry.slashingEnabled());
+    }
+
+    function test_setSlashingEnabled_nonOwnerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                bytes4(keccak256("OwnableUnauthorizedAccount(address)")), stranger
+            )
+        );
+        registry.setSlashingEnabled(true);
+    }
+
+    // ================================================================
+    //  11. isActiveEdgeProvider view
+    // ================================================================
+
+    function test_isActive_falseWhenUnregistered() public view {
+        assertFalse(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_isActive_trueAfterRegister() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        assertTrue(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_isActive_falseAfterDeregister() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(edge1);
+        registry.deregisterEdgeProvider();
+        assertFalse(registry.isActiveEdgeProvider(edge1));
+    }
+
+    function test_isActive_falseWhenFrozen() public {
+        _register(edge1, NODE_ID_1, REGION_US);
+        vm.prank(slasher);
+        registry.freezeEdgeProvider(edge1);
+        assertFalse(registry.isActiveEdgeProvider(edge1));
+    }
+
+    // ================================================================
+    //  12. Ownership transfer syncs admin role
+    // ================================================================
+
+    function test_transferOwnership_syncsAdminRole() public {
+        address newOwner = makeAddr("newOwner");
+
+        vm.prank(owner);
+        registry.transferOwnership(newOwner);
+        vm.prank(newOwner);
+        registry.acceptOwnership();
+
+        assertEq(registry.owner(), newOwner);
+        assertTrue(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), newOwner));
+        assertFalse(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), owner));
+    }
+
+    // ================================================================
+    //  13. FUZZ
+    // ================================================================
+
+    function testFuzz_registerAndQuery(bytes32 nodeId, bytes32 region, uint128 stakeAmount)
+        public
+    {
+        // Bound the stake to a sane mintable range, then skip below-threshold runs.
+        stakeAmount = uint128(bound(uint256(stakeAmount), 0, 1_500_000_000e18));
+        vm.assume(nodeId != bytes32(0));
+        vm.assume(registry.nodeIdToEdgeProvider(nodeId) == address(0));
+
+        address fuzzEdge = makeAddr("fuzzEdge");
+        vm.prank(owner);
+        token.mint(fuzzEdge, uint256(stakeAmount) + 1);
+
+        if (stakeAmount > 0) {
+            vm.startPrank(fuzzEdge);
+            token.approve(address(staking), type(uint256).max);
+            // staking requires at least the Starter minimum to register.
+            if (stakeAmount >= STARTER_MIN) {
+                staking.stake(stakeAmount);
+            }
+            vm.stopPrank();
+        }
+
+        if (stakeAmount < DEFAULT_MIN_EDGE_STAKE) {
+            vm.prank(fuzzEdge);
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    BunkerEdgeRegistry.InsufficientStake.selector,
+                    stakeAmount >= STARTER_MIN ? uint256(stakeAmount) : 0,
+                    DEFAULT_MIN_EDGE_STAKE
+                )
+            );
+            registry.registerEdgeProvider(nodeId, region, ENDPOINT_1, TLS_HASH_1);
+            return;
+        }
+
+        vm.prank(fuzzEdge);
+        registry.registerEdgeProvider(nodeId, region, ENDPOINT_1, TLS_HASH_1);
+
+        assertTrue(registry.isActiveEdgeProvider(fuzzEdge));
+        BunkerEdgeRegistry.EdgeProviderInfo memory info = registry.getEdgeProviderInfo(fuzzEdge);
+        assertEq(info.nodeId, nodeId);
+        assertEq(info.region, region);
+        assertEq(registry.nodeIdToEdgeProvider(nodeId), fuzzEdge);
+    }
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,28 +16,28 @@ import (
 
 	"golang.org/x/time/rate"
 
+	"github.com/moltbunker/moltbunker/internal/agent"
 	"github.com/moltbunker/moltbunker/internal/client"
 	"github.com/moltbunker/moltbunker/internal/cloning"
 	"github.com/moltbunker/moltbunker/internal/config"
+	"github.com/moltbunker/moltbunker/internal/crawl"
 	"github.com/moltbunker/moltbunker/internal/daemon"
 	"github.com/moltbunker/moltbunker/internal/logging"
 	"github.com/moltbunker/moltbunker/internal/metrics"
-	"github.com/moltbunker/moltbunker/internal/snapshot"
-	"github.com/moltbunker/moltbunker/internal/agent"
-	"github.com/moltbunker/moltbunker/internal/crawl"
 	"github.com/moltbunker/moltbunker/internal/proxy"
+	"github.com/moltbunker/moltbunker/internal/snapshot"
 	"github.com/moltbunker/moltbunker/internal/storage"
 	"github.com/moltbunker/moltbunker/internal/threat"
 )
 
 // Server is the external HTTP API server
 type Server struct {
-	config          *ServerConfig
-	fullConfig      *config.Config // Full app config for fallback values
-	httpServer      *http.Server
-	tlsServer       *http.Server
-	mu              sync.RWMutex
-	running         bool
+	config     *ServerConfig
+	fullConfig *config.Config // Full app config for fallback values
+	httpServer *http.Server
+	tlsServer  *http.Server
+	mu         sync.RWMutex
+	running    bool
 
 	// Core components
 	daemonAPI       *daemon.APIServer
@@ -46,19 +46,19 @@ type Server struct {
 	cloningManager  *cloning.Manager
 
 	// Daemon bridge for forwarding requests
-	daemonBridge    *DaemonBridge
+	daemonBridge *DaemonBridge
 
 	// API key manager
-	apiKeyManager   *APIKeyManager
+	apiKeyManager *APIKeyManager
 
 	// Wallet authentication manager (permissionless)
-	walletAuth      *WalletAuthManager
+	walletAuth *WalletAuthManager
 
 	// WebSocket hub
-	wsHub           *WebSocketHub
+	wsHub *WebSocketHub
 
 	// Exec session manager
-	execSessions    *ExecSessionManager
+	execSessions *ExecSessionManager
 
 	// Metrics collector
 	metricsCollector *metrics.Collector
@@ -74,8 +74,13 @@ type Server struct {
 	crawlHandler   *crawl.RESTHandler
 	agentHandler   *agent.RESTHandler
 
+	// Extra admin-gated handlers registered by the daemon at startup
+	// (e.g. EDGE-02 custom-domain verification + takedown blocklist). Each is
+	// mounted at its prefix behind the admin middleware in buildRouter.
+	extraAdminHandlers map[string]http.Handler
+
 	// Per-IP rate limiters
-	rateLimiters    sync.Map
+	rateLimiters sync.Map
 
 	// Rate limiter cleanup control
 	rateLimitCtx    context.Context
@@ -91,31 +96,31 @@ type rateLimiterEntry struct {
 // ServerConfig configures the HTTP API server
 type ServerConfig struct {
 	// HTTP settings
-	HTTPAddr        string `yaml:"http_addr"`        // e.g., ":8080"
-	HTTPSAddr       string `yaml:"https_addr"`       // e.g., ":8443"
-	EnableHTTPS     bool   `yaml:"enable_https"`
-	TLSCertFile     string `yaml:"tls_cert_file"`
-	TLSKeyFile      string `yaml:"tls_key_file"`
+	HTTPAddr    string `yaml:"http_addr"`  // e.g., ":8080"
+	HTTPSAddr   string `yaml:"https_addr"` // e.g., ":8443"
+	EnableHTTPS bool   `yaml:"enable_https"`
+	TLSCertFile string `yaml:"tls_cert_file"`
+	TLSKeyFile  string `yaml:"tls_key_file"`
 
 	// Daemon connection
 	DaemonSocketPath string `yaml:"daemon_socket_path"`
 	DaemonPoolSize   int    `yaml:"daemon_pool_size"`
 
 	// Rate limiting
-	RateLimit       int    `yaml:"rate_limit"`        // Requests per minute
-	RateLimitBurst  int    `yaml:"rate_limit_burst"`
+	RateLimit      int `yaml:"rate_limit"` // Requests per minute
+	RateLimitBurst int `yaml:"rate_limit_burst"`
 
 	// Authentication
 	EnableAuth      bool   `yaml:"enable_auth"`
-	APIKeyHeader    string `yaml:"api_key_header"`    // Default: X-API-Key
+	APIKeyHeader    string `yaml:"api_key_header"` // Default: X-API-Key
 	APIKeyStorePath string `yaml:"api_key_store_path"`
 
 	// Proxy trust (only enable behind a trusted reverse proxy like Cloudflare)
 	TrustProxy bool `yaml:"trust_proxy"`
 
 	// CORS
-	EnableCORS      bool     `yaml:"enable_cors"`
-	AllowedOrigins  []string `yaml:"allowed_origins"`
+	EnableCORS     bool     `yaml:"enable_cors"`
+	AllowedOrigins []string `yaml:"allowed_origins"`
 
 	// Timeouts
 	ReadTimeout       time.Duration `yaml:"read_timeout"`
@@ -258,6 +263,22 @@ func (s *Server) SetCrawlHandler(handler *crawl.RESTHandler) {
 // SetAgentHandler sets the agent REST handler for AI agent runtime API.
 func (s *Server) SetAgentHandler(handler *agent.RESTHandler) {
 	s.agentHandler = handler
+}
+
+// SetExtraAdminHandler registers an additional handler mounted at prefix and
+// served behind the admin auth middleware. Used by the daemon at startup to
+// expose operator surfaces that live in other packages (EDGE-02 custom-domain
+// verification and the takedown blocklist) without those packages depending on
+// internal/api. Must be called before Start. The prefix is matched with a
+// trailing-slash subtree (e.g. "/v1/ingress/custom-domain/").
+func (s *Server) SetExtraAdminHandler(prefix string, handler http.Handler) {
+	if handler == nil || prefix == "" {
+		return
+	}
+	if s.extraAdminHandlers == nil {
+		s.extraAdminHandlers = make(map[string]http.Handler)
+	}
+	s.extraAdminHandlers[prefix] = handler
 }
 
 // Start starts the HTTP API server
@@ -522,6 +543,16 @@ func (s *Server) buildRouter() http.Handler {
 			func(h http.HandlerFunc) http.HandlerFunc { return s.withPermissionMiddleware(h, "read") },
 			func(h http.HandlerFunc) http.HandlerFunc { return s.withPermissionMiddleware(h, "write") },
 		)
+	}
+
+	// Extra admin-gated handlers registered by the daemon (EDGE-02:
+	// custom-domain verification + takedown blocklist). Mounted behind admin
+	// auth so only operators can verify domains or take subdomains down.
+	for prefix, h := range s.extraAdminHandlers {
+		handler := h // capture
+		mux.HandleFunc(prefix, s.withAdminMiddleware(func(w http.ResponseWriter, r *http.Request) {
+			handler.ServeHTTP(w, r)
+		}))
 	}
 
 	// Health endpoints (no auth required)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,6 +253,40 @@ type ProviderNodeConfig struct {
 	// Reverse tunnel server (ingress-side — accepts incoming reverse tunnels from providers)
 	ReverseTunnelPort     int `yaml:"reverse_tunnel_port,omitempty"`      // Listen port (default: 9443)
 	ReverseTunnelMaxConns int `yaml:"reverse_tunnel_max_conns,omitempty"` // Global max connections (default: 10000)
+
+	// Edge-provider role (EDGE-02). When enabled the ingress-side reverse
+	// tunnel server additionally gates provider registration on edge-tier
+	// authorization. Zero-value = disabled, so existing configs are unaffected.
+	EdgeRole EdgeRoleConfig `yaml:"edge_role,omitempty"`
+
+	// BYO custom-hostname ACME (EDGE-02). When enabled, customers can point
+	// their own domain at this ingress after proving ownership via a CNAME/TXT
+	// DNS record. Zero-value = disabled.
+	CustomDomain CustomDomainConfig `yaml:"custom_domain,omitempty"`
+}
+
+// EdgeRoleConfig gates the stake-gated edge-provider role (EDGE-02). The actual
+// edge-tier check is pluggable: "config" uses AllowedNodeIDs (works with no
+// contract deployed, the default), "onchain" uses the BunkerEdgeRegistry via
+// the payment service. AllowedNodeIDs holds NodeID hex strings (public SHA256
+// hashes), not secrets.
+type EdgeRoleConfig struct {
+	Enabled        bool     `yaml:"enabled,omitempty"`          // Gate reverse-tunnel registration on edge tier
+	Mode           string   `yaml:"mode,omitempty"`             // "config" (allowlist, default) or "onchain"
+	MinStakeTier   string   `yaml:"min_stake_tier,omitempty"`   // Minimum tier for onchain mode (default: bronze)
+	AllowedNodeIDs []string `yaml:"allowed_node_ids,omitempty"` // NodeID hex allowlist for "config" mode
+	RegistryAddr   string   `yaml:"registry_addr,omitempty"`    // BunkerEdgeRegistry address for "onchain" mode (public)
+}
+
+// CustomDomainConfig configures BYO custom-hostname verification (EDGE-02).
+// VerifyMethod selects the DNS proof: "cname" (CNAME to <token>.<domain>) or
+// "txt" (TXT moltbunker-verify=<token> on _moltbunker.<host>). No secret fields
+// — the verification HMAC secret is generated in memory at startup.
+type CustomDomainConfig struct {
+	Enabled                 bool   `yaml:"enabled,omitempty"`                    // Accept BYO custom hostnames
+	VerifyMethod            string `yaml:"verify_method,omitempty"`              // "cname" (default) or "txt"
+	MaxDomainsPerDeployment int    `yaml:"max_domains_per_deployment,omitempty"` // 0 = unlimited
+	OwnershipTTLHours       int    `yaml:"ownership_ttl_hours,omitempty"`        // Verification validity (default: 72)
 }
 
 // RequesterNodeConfig contains requester-specific configuration

--- a/internal/edge/edge.go
+++ b/internal/edge/edge.go
@@ -1,0 +1,157 @@
+// Package edge implements the daemon-side edge-provider role: the stake-gated
+// "edge" node tier (Approach A from the 2026-05-18 decision) that terminates
+// TLS + runs an L7 WAF + handles DDoS for container hosts that tunnel to it.
+//
+// This package is interface-first and deliberately decoupled from the on-chain
+// edge-stake contract (BunkerEdgeRegistry, SC-EDGE-01). The daemon can gate the
+// edge role with either:
+//
+//   - ConfigEdgeTierChecker — a static allowlist of NodeIDs from config. This is
+//     the default and lets the edge role work WITHOUT any contract deployed.
+//   - OnChainEdgeTierChecker — backed by the EdgeRegistryReader seam from
+//     SC-EDGE-01 (payment.EdgeRegistryReader), which checks the wallet's
+//     on-chain edge-provider registration.
+//
+// A third implementation can be dropped in later (e.g. a dedicated edge-staking
+// contract) without touching any call site, because everything consumes the
+// EdgeTierChecker interface.
+package edge
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/moltbunker/moltbunker/pkg/types"
+)
+
+// EdgeTierChecker decides whether a node is authorized to act as an edge
+// provider. It is the single gating seam consumed by the reverse tunnel server
+// (internal/tunnel) so the gate can be swapped between a config allowlist and
+// an on-chain check without changing the call site.
+type EdgeTierChecker interface {
+	// IsEdgeAuthorized reports whether the node identified by nodeID / wallet is
+	// permitted to register as an edge provider. A non-nil error means the check
+	// could not be completed (e.g. RPC failure) and callers MUST treat that as
+	// "not authorized" (fail-closed) for the edge role.
+	IsEdgeAuthorized(ctx context.Context, nodeID types.NodeID, wallet common.Address) (bool, error)
+}
+
+// Mode selects which EdgeTierChecker implementation NewEdgeTierChecker builds.
+type Mode string
+
+const (
+	// ModeConfig gates the edge role on a static allowlist of NodeIDs. Default.
+	ModeConfig Mode = "config"
+	// ModeOnChain gates the edge role on the on-chain BunkerEdgeRegistry via the
+	// payment.EdgeRegistryReader seam.
+	ModeOnChain Mode = "onchain"
+)
+
+// Config is the daemon-side edge-role configuration, mapped from
+// config.EdgeRoleConfig. Kept in this package (rather than importing
+// internal/config) so internal/config does not depend on internal/edge.
+type Config struct {
+	// Mode is "config" (allowlist) or "onchain" (contract). Empty defaults to
+	// "config".
+	Mode Mode
+	// AllowedNodeIDs is the allowlist consumed by ConfigEdgeTierChecker. Each
+	// entry is a NodeID hex string (the SHA256 of the node's SPKI, as returned
+	// by types.NodeID.String()).
+	AllowedNodeIDs []string
+	// MinTier is the minimum staking tier accepted by tier-based checks. It is
+	// informational for the config checker and reserved for future tier-aware
+	// on-chain policy; the current OnChainEdgeTierChecker uses the registry's
+	// active/frozen flags rather than a tier comparison.
+	MinTier string
+}
+
+// EdgeRegistryReader is the read-only on-chain seam this package consumes for
+// the on-chain gate. It is satisfied by payment.EdgeRegistryReader (the
+// production contract reader and its mock both implement it). Re-declaring the
+// method set here keeps internal/edge from importing internal/payment, avoiding
+// an import cycle and keeping the dependency direction one-way.
+type EdgeRegistryReader interface {
+	IsActiveEdgeProvider(ctx context.Context, addr common.Address) (bool, error)
+}
+
+// ConfigEdgeTierChecker authorizes the edge role from a static NodeID
+// allowlist. It is the default gate and requires no contract. Safe for
+// concurrent use (the allowlist is immutable after construction).
+type ConfigEdgeTierChecker struct {
+	allowed map[string]struct{}
+}
+
+// NewConfigEdgeTierChecker builds an allowlist gate from the given NodeID hex
+// strings. An empty allowlist authorizes nothing.
+func NewConfigEdgeTierChecker(allowedNodeIDs []string) *ConfigEdgeTierChecker {
+	allowed := make(map[string]struct{}, len(allowedNodeIDs))
+	for _, id := range allowedNodeIDs {
+		if id == "" {
+			continue
+		}
+		allowed[id] = struct{}{}
+	}
+	return &ConfigEdgeTierChecker{allowed: allowed}
+}
+
+// IsEdgeAuthorized implements EdgeTierChecker against the static allowlist.
+func (c *ConfigEdgeTierChecker) IsEdgeAuthorized(_ context.Context, nodeID types.NodeID, _ common.Address) (bool, error) {
+	_, ok := c.allowed[nodeID.String()]
+	return ok, nil
+}
+
+// OnChainEdgeTierChecker authorizes the edge role from the on-chain
+// BunkerEdgeRegistry via the EdgeRegistryReader seam. It works on Base Sepolia
+// today against a deployed registry and falls back cleanly (returns the
+// registry error, which the caller treats as not-authorized) when the RPC is
+// unavailable.
+type OnChainEdgeTierChecker struct {
+	reader EdgeRegistryReader
+}
+
+// NewOnChainEdgeTierChecker builds an on-chain gate backed by the given
+// registry reader (payment.EdgeRegistryReader satisfies it).
+func NewOnChainEdgeTierChecker(reader EdgeRegistryReader) *OnChainEdgeTierChecker {
+	return &OnChainEdgeTierChecker{reader: reader}
+}
+
+// IsEdgeAuthorized implements EdgeTierChecker against the on-chain registry.
+// A nil reader fails closed (returns false, nil) so a mis-wired daemon never
+// silently authorizes every node.
+func (c *OnChainEdgeTierChecker) IsEdgeAuthorized(ctx context.Context, _ types.NodeID, wallet common.Address) (bool, error) {
+	if c.reader == nil {
+		return false, nil
+	}
+	return c.reader.IsActiveEdgeProvider(ctx, wallet)
+}
+
+// NewEdgeTierChecker selects the right EdgeTierChecker for the config Mode.
+//
+//   - ModeOnChain requires a non-nil reader; if reader is nil it falls back to
+//     the config allowlist (fail-safe: never returns nil).
+//   - Any other Mode (including the empty default) returns the config allowlist
+//     checker.
+func NewEdgeTierChecker(cfg Config, reader EdgeRegistryReader) EdgeTierChecker {
+	if cfg.Mode == ModeOnChain && reader != nil {
+		return NewOnChainEdgeTierChecker(reader)
+	}
+	return NewConfigEdgeTierChecker(cfg.AllowedNodeIDs)
+}
+
+// MockEdgeTierChecker is a fixed-answer EdgeTierChecker for tests.
+type MockEdgeTierChecker struct {
+	Authorized bool
+	Err        error
+}
+
+// IsEdgeAuthorized returns the configured answer.
+func (m *MockEdgeTierChecker) IsEdgeAuthorized(_ context.Context, _ types.NodeID, _ common.Address) (bool, error) {
+	return m.Authorized, m.Err
+}
+
+// Compile-time assertions that all implementations satisfy the interface.
+var (
+	_ EdgeTierChecker = (*ConfigEdgeTierChecker)(nil)
+	_ EdgeTierChecker = (*OnChainEdgeTierChecker)(nil)
+	_ EdgeTierChecker = (*MockEdgeTierChecker)(nil)
+)

--- a/internal/edge/edge_probe.go
+++ b/internal/edge/edge_probe.go
@@ -1,0 +1,155 @@
+package edge
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/moltbunker/moltbunker/internal/logging"
+	"github.com/moltbunker/moltbunker/internal/util"
+	"github.com/moltbunker/moltbunker/pkg/types"
+)
+
+const (
+	// defaultProbeInterval is how often each edge node is probed.
+	defaultProbeInterval = 30 * time.Second
+	// defaultProbeTimeout bounds a single dial+handshake.
+	defaultProbeTimeout = 5 * time.Second
+	// probeFailThreshold is how many consecutive failed probes flip a node
+	// unhealthy. A single success resets the counter and marks it healthy.
+	probeFailThreshold = 3
+)
+
+// EdgeProbe is a background goroutine that periodically TLS-dials each
+// registered edge node's tunnel port to verify liveness, then updates the
+// registry's health flag. It is a pure connectivity check — no yamux, no
+// authentication — mirroring the ingress-side intent of the reverse server's
+// heartbeat but pointed outward at the edge set.
+type EdgeProbe struct {
+	registry *EdgeRegistry
+	tlsCfg   *tls.Config
+	interval time.Duration
+	timeout  time.Duration
+
+	mu     sync.Mutex
+	misses map[types.NodeID]int
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewEdgeProbe creates a probe. Non-positive interval/timeout fall back to the
+// package defaults. A nil tlsCfg uses InsecureSkipVerify=false defaults (a real
+// edge cert is expected in production); tests inject a config trusting the
+// self-signed test cert.
+func NewEdgeProbe(registry *EdgeRegistry, tlsCfg *tls.Config, interval, timeout time.Duration) *EdgeProbe {
+	if interval <= 0 {
+		interval = defaultProbeInterval
+	}
+	if timeout <= 0 {
+		timeout = defaultProbeTimeout
+	}
+	return &EdgeProbe{
+		registry: registry,
+		tlsCfg:   tlsCfg,
+		interval: interval,
+		timeout:  timeout,
+		misses:   make(map[types.NodeID]int),
+	}
+}
+
+// Start launches the probe loop until ctx is cancelled or Stop is called.
+func (p *EdgeProbe) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	p.mu.Lock()
+	p.cancel = cancel
+	p.done = make(chan struct{})
+	p.mu.Unlock()
+
+	util.SafeGoWithName("edge-probe", func() {
+		defer close(p.done)
+		ticker := time.NewTicker(p.interval)
+		defer ticker.Stop()
+		// Probe once immediately so health is fresh without waiting a full tick.
+		p.probeAll(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.probeAll(ctx)
+			}
+		}
+	})
+}
+
+// Stop cancels the probe loop and waits for it to exit.
+func (p *EdgeProbe) Stop() {
+	p.mu.Lock()
+	cancel := p.cancel
+	done := p.done
+	p.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+// probeAll probes every registered node once and updates health.
+func (p *EdgeProbe) probeAll(ctx context.Context) {
+	for _, n := range p.registry.ListAll() {
+		if ctx.Err() != nil {
+			return
+		}
+		p.probeOne(ctx, n)
+	}
+}
+
+// probeOne dials a single node. On success the miss counter resets and the node
+// is marked healthy; on failure the counter increments and the node is marked
+// unhealthy once it reaches probeFailThreshold consecutive misses.
+func (p *EdgeProbe) probeOne(ctx context.Context, n EdgeNodeInfo) {
+	if p.dial(ctx, n.FullAddr()) {
+		p.mu.Lock()
+		p.misses[n.NodeID] = 0
+		p.mu.Unlock()
+		p.registry.UpdateHealth(n.NodeID, true)
+		return
+	}
+
+	p.mu.Lock()
+	p.misses[n.NodeID]++
+	missed := p.misses[n.NodeID]
+	p.mu.Unlock()
+
+	if missed >= probeFailThreshold {
+		logging.Warn("edge node marked unhealthy",
+			"node_id", n.NodeID.String()[:16],
+			"addr", n.FullAddr(),
+			"missed", missed,
+			logging.Component("edge"))
+		p.registry.UpdateHealth(n.NodeID, false)
+	}
+}
+
+// dial performs a single TCP+TLS connectivity check, returning true on a
+// completed handshake. It never returns an error to the caller — failure is
+// just "not reachable right now".
+func (p *EdgeProbe) dial(ctx context.Context, addr string) bool {
+	dialCtx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: p.timeout},
+		Config:    p.tlsCfg,
+	}
+	conn, err := dialer.DialContext(dialCtx, "tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/internal/edge/edge_registry.go
+++ b/internal/edge/edge_registry.go
@@ -1,0 +1,137 @@
+package edge
+
+import (
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/moltbunker/moltbunker/pkg/types"
+)
+
+// EdgeNodeInfo describes a known edge provider node: where it accepts tunnels
+// and its current liveness. Edge nodes are a small, operator-curated, stake-
+// gated set (not the DHT/gossip container-provider population), so an in-memory
+// registry is the correct fit. Persistence across daemon restart is a follow-up.
+type EdgeNodeInfo struct {
+	NodeID         types.NodeID
+	WalletAddr     string // hex wallet address (public), informational
+	IngressAddr    string // public host the edge node terminates TLS on
+	TunnelPort     int    // port providers dial to open a reverse tunnel
+	TLSFingerprint string // hex SHA256 of the edge node's TLS SPKI (optional)
+	Tier           string // staking tier label (informational)
+	LastSeen       time.Time
+	Healthy        bool
+}
+
+// FullAddr returns the dial target "host:port" for the edge node's tunnel
+// endpoint. It joins IngressAddr with TunnelPort using net.JoinHostPort so IPv6
+// literals are bracketed correctly.
+func (e EdgeNodeInfo) FullAddr() string {
+	return net.JoinHostPort(e.IngressAddr, strconv.Itoa(e.TunnelPort))
+}
+
+// EdgeRegistry is a thread-safe in-memory map of known edge nodes. It is
+// populated by the ingress side when an edge provider announces its
+// EdgeCapabilities during reverse-tunnel registration, and read by the
+// EdgeSelector when choosing an edge for a new tunnel.
+type EdgeRegistry struct {
+	mu    sync.RWMutex
+	nodes map[types.NodeID]*EdgeNodeInfo
+}
+
+// NewEdgeRegistry creates an empty registry.
+func NewEdgeRegistry() *EdgeRegistry {
+	return &EdgeRegistry{nodes: make(map[types.NodeID]*EdgeNodeInfo)}
+}
+
+// Register adds or replaces an edge node. LastSeen is stamped to now and a node
+// is considered Healthy on (re-)registration; the EdgeProbe flips it unhealthy
+// if it stops responding. A copy is stored so callers cannot mutate the record.
+func (r *EdgeRegistry) Register(info EdgeNodeInfo) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	info.LastSeen = time.Now()
+	info.Healthy = true
+	cp := info
+	r.nodes[info.NodeID] = &cp
+}
+
+// RegisterEdge is the convenience seam consumed by the tunnel server's
+// EdgeRegistrar interface: it builds an EdgeNodeInfo from the announced
+// capabilities and registers it. Keeping the signature primitive-only lets
+// internal/tunnel declare the seam without importing this package. The
+// maxStreams hint is currently advisory (recorded via TLSFingerprint-adjacent
+// metadata is out of scope here); selection uses live connection counts.
+func (r *EdgeRegistry) RegisterEdge(nodeID types.NodeID, walletAddr, ingressAddr string, tunnelPort, _ int) {
+	r.Register(EdgeNodeInfo{
+		NodeID:      nodeID,
+		WalletAddr:  walletAddr,
+		IngressAddr: ingressAddr,
+		TunnelPort:  tunnelPort,
+	})
+}
+
+// Unregister removes an edge node.
+func (r *EdgeRegistry) Unregister(nodeID types.NodeID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.nodes, nodeID)
+}
+
+// ListHealthy returns a snapshot of the currently-healthy edge nodes.
+func (r *EdgeRegistry) ListHealthy() []EdgeNodeInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]EdgeNodeInfo, 0, len(r.nodes))
+	for _, n := range r.nodes {
+		if n.Healthy {
+			out = append(out, *n)
+		}
+	}
+	return out
+}
+
+// ListAll returns a snapshot of every registered edge node regardless of health.
+func (r *EdgeRegistry) ListAll() []EdgeNodeInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]EdgeNodeInfo, 0, len(r.nodes))
+	for _, n := range r.nodes {
+		out = append(out, *n)
+	}
+	return out
+}
+
+// ByNodeID returns the edge node info for nodeID, if registered.
+func (r *EdgeRegistry) ByNodeID(nodeID types.NodeID) (EdgeNodeInfo, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	n, ok := r.nodes[nodeID]
+	if !ok {
+		return EdgeNodeInfo{}, false
+	}
+	return *n, true
+}
+
+// UpdateHealth sets the health flag for a node and refreshes LastSeen when
+// marking healthy. A missing node is a no-op.
+func (r *EdgeRegistry) UpdateHealth(nodeID types.NodeID, healthy bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n, ok := r.nodes[nodeID]
+	if !ok {
+		return
+	}
+	n.Healthy = healthy
+	if healthy {
+		n.LastSeen = time.Now()
+	}
+}
+
+// Len returns the number of registered edge nodes.
+func (r *EdgeRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.nodes)
+}

--- a/internal/edge/edge_selector.go
+++ b/internal/edge/edge_selector.go
@@ -1,0 +1,107 @@
+package edge
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/moltbunker/moltbunker/pkg/types"
+)
+
+// EdgeSelector picks an edge node for a new tunnel and is the foundation for
+// multi-edge failover: a provider that loses its edge can call SelectEdge again
+// to obtain the next-best healthy candidate. Selection policy for this PR is
+// least-connections with round-robin among ties, which spreads load across a
+// small operator-curated edge set. Session-affinity (consistent hashing) is a
+// documented follow-up.
+//
+// EdgeSelector owns no goroutines; it is backed by an EdgeRegistry and tracks
+// an in-flight connection count per node. Safe for concurrent use.
+type EdgeSelector struct {
+	registry *EdgeRegistry
+
+	mu       sync.Mutex
+	conns    map[types.NodeID]int // in-flight tunnel count per node
+	rrCursor int                  // round-robin cursor for tie-breaking
+}
+
+// NewEdgeSelector creates a selector backed by registry.
+func NewEdgeSelector(registry *EdgeRegistry) *EdgeSelector {
+	return &EdgeSelector{
+		registry: registry,
+		conns:    make(map[types.NodeID]int),
+	}
+}
+
+// AddEdge registers an edge node (delegates to the backing registry).
+func (s *EdgeSelector) AddEdge(info EdgeNodeInfo) {
+	s.registry.Register(info)
+}
+
+// RemoveEdge unregisters an edge node and drops its connection count.
+func (s *EdgeSelector) RemoveEdge(nodeID types.NodeID) {
+	s.registry.Unregister(nodeID)
+	s.mu.Lock()
+	delete(s.conns, nodeID)
+	s.mu.Unlock()
+}
+
+// MarkHealthy flips a node's health in the backing registry.
+func (s *EdgeSelector) MarkHealthy(nodeID types.NodeID, healthy bool) {
+	s.registry.UpdateHealth(nodeID, healthy)
+}
+
+// SelectEdge returns the best healthy edge node: the one with the fewest
+// in-flight tunnels, breaking ties round-robin. Returns an error when no healthy
+// edge is available (the caller's failover signal). The chosen node's
+// connection count is incremented; callers MUST call Release(nodeID) when the
+// tunnel closes.
+func (s *EdgeSelector) SelectEdge(_ context.Context) (EdgeNodeInfo, error) {
+	healthy := s.registry.ListHealthy()
+	if len(healthy) == 0 {
+		return EdgeNodeInfo{}, fmt.Errorf("no healthy edge nodes available")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Find the minimum in-flight count.
+	minConns := -1
+	for _, n := range healthy {
+		c := s.conns[n.NodeID]
+		if minConns < 0 || c < minConns {
+			minConns = c
+		}
+	}
+
+	// Collect the tied candidates (deterministic membership; order within the
+	// slice follows the registry snapshot, which the round-robin cursor walks).
+	candidates := make([]EdgeNodeInfo, 0, len(healthy))
+	for _, n := range healthy {
+		if s.conns[n.NodeID] == minConns {
+			candidates = append(candidates, n)
+		}
+	}
+
+	chosen := candidates[s.rrCursor%len(candidates)]
+	s.rrCursor++
+	s.conns[chosen.NodeID]++
+	return chosen, nil
+}
+
+// Release decrements the in-flight tunnel count for a node (call when a tunnel
+// established via SelectEdge closes). It never goes below zero.
+func (s *EdgeSelector) Release(nodeID types.NodeID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.conns[nodeID] > 0 {
+		s.conns[nodeID]--
+	}
+}
+
+// InFlight returns the current in-flight tunnel count for a node (test/observability).
+func (s *EdgeSelector) InFlight(nodeID types.NodeID) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.conns[nodeID]
+}

--- a/internal/edge/edge_test.go
+++ b/internal/edge/edge_test.go
@@ -1,0 +1,349 @@
+package edge
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/moltbunker/moltbunker/pkg/types"
+)
+
+// nodeIDFromByte builds a deterministic NodeID for tests.
+func nodeIDFromByte(b byte) types.NodeID {
+	var id types.NodeID
+	for i := range id {
+		id[i] = b
+	}
+	return id
+}
+
+func TestConfigEdgeTierChecker_Authorized(t *testing.T) {
+	id := nodeIDFromByte(0x01)
+	c := NewConfigEdgeTierChecker([]string{id.String()})
+	ok, err := c.IsEdgeAuthorized(context.Background(), id, common.Address{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected node in allowlist to be authorized")
+	}
+}
+
+func TestConfigEdgeTierChecker_NotInList(t *testing.T) {
+	c := NewConfigEdgeTierChecker([]string{nodeIDFromByte(0x01).String()})
+	ok, err := c.IsEdgeAuthorized(context.Background(), nodeIDFromByte(0x02), common.Address{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected node not in allowlist to be rejected")
+	}
+}
+
+func TestConfigEdgeTierChecker_EmptyAllowlistRejects(t *testing.T) {
+	c := NewConfigEdgeTierChecker(nil)
+	ok, _ := c.IsEdgeAuthorized(context.Background(), nodeIDFromByte(0x03), common.Address{})
+	if ok {
+		t.Fatal("empty allowlist must authorize nothing")
+	}
+}
+
+// fakeRegistryReader implements EdgeRegistryReader for the on-chain checker test.
+type fakeRegistryReader struct {
+	active map[common.Address]bool
+	err    error
+}
+
+func (f fakeRegistryReader) IsActiveEdgeProvider(_ context.Context, addr common.Address) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.active[addr], nil
+}
+
+func TestOnChainEdgeTierChecker_Active(t *testing.T) {
+	addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	c := NewOnChainEdgeTierChecker(fakeRegistryReader{active: map[common.Address]bool{addr: true}})
+	ok, err := c.IsEdgeAuthorized(context.Background(), types.NodeID{}, addr)
+	if err != nil || !ok {
+		t.Fatalf("expected active provider authorized, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestOnChainEdgeTierChecker_NilReaderFailsClosed(t *testing.T) {
+	c := NewOnChainEdgeTierChecker(nil)
+	ok, err := c.IsEdgeAuthorized(context.Background(), types.NodeID{}, common.Address{})
+	if err != nil {
+		t.Fatalf("nil reader should not error, got %v", err)
+	}
+	if ok {
+		t.Fatal("nil reader must fail closed (not authorized)")
+	}
+}
+
+func TestNewEdgeTierChecker_DefaultsToConfig(t *testing.T) {
+	id := nodeIDFromByte(0x09)
+	chk := NewEdgeTierChecker(Config{AllowedNodeIDs: []string{id.String()}}, nil)
+	if _, ok := chk.(*ConfigEdgeTierChecker); !ok {
+		t.Fatalf("expected ConfigEdgeTierChecker, got %T", chk)
+	}
+	ok, _ := chk.IsEdgeAuthorized(context.Background(), id, common.Address{})
+	if !ok {
+		t.Fatal("config checker should authorize allowlisted node")
+	}
+}
+
+func TestNewEdgeTierChecker_OnChainSelected(t *testing.T) {
+	chk := NewEdgeTierChecker(Config{Mode: ModeOnChain}, fakeRegistryReader{})
+	if _, ok := chk.(*OnChainEdgeTierChecker); !ok {
+		t.Fatalf("expected OnChainEdgeTierChecker, got %T", chk)
+	}
+}
+
+func TestNewEdgeTierChecker_OnChainNilReaderFallsBackToConfig(t *testing.T) {
+	chk := NewEdgeTierChecker(Config{Mode: ModeOnChain}, nil)
+	if _, ok := chk.(*ConfigEdgeTierChecker); !ok {
+		t.Fatalf("expected fallback to ConfigEdgeTierChecker, got %T", chk)
+	}
+}
+
+func TestEdgeRegistry_RegisterAndList(t *testing.T) {
+	r := NewEdgeRegistry()
+	r.Register(EdgeNodeInfo{NodeID: nodeIDFromByte(0x01), IngressAddr: "10.0.0.1", TunnelPort: 9443})
+	r.Register(EdgeNodeInfo{NodeID: nodeIDFromByte(0x02), IngressAddr: "10.0.0.2", TunnelPort: 9443})
+	if got := len(r.ListHealthy()); got != 2 {
+		t.Fatalf("ListHealthy = %d, want 2", got)
+	}
+	info, ok := r.ByNodeID(nodeIDFromByte(0x01))
+	if !ok {
+		t.Fatal("expected node 0x01 present")
+	}
+	if info.FullAddr() != "10.0.0.1:9443" {
+		t.Fatalf("FullAddr = %q, want 10.0.0.1:9443", info.FullAddr())
+	}
+}
+
+func TestEdgeRegistry_UpdateHealth(t *testing.T) {
+	r := NewEdgeRegistry()
+	id := nodeIDFromByte(0x05)
+	r.Register(EdgeNodeInfo{NodeID: id, IngressAddr: "10.0.0.5", TunnelPort: 9443})
+	r.UpdateHealth(id, false)
+	if got := len(r.ListHealthy()); got != 0 {
+		t.Fatalf("ListHealthy after unhealthy = %d, want 0", got)
+	}
+	if got := len(r.ListAll()); got != 1 {
+		t.Fatalf("ListAll = %d, want 1", got)
+	}
+}
+
+func TestEdgeRegistry_Unregister(t *testing.T) {
+	r := NewEdgeRegistry()
+	id := nodeIDFromByte(0x07)
+	r.Register(EdgeNodeInfo{NodeID: id, IngressAddr: "10.0.0.7", TunnelPort: 9443})
+	r.Unregister(id)
+	if _, ok := r.ByNodeID(id); ok {
+		t.Fatal("expected node absent after Unregister")
+	}
+}
+
+func TestEdgeRegistry_RegisterEdgeSeam(t *testing.T) {
+	r := NewEdgeRegistry()
+	id := nodeIDFromByte(0x08)
+	r.RegisterEdge(id, "0xabc", "edge.example.com", 9443, 1000)
+	info, ok := r.ByNodeID(id)
+	if !ok {
+		t.Fatal("expected node registered via RegisterEdge")
+	}
+	if info.IngressAddr != "edge.example.com" || info.TunnelPort != 9443 {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+}
+
+func TestEdgeSelector_SelectsHealthy(t *testing.T) {
+	r := NewEdgeRegistry()
+	healthy := nodeIDFromByte(0x01)
+	unhealthy := nodeIDFromByte(0x02)
+	r.Register(EdgeNodeInfo{NodeID: healthy, IngressAddr: "10.0.0.1", TunnelPort: 9443})
+	r.Register(EdgeNodeInfo{NodeID: unhealthy, IngressAddr: "10.0.0.2", TunnelPort: 9443})
+	r.UpdateHealth(unhealthy, false)
+
+	s := NewEdgeSelector(r)
+	got, err := s.SelectEdge(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.NodeID != healthy {
+		t.Fatalf("selected %v, want healthy node", got.NodeID.String()[:8])
+	}
+}
+
+func TestEdgeSelector_LeastConnRoundRobin(t *testing.T) {
+	r := NewEdgeRegistry()
+	a := nodeIDFromByte(0x01)
+	b := nodeIDFromByte(0x02)
+	r.Register(EdgeNodeInfo{NodeID: a, IngressAddr: "10.0.0.1", TunnelPort: 9443})
+	r.Register(EdgeNodeInfo{NodeID: b, IngressAddr: "10.0.0.2", TunnelPort: 9443})
+
+	s := NewEdgeSelector(r)
+	// Two selections with equal (zero) connection counts must hit both nodes.
+	seen := map[types.NodeID]int{}
+	for i := 0; i < 2; i++ {
+		got, err := s.SelectEdge(context.Background())
+		if err != nil {
+			t.Fatalf("select %d: %v", i, err)
+		}
+		seen[got.NodeID]++
+	}
+	if seen[a] != 1 || seen[b] != 1 {
+		t.Fatalf("expected round-robin across both nodes, got %v", seen)
+	}
+	// Both now have 1 in-flight; releasing a makes it least-loaded → next pick.
+	s.Release(a)
+	got, err := s.SelectEdge(context.Background())
+	if err != nil {
+		t.Fatalf("post-release select: %v", err)
+	}
+	if got.NodeID != a {
+		t.Fatalf("expected least-loaded node a after release, got %v", got.NodeID.String()[:8])
+	}
+}
+
+func TestEdgeSelector_NoHealthyNodes(t *testing.T) {
+	r := NewEdgeRegistry()
+	s := NewEdgeSelector(r)
+	if _, err := s.SelectEdge(context.Background()); err == nil {
+		t.Fatal("expected error when no healthy edge nodes")
+	}
+}
+
+// --- EdgeProbe tests ------------------------------------------------------
+
+func selfSignedTLSConfig(t *testing.T) (*tls.Config, *tls.Config) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "edge-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCfg := &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}},
+		MinVersion:   tls.VersionTLS12,
+	}
+	// Client trusts the self-signed cert (avoids InsecureSkipVerify in tests).
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+	clientCfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+	return serverCfg, clientCfg
+}
+
+func TestEdgeProbe_MarksHealthy(t *testing.T) {
+	serverCfg, clientCfg := selfSignedTLSConfig(t)
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+	go func() {
+		for {
+			c, aerr := lis.Accept()
+			if aerr != nil {
+				return
+			}
+			_ = c.(*tls.Conn).Handshake()
+			_ = c.Close()
+		}
+	}()
+
+	port := lis.Addr().(*net.TCPAddr).Port
+	r := NewEdgeRegistry()
+	id := nodeIDFromByte(0x01)
+	r.Register(EdgeNodeInfo{NodeID: id, IngressAddr: "127.0.0.1", TunnelPort: port})
+	// Force unhealthy first so the probe must flip it back.
+	r.UpdateHealth(id, false)
+
+	p := NewEdgeProbe(r, clientCfg, 20*time.Millisecond, time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.Start(ctx)
+	defer p.Stop()
+
+	if !waitFor(2*time.Second, func() bool {
+		info, ok := r.ByNodeID(id)
+		return ok && info.Healthy
+	}) {
+		t.Fatal("probe did not mark node healthy")
+	}
+}
+
+func TestEdgeProbe_MarksUnhealthyAfterFailures(t *testing.T) {
+	_, clientCfg := selfSignedTLSConfig(t)
+	// Bind+close a listener to obtain a port that is then unreachable.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	_ = lis.Close()
+
+	r := NewEdgeRegistry()
+	id := nodeIDFromByte(0x01)
+	r.Register(EdgeNodeInfo{NodeID: id, IngressAddr: "127.0.0.1", TunnelPort: port}) // starts healthy
+
+	p := NewEdgeProbe(r, clientCfg, 15*time.Millisecond, 200*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.Start(ctx)
+	defer p.Stop()
+
+	if !waitFor(3*time.Second, func() bool {
+		info, ok := r.ByNodeID(id)
+		return ok && !info.Healthy
+	}) {
+		t.Fatal("probe did not mark unreachable node unhealthy after failures")
+	}
+}
+
+func TestMockEdgeTierChecker(t *testing.T) {
+	m := &MockEdgeTierChecker{Authorized: true}
+	if ok, _ := m.IsEdgeAuthorized(context.Background(), types.NodeID{}, common.Address{}); !ok {
+		t.Fatal("mock should return configured answer")
+	}
+}
+
+// waitFor polls cond until true or timeout. Returns whether cond became true.
+func waitFor(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}

--- a/internal/ingress/autotls.go
+++ b/internal/ingress/autotls.go
@@ -17,6 +17,12 @@ type AutoTLSConfig struct {
 	Manager  *autocert.Manager
 	domain   string
 	resolver *Resolver
+
+	// customDomains, when set, lets hostPolicy accept BYO custom hostnames that
+	// have proven DNS ownership (EDGE-02). Nil = the original behavior (only
+	// *.<domain> hosts are issued certs). Wired post-construction via
+	// SetCustomDomains so main.go can build the store after the manager.
+	customDomains *DomainOwnershipStore
 }
 
 // NewAutoTLSConfig creates an auto-TLS configuration with Let's Encrypt.
@@ -46,13 +52,32 @@ func (a *AutoTLSConfig) TLSConfig() *tls.Config {
 	return tlsCfg
 }
 
+// SetCustomDomains wires the verified-custom-domain store so hostPolicy will
+// also issue certs for BYO hostnames that proved ownership. Safe to call once
+// post-construction (EDGE-02). A nil store leaves the original policy intact.
+func (a *AutoTLSConfig) SetCustomDomains(store *DomainOwnershipStore) {
+	a.customDomains = store
+}
+
 // hostPolicy decides whether to issue a certificate for the given host.
 // It rejects bare domains, wrong domain suffixes, and subdomains that
-// don't resolve to any active service.
+// don't resolve to any active service. A verified BYO custom hostname
+// (EDGE-02) is accepted via a secondary lookup once the *.<domain> fast path
+// has been ruled out.
 func (a *AutoTLSConfig) hostPolicy(ctx context.Context, host string) error {
-	// Must be under our domain
+	// Must be under our domain — fast path, unchanged for *.<domain> hosts.
 	suffix := "." + a.domain
 	if !strings.HasSuffix(host, suffix) {
+		// Secondary path: a BYO custom hostname that proved DNS ownership.
+		// Only consulted when a custom-domain store is wired AND the host is
+		// NOT under our base domain, so existing behavior is preserved both for
+		// *.<domain> hosts and when the feature is disabled.
+		if a.customDomains != nil {
+			if _, ok := a.customDomains.LookupByHost(host); ok {
+				return nil
+			}
+			return fmt.Errorf("custom domain not verified: %s", host)
+		}
 		return fmt.Errorf("host %q is not under %s", host, a.domain)
 	}
 

--- a/internal/ingress/autotls_test.go
+++ b/internal/ingress/autotls_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHostPolicy_ValidResolving(t *testing.T) {
@@ -60,7 +61,28 @@ func TestHostPolicy_WrongDomainSuffix(t *testing.T) {
 	if err == nil {
 		t.Error("expected wrong domain suffix to be rejected")
 	}
+	// No custom-domain store wired: original "not under" semantics preserved.
 	if !strings.Contains(err.Error(), "not under") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestHostPolicy_CustomDomainVerified(t *testing.T) {
+	a := NewAutoTLSConfig(t.TempDir(), "moltbunker.dev", "test@example.com", nil)
+	store := NewDomainOwnershipStore(time.Hour)
+	store.Store("app.customer.com", "dep-123", "", MethodCNAME)
+	a.SetCustomDomains(store)
+
+	if err := a.hostPolicy(context.Background(), "app.customer.com"); err != nil {
+		t.Errorf("expected verified custom domain to be accepted, got %v", err)
+	}
+}
+
+func TestHostPolicy_CustomDomainUnverified(t *testing.T) {
+	a := NewAutoTLSConfig(t.TempDir(), "moltbunker.dev", "test@example.com", nil)
+	a.SetCustomDomains(NewDomainOwnershipStore(time.Hour)) // empty store
+
+	if err := a.hostPolicy(context.Background(), "app.customer.com"); err == nil {
+		t.Error("expected unverified custom domain to be rejected")
 	}
 }

--- a/internal/ingress/custom_domain.go
+++ b/internal/ingress/custom_domain.go
@@ -1,0 +1,318 @@
+package ingress
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// custom_domain.go implements BYO ("bring your own") custom-hostname ownership
+// verification for the edge layer (EDGE-02).
+//
+// A customer who wants app.customer.com served by moltbunker proves they
+// control the DNS for that host BEFORE the autocert hostPolicy will let Let's
+// Encrypt issue a certificate for it. Verification is a second ownership-proof
+// layer ON TOP of ACME (not a replacement for the ACME challenge): the customer
+// publishes a CNAME or TXT record carrying a per-host token derived from an
+// in-memory HMAC secret, the daemon confirms it via stdlib DNS, then persists
+// the (host -> deployment) mapping so hostPolicy and the proxy will accept it.
+//
+// This mirrors how Cloudflare Pages (CNAME) and Vercel (CNAME/TXT) verify
+// custom domains. DNS-01 ACME delegation (for wildcard custom certs) is a
+// documented follow-up; here we issue an individual LE cert per verified host.
+
+const (
+	// verifyTokenLabelPrefix is the DNS label the TXT verifier looks under:
+	// _moltbunker.<host>.
+	verifyTXTPrefix = "_moltbunker."
+	// txtRecordPrefix is the value prefix in the published TXT record.
+	txtRecordPrefix = "moltbunker-verify="
+	// defaultOwnershipTTL is the verification validity window when the config
+	// does not set one.
+	defaultOwnershipTTL = 72 * time.Hour
+)
+
+// VerifyMethod identifies which DNS proof a verifier expects.
+type VerifyMethod string
+
+const (
+	// MethodCNAME expects a CNAME from <host> to <token>.<domain>.
+	MethodCNAME VerifyMethod = "cname"
+	// MethodTXT expects a TXT record moltbunker-verify=<token> on
+	// _moltbunker.<host>.
+	MethodTXT VerifyMethod = "txt"
+)
+
+// VerifiedDomain is a persisted record that a custom host was proven to belong
+// to a deployment. All fields are public routing metadata — no secrets.
+type VerifiedDomain struct {
+	Host         string       `json:"host"`
+	DeploymentID string       `json:"deployment_id"`
+	OwnerWallet  string       `json:"owner_wallet,omitempty"`
+	Method       VerifyMethod `json:"method"`
+	VerifiedAt   time.Time    `json:"verified_at"`
+	ExpiresAt    time.Time    `json:"expires_at"`
+}
+
+// expired reports whether the record's TTL has elapsed. A zero ExpiresAt never
+// expires (TTL disabled).
+func (v VerifiedDomain) expired(now time.Time) bool {
+	return !v.ExpiresAt.IsZero() && now.After(v.ExpiresAt)
+}
+
+// DomainOwnershipStore is a thread-safe map of verified custom hosts. In-memory
+// for this PR (persistence across daemon restart is a documented follow-up);
+// the autocert DirCache still caches issued certs on disk, so a restart only
+// requires re-verifying ownership, not re-issuing certs.
+type DomainOwnershipStore struct {
+	mu      sync.RWMutex
+	domains map[string]VerifiedDomain // lowercased host -> record
+	ttl     time.Duration
+}
+
+// NewDomainOwnershipStore creates an empty store. A non-positive ttl uses the
+// 72h default; pass a negative sentinel via WithNoTTL semantics is not needed —
+// callers that want no expiry should set OwnershipTTLHours appropriately.
+func NewDomainOwnershipStore(ttl time.Duration) *DomainOwnershipStore {
+	if ttl <= 0 {
+		ttl = defaultOwnershipTTL
+	}
+	return &DomainOwnershipStore{
+		domains: make(map[string]VerifiedDomain),
+		ttl:     ttl,
+	}
+}
+
+// normalizeHost lowercases and strips a trailing dot / port so lookups are
+// stable regardless of how the Host header arrives.
+func normalizeHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.TrimSuffix(host, ".")
+}
+
+// Store records a verified custom host. VerifiedAt is stamped now and ExpiresAt
+// is set from the store TTL.
+func (s *DomainOwnershipStore) Store(host, deploymentID, ownerWallet string, method VerifyMethod) {
+	host = normalizeHost(host)
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.domains[host] = VerifiedDomain{
+		Host:         host,
+		DeploymentID: deploymentID,
+		OwnerWallet:  ownerWallet,
+		Method:       method,
+		VerifiedAt:   now,
+		ExpiresAt:    now.Add(s.ttl),
+	}
+}
+
+// StoreIfUnderCap atomically enforces the per-deployment domain cap and stores
+// the mapping under a single write lock, removing the check-then-store TOCTOU
+// that a separate CountForDeployment + Store would leave open under concurrent
+// verifies for the same deployment.
+//
+// maxPerDep <= 0 means unlimited (always stores). Re-verifying a host that is
+// already mapped to the SAME deployment never counts against the cap (it is an
+// in-place refresh). It returns the stored record and ok=false (without storing)
+// when adding a NEW host would exceed the cap.
+func (s *DomainOwnershipStore) StoreIfUnderCap(host, deploymentID, ownerWallet string, method VerifyMethod, maxPerDep int) (VerifiedDomain, bool) {
+	host = normalizeHost(host)
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if maxPerDep > 0 {
+		// A re-verify of an existing, non-expired mapping to the same deployment
+		// is an in-place refresh and must not be blocked by the cap.
+		existing, present := s.domains[host]
+		isRefresh := present && !existing.expired(now) && existing.DeploymentID == deploymentID
+		if !isRefresh {
+			n := 0
+			for _, rec := range s.domains {
+				if rec.DeploymentID == deploymentID && !rec.expired(now) {
+					n++
+				}
+			}
+			if n >= maxPerDep {
+				return VerifiedDomain{}, false
+			}
+		}
+	}
+
+	rec := VerifiedDomain{
+		Host:         host,
+		DeploymentID: deploymentID,
+		OwnerWallet:  ownerWallet,
+		Method:       method,
+		VerifiedAt:   now,
+		ExpiresAt:    now.Add(s.ttl),
+	}
+	s.domains[host] = rec
+	return rec, true
+}
+
+// LookupByHost returns the verified record for host if present and not expired.
+func (s *DomainOwnershipStore) LookupByHost(host string) (VerifiedDomain, bool) {
+	host = normalizeHost(host)
+	s.mu.RLock()
+	rec, ok := s.domains[host]
+	s.mu.RUnlock()
+	if !ok || rec.expired(time.Now()) {
+		return VerifiedDomain{}, false
+	}
+	return rec, true
+}
+
+// Remove deletes a custom-host record (operator revocation / customer offboard).
+func (s *DomainOwnershipStore) Remove(host string) {
+	host = normalizeHost(host)
+	s.mu.Lock()
+	delete(s.domains, host)
+	s.mu.Unlock()
+}
+
+// Count returns the number of (possibly expired) stored records.
+func (s *DomainOwnershipStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.domains)
+}
+
+// CountForDeployment returns the number of non-expired hosts mapped to a
+// deployment (used to enforce MaxDomainsPerDeployment).
+func (s *DomainOwnershipStore) CountForDeployment(deploymentID string) int {
+	now := time.Now()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	n := 0
+	for _, rec := range s.domains {
+		if rec.DeploymentID == deploymentID && !rec.expired(now) {
+			n++
+		}
+	}
+	return n
+}
+
+// GenerateVerificationToken derives a deterministic per-(host,deployment) proof
+// token. Binding the token to an HMAC secret prevents an attacker from
+// pre-computing a valid token for a host they do not control: only a party that
+// can publish the DNS record for the host (which they prove by doing so) AND
+// that received the token from this daemon can pass verification. The token is
+// hex(HMAC-SHA256(secret, host + "|" + deploymentID)).
+func GenerateVerificationToken(secret []byte, host, deploymentID string) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(normalizeHost(host)))
+	mac.Write([]byte("|"))
+	mac.Write([]byte(deploymentID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// resolverFunc is the minimal DNS surface the verifiers need. The stdlib
+// *net.Resolver satisfies it; tests inject a fake without a DNS library.
+type resolverFunc interface {
+	LookupCNAME(ctx context.Context, host string) (string, error)
+	LookupTXT(ctx context.Context, host string) ([]string, error)
+}
+
+// DomainVerifier proves DNS ownership of a custom host for a deployment.
+type DomainVerifier interface {
+	// Verify checks the DNS proof for host bound to deploymentID. It returns nil
+	// when ownership is proven, or an error describing the missing/incorrect
+	// record. Method reports which proof this verifier checks.
+	Verify(ctx context.Context, host, deploymentID string) error
+	Method() VerifyMethod
+}
+
+// baseVerifier holds the shared resolver + secret + expected CNAME target
+// domain (e.g. "moltbunker.dev").
+type baseVerifier struct {
+	resolver  resolverFunc
+	secret    []byte
+	verifyDom string
+}
+
+// CNAMEVerifier proves ownership by checking that <host> CNAMEs to
+// <token>.<verifyDom>.
+type CNAMEVerifier struct{ baseVerifier }
+
+// Method implements DomainVerifier.
+func (CNAMEVerifier) Method() VerifyMethod { return MethodCNAME }
+
+// Verify implements DomainVerifier for the CNAME proof.
+func (v CNAMEVerifier) Verify(ctx context.Context, host, deploymentID string) error {
+	host = normalizeHost(host)
+	token := GenerateVerificationToken(v.secret, host, deploymentID)
+	want := normalizeHost(token + "." + v.verifyDom)
+
+	cname, err := v.resolver.LookupCNAME(ctx, host)
+	if err != nil {
+		return fmt.Errorf("CNAME lookup for %q failed: %w", host, err)
+	}
+	if normalizeHost(cname) != want {
+		return fmt.Errorf("CNAME for %q is %q, expected %q", host, normalizeHost(cname), want)
+	}
+	return nil
+}
+
+// TXTVerifier proves ownership by checking for a TXT record
+// moltbunker-verify=<token> on _moltbunker.<host>.
+type TXTVerifier struct{ baseVerifier }
+
+// Method implements DomainVerifier.
+func (TXTVerifier) Method() VerifyMethod { return MethodTXT }
+
+// Verify implements DomainVerifier for the TXT proof.
+func (v TXTVerifier) Verify(ctx context.Context, host, deploymentID string) error {
+	host = normalizeHost(host)
+	token := GenerateVerificationToken(v.secret, host, deploymentID)
+	want := txtRecordPrefix + token
+
+	lookupName := verifyTXTPrefix + host
+	records, err := v.resolver.LookupTXT(ctx, lookupName)
+	if err != nil {
+		return fmt.Errorf("TXT lookup for %q failed: %w", lookupName, err)
+	}
+	for _, rec := range records {
+		if strings.TrimSpace(rec) == want {
+			return nil
+		}
+	}
+	return fmt.Errorf("no matching TXT record on %q (expected %q)", lookupName, want)
+}
+
+// NewDomainVerifier builds the verifier for the given method. An unknown method
+// defaults to CNAME. verifyDom is the base domain custom hosts CNAME to (e.g.
+// "moltbunker.dev"). resolver may be nil to use the stdlib default resolver.
+func NewDomainVerifier(method VerifyMethod, verifyDom string, secret []byte, resolver resolverFunc) DomainVerifier {
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	base := baseVerifier{resolver: resolver, secret: secret, verifyDom: verifyDom}
+	if method == MethodTXT {
+		return TXTVerifier{base}
+	}
+	return CNAMEVerifier{base}
+}
+
+// CNAMETarget returns the value a customer must set their CNAME record to for
+// the given host+deployment (shown by the challenge API).
+func CNAMETarget(secret []byte, verifyDom, host, deploymentID string) string {
+	return GenerateVerificationToken(secret, host, deploymentID) + "." + verifyDom
+}
+
+// TXTRecord returns the (name, value) pair a customer must publish for the TXT
+// proof (shown by the challenge API).
+func TXTRecord(secret []byte, host, deploymentID string) (name, value string) {
+	host = normalizeHost(host)
+	return verifyTXTPrefix + host, txtRecordPrefix + GenerateVerificationToken(secret, host, deploymentID)
+}

--- a/internal/ingress/custom_domain_api.go
+++ b/internal/ingress/custom_domain_api.go
@@ -1,0 +1,205 @@
+package ingress
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/moltbunker/moltbunker/internal/logging"
+)
+
+// custom_domain_api.go exposes the two-step BYO custom-hostname verification
+// workflow as HTTP handlers (EDGE-02). The handlers are intentionally separate
+// from the storage/verification logic so they can be unit-tested without a live
+// server. They carry NO authentication of their own — the daemon mounts them
+// behind the existing API-key middleware, and the verifier's HMAC-bound token
+// prevents a caller from claiming a host they do not control.
+//
+// Routes (mounted under a prefix by the daemon, e.g. /ingress/custom-domain/):
+//
+//	POST .../challenge  {host, deployment_id}
+//	  -> {method, token, cname_target, txt_name, txt_value}   (nothing persisted)
+//	POST .../verify     {host, deployment_id, owner_wallet?}
+//	  -> 200 {host, deployment_id, expires_at} on proof success, else 4xx
+
+const (
+	// maxCustomDomainBody bounds the request body for the verification API.
+	maxCustomDomainBody = 4 << 10 // 4 KiB
+)
+
+// challengeRequest is the body for POST .../challenge.
+type challengeRequest struct {
+	Host         string `json:"host"`
+	DeploymentID string `json:"deployment_id"`
+}
+
+// challengeResponse describes what DNS record the customer must publish.
+type challengeResponse struct {
+	Method      VerifyMethod `json:"method"`
+	Token       string       `json:"token"`
+	CNAMETarget string       `json:"cname_target,omitempty"`
+	TXTName     string       `json:"txt_name,omitempty"`
+	TXTValue    string       `json:"txt_value,omitempty"`
+}
+
+// verifyRequest is the body for POST .../verify.
+type verifyRequest struct {
+	Host         string `json:"host"`
+	DeploymentID string `json:"deployment_id"`
+	OwnerWallet  string `json:"owner_wallet,omitempty"`
+}
+
+// verifyResponse is returned on a successful proof.
+type verifyResponse struct {
+	Host         string       `json:"host"`
+	DeploymentID string       `json:"deployment_id"`
+	Method       VerifyMethod `json:"method"`
+	ExpiresAt    time.Time    `json:"expires_at"`
+}
+
+// CustomDomainHandler implements the challenge/verify workflow over HTTP.
+type CustomDomainHandler struct {
+	verifier  DomainVerifier
+	store     *DomainOwnershipStore
+	secret    []byte
+	verifyDom string
+	maxPerDep int // 0 = unlimited
+}
+
+// NewDomainVerifyHandler builds the custom-domain HTTP handler. verifyDom is the
+// base domain custom hosts CNAME to (e.g. "moltbunker.dev"); maxPerDeployment
+// caps how many hosts a single deployment may verify (0 = unlimited).
+func NewDomainVerifyHandler(verifier DomainVerifier, store *DomainOwnershipStore, secret []byte, verifyDom string, maxPerDeployment int) *CustomDomainHandler {
+	return &CustomDomainHandler{
+		verifier:  verifier,
+		store:     store,
+		secret:    secret,
+		verifyDom: verifyDom,
+		maxPerDep: maxPerDeployment,
+	}
+}
+
+// ServeHTTP routes the two sub-paths. It matches on the trailing path element so
+// the daemon can mount it under any prefix.
+func (h *CustomDomainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasSuffix(r.URL.Path, "/challenge"):
+		h.handleChallenge(w, r)
+	case strings.HasSuffix(r.URL.Path, "/verify"):
+		h.handleVerify(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// handleChallenge returns the DNS record the customer must publish. It persists
+// nothing — verification is confirmed in a later /verify call.
+func (h *CustomDomainHandler) handleChallenge(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req challengeRequest
+	if !decodeJSONBody(w, r, &req) {
+		return
+	}
+	if req.Host == "" || req.DeploymentID == "" {
+		writeJSONError(w, http.StatusBadRequest, "host and deployment_id are required")
+		return
+	}
+
+	token := GenerateVerificationToken(h.secret, req.Host, req.DeploymentID)
+	resp := challengeResponse{
+		Method: h.verifier.Method(),
+		Token:  token,
+	}
+	switch h.verifier.Method() {
+	case MethodTXT:
+		resp.TXTName, resp.TXTValue = TXTRecord(h.secret, req.Host, req.DeploymentID)
+	default:
+		resp.CNAMETarget = CNAMETarget(h.secret, h.verifyDom, req.Host, req.DeploymentID)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleVerify confirms the DNS proof and, on success, persists the mapping.
+func (h *CustomDomainHandler) handleVerify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req verifyRequest
+	if !decodeJSONBody(w, r, &req) {
+		return
+	}
+	if req.Host == "" || req.DeploymentID == "" {
+		writeJSONError(w, http.StatusBadRequest, "host and deployment_id are required")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	if err := h.verifier.Verify(ctx, req.Host, req.DeploymentID); err != nil {
+		logging.Info("custom domain verification failed",
+			"host", req.Host,
+			"deployment_id", req.DeploymentID,
+			logging.Err(err),
+			logging.Component("ingress"))
+		writeJSONError(w, http.StatusUnprocessableEntity, "ownership verification failed: "+err.Error())
+		return
+	}
+
+	// Persist the proven mapping, enforcing the per-deployment cap atomically
+	// (check + insert under a single write lock) so concurrent verifies for the
+	// same deployment cannot each slip past a separate count check. A re-verify
+	// of an already-mapped host for this deployment is an in-place refresh and
+	// is not counted against the cap.
+	rec, ok := h.store.StoreIfUnderCap(req.Host, req.DeploymentID, req.OwnerWallet, h.verifier.Method(), h.maxPerDep)
+	if !ok {
+		writeJSONError(w, http.StatusConflict, "custom domain limit reached for deployment")
+		return
+	}
+	logging.Info("custom domain verified",
+		"host", req.Host,
+		"deployment_id", req.DeploymentID,
+		"method", string(h.verifier.Method()),
+		logging.Component("ingress"))
+	writeJSON(w, http.StatusOK, verifyResponse{
+		Host:         rec.Host,
+		DeploymentID: rec.DeploymentID,
+		Method:       rec.Method,
+		ExpiresAt:    rec.ExpiresAt,
+	})
+}
+
+// decodeJSONBody reads and unmarshals a size-limited JSON body, writing a 400
+// on failure. It reports whether decoding succeeded.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) bool {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCustomDomainBody))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return false
+	}
+	if err := json.Unmarshal(body, dst); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return false
+	}
+	return true
+}
+
+// writeJSON writes a JSON response with the given status.
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeJSONError writes a {"error": msg} body with the given status.
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/ingress/custom_domain_api_test.go
+++ b/internal/ingress/custom_domain_api_test.go
@@ -1,0 +1,120 @@
+package ingress
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestAPIHandler(t *testing.T, resolver resolverFunc, method VerifyMethod, maxPerDep int) (*CustomDomainHandler, *DomainOwnershipStore) {
+	t.Helper()
+	store := NewDomainOwnershipStore(time.Hour)
+	verifier := NewDomainVerifier(method, "moltbunker.dev", testSecret, resolver)
+	return NewDomainVerifyHandler(verifier, store, testSecret, "moltbunker.dev", maxPerDep), store
+}
+
+func TestDomainAPI_Challenge_CNAME(t *testing.T) {
+	h, _ := newTestAPIHandler(t, fakeResolver{}, MethodCNAME, 0)
+	body := `{"host":"app.customer.com","deployment_id":"dep-123"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/ingress/custom-domain/challenge", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp challengeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Method != MethodCNAME || resp.CNAMETarget == "" {
+		t.Fatalf("unexpected challenge response: %+v", resp)
+	}
+}
+
+func TestDomainAPI_Verify_Success(t *testing.T) {
+	host, dep := "app.customer.com", "dep-123"
+	target := CNAMETarget(testSecret, "moltbunker.dev", host, dep)
+	h, store := newTestAPIHandler(t, fakeResolver{cname: target}, MethodCNAME, 0)
+
+	body := `{"host":"app.customer.com","deployment_id":"dep-123","owner_wallet":"0xabc"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/ingress/custom-domain/verify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if _, ok := store.LookupByHost(host); !ok {
+		t.Fatal("verified host not persisted to store")
+	}
+}
+
+func TestDomainAPI_Verify_Failure(t *testing.T) {
+	h, store := newTestAPIHandler(t, fakeResolver{cname: "wrong.moltbunker.dev"}, MethodCNAME, 0)
+	body := `{"host":"app.customer.com","deployment_id":"dep-123"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/ingress/custom-domain/verify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if store.Count() != 0 {
+		t.Fatal("failed verification must not persist")
+	}
+}
+
+func TestDomainAPI_Verify_PerDeploymentCap(t *testing.T) {
+	// maxPerDep=1; first host succeeds, second host for same deployment is capped.
+	h, store := newTestAPIHandler(t, fakeResolver{}, MethodCNAME, 1)
+	// Pre-seed one verified host for dep-123.
+	store.Store("a.customer.com", "dep-123", "", MethodCNAME)
+
+	// Point the verifier's resolver at the correct target for b.customer.com so
+	// the only reason to reject is the cap, not the DNS proof.
+	target := CNAMETarget(testSecret, "moltbunker.dev", "b.customer.com", "dep-123")
+	h.verifier = NewDomainVerifier(MethodCNAME, "moltbunker.dev", testSecret, fakeResolver{cname: target})
+
+	body := `{"host":"b.customer.com","deployment_id":"dep-123"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/ingress/custom-domain/verify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (cap); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDomainAPI_MethodNotAllowed(t *testing.T) {
+	h, _ := newTestAPIHandler(t, fakeResolver{}, MethodCNAME, 0)
+	req := httptest.NewRequest(http.MethodGet, "/v1/ingress/custom-domain/challenge", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestDomainAPI_BadRequest(t *testing.T) {
+	h, _ := newTestAPIHandler(t, fakeResolver{}, MethodCNAME, 0)
+	req := httptest.NewRequest(http.MethodPost, "/v1/ingress/custom-domain/challenge", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// Ensure the verifier honors context (smoke test the ctx plumbing compiles/runs).
+func TestDomainVerifier_ContextWired(t *testing.T) {
+	host, dep := "app.customer.com", "dep-123"
+	target := CNAMETarget(testSecret, "moltbunker.dev", host, dep)
+	v := NewDomainVerifier(MethodCNAME, "moltbunker.dev", testSecret, fakeResolver{cname: target})
+	if err := v.Verify(context.Background(), host, dep); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}

--- a/internal/ingress/custom_domain_test.go
+++ b/internal/ingress/custom_domain_test.go
@@ -1,0 +1,225 @@
+package ingress
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeResolver is an injectable resolverFunc for DNS proof tests (no real DNS).
+type fakeResolver struct {
+	cname    string
+	cnameErr error
+	txt      []string
+	txtErr   error
+}
+
+func (f fakeResolver) LookupCNAME(_ context.Context, _ string) (string, error) {
+	return f.cname, f.cnameErr
+}
+func (f fakeResolver) LookupTXT(_ context.Context, _ string) ([]string, error) {
+	return f.txt, f.txtErr
+}
+
+var testSecret = []byte("edge-02-test-hmac-secret-not-a-real-credential")
+
+func TestGenerateVerificationToken_Deterministic(t *testing.T) {
+	a := GenerateVerificationToken(testSecret, "app.customer.com", "dep-123")
+	b := GenerateVerificationToken(testSecret, "app.customer.com", "dep-123")
+	if a != b {
+		t.Fatalf("token not deterministic: %q != %q", a, b)
+	}
+	if a == "" {
+		t.Fatal("token must not be empty")
+	}
+}
+
+func TestGenerateVerificationToken_DifferentInputsDiffer(t *testing.T) {
+	base := GenerateVerificationToken(testSecret, "app.customer.com", "dep-123")
+	if GenerateVerificationToken(testSecret, "evil.customer.com", "dep-123") == base {
+		t.Fatal("different host produced same token")
+	}
+	if GenerateVerificationToken(testSecret, "app.customer.com", "dep-999") == base {
+		t.Fatal("different deployment produced same token")
+	}
+	if GenerateVerificationToken([]byte("other-secret"), "app.customer.com", "dep-123") == base {
+		t.Fatal("different secret produced same token")
+	}
+}
+
+func TestCNAMEVerifier_Accept(t *testing.T) {
+	host := "app.customer.com"
+	dep := "dep-123"
+	target := CNAMETarget(testSecret, "moltbunker.dev", host, dep) + "." // trailing dot like real CNAME
+	v := NewDomainVerifier(MethodCNAME, "moltbunker.dev", testSecret, fakeResolver{cname: target})
+	if err := v.Verify(context.Background(), host, dep); err != nil {
+		t.Fatalf("expected accept, got %v", err)
+	}
+	if v.Method() != MethodCNAME {
+		t.Fatalf("Method = %q", v.Method())
+	}
+}
+
+func TestCNAMEVerifier_WrongTarget(t *testing.T) {
+	v := NewDomainVerifier(MethodCNAME, "moltbunker.dev", testSecret, fakeResolver{cname: "wrong.moltbunker.dev."})
+	if err := v.Verify(context.Background(), "app.customer.com", "dep-123"); err == nil {
+		t.Fatal("expected error for wrong CNAME target")
+	}
+}
+
+func TestCNAMEVerifier_LookupError(t *testing.T) {
+	v := NewDomainVerifier(MethodCNAME, "moltbunker.dev", testSecret, fakeResolver{cnameErr: errors.New("nxdomain")})
+	if err := v.Verify(context.Background(), "app.customer.com", "dep-123"); err == nil {
+		t.Fatal("expected lookup error to propagate")
+	}
+}
+
+func TestTXTVerifier_Accept(t *testing.T) {
+	host := "app.customer.com"
+	dep := "dep-123"
+	_, value := TXTRecord(testSecret, host, dep)
+	v := NewDomainVerifier(MethodTXT, "moltbunker.dev", testSecret, fakeResolver{txt: []string{"unrelated", value}})
+	if err := v.Verify(context.Background(), host, dep); err != nil {
+		t.Fatalf("expected accept, got %v", err)
+	}
+	if v.Method() != MethodTXT {
+		t.Fatalf("Method = %q", v.Method())
+	}
+}
+
+func TestTXTVerifier_MissingRecord(t *testing.T) {
+	v := NewDomainVerifier(MethodTXT, "moltbunker.dev", testSecret, fakeResolver{txt: []string{"some-other-record"}})
+	if err := v.Verify(context.Background(), "app.customer.com", "dep-123"); err == nil {
+		t.Fatal("expected error when TXT record missing")
+	}
+}
+
+func TestDomainOwnershipStore_StoreAndLookup(t *testing.T) {
+	s := NewDomainOwnershipStore(time.Hour)
+	s.Store("App.Customer.com", "dep-123", "0xwallet", MethodCNAME)
+	rec, ok := s.LookupByHost("app.customer.com") // case-insensitive
+	if !ok {
+		t.Fatal("expected lookup hit")
+	}
+	if rec.DeploymentID != "dep-123" {
+		t.Fatalf("DeploymentID = %q", rec.DeploymentID)
+	}
+	// Lookup with port should normalize.
+	if _, ok := s.LookupByHost("app.customer.com:443"); !ok {
+		t.Fatal("expected lookup hit with port")
+	}
+}
+
+func TestDomainOwnershipStore_Expiry(t *testing.T) {
+	s := NewDomainOwnershipStore(time.Hour)
+	// Manually insert an already-expired record.
+	s.mu.Lock()
+	s.domains["expired.customer.com"] = VerifiedDomain{
+		Host:         "expired.customer.com",
+		DeploymentID: "dep-x",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	}
+	s.mu.Unlock()
+	if _, ok := s.LookupByHost("expired.customer.com"); ok {
+		t.Fatal("expired record must not be returned")
+	}
+}
+
+func TestDomainOwnershipStore_Remove(t *testing.T) {
+	s := NewDomainOwnershipStore(time.Hour)
+	s.Store("app.customer.com", "dep-1", "", MethodCNAME)
+	s.Remove("app.customer.com")
+	if _, ok := s.LookupByHost("app.customer.com"); ok {
+		t.Fatal("record should be gone after Remove")
+	}
+}
+
+func TestDomainOwnershipStore_CountForDeployment(t *testing.T) {
+	s := NewDomainOwnershipStore(time.Hour)
+	s.Store("a.customer.com", "dep-1", "", MethodCNAME)
+	s.Store("b.customer.com", "dep-1", "", MethodCNAME)
+	s.Store("c.customer.com", "dep-2", "", MethodCNAME)
+	if got := s.CountForDeployment("dep-1"); got != 2 {
+		t.Fatalf("CountForDeployment(dep-1) = %d, want 2", got)
+	}
+}
+
+func TestStoreIfUnderCap_EnforcesCap(t *testing.T) {
+	s := NewDomainOwnershipStore(time.Hour)
+	if _, ok := s.StoreIfUnderCap("a.customer.com", "dep-1", "", MethodCNAME, 1); !ok {
+		t.Fatal("first host under cap should store")
+	}
+	if _, ok := s.StoreIfUnderCap("b.customer.com", "dep-1", "", MethodCNAME, 1); ok {
+		t.Fatal("second host for same deployment must be capped")
+	}
+	// A different deployment is unaffected by dep-1's cap.
+	if _, ok := s.StoreIfUnderCap("c.customer.com", "dep-2", "", MethodCNAME, 1); !ok {
+		t.Fatal("different deployment must not be capped by dep-1")
+	}
+}
+
+func TestStoreIfUnderCap_RefreshNotCounted(t *testing.T) {
+	s := NewDomainOwnershipStore(time.Hour)
+	if _, ok := s.StoreIfUnderCap("a.customer.com", "dep-1", "", MethodCNAME, 1); !ok {
+		t.Fatal("first store should succeed")
+	}
+	// Re-verifying the SAME host for the SAME deployment is an in-place refresh
+	// and must not be blocked by the cap.
+	if _, ok := s.StoreIfUnderCap("a.customer.com", "dep-1", "0xnew", MethodCNAME, 1); !ok {
+		t.Fatal("re-verify of existing host must not be capped")
+	}
+	if s.CountForDeployment("dep-1") != 1 {
+		t.Fatalf("refresh must not increase count, got %d", s.CountForDeployment("dep-1"))
+	}
+}
+
+func TestStoreIfUnderCap_Unlimited(t *testing.T) {
+	s := NewDomainOwnershipStore(time.Hour)
+	for _, h := range []string{"a.c.com", "b.c.com", "c.c.com"} {
+		if _, ok := s.StoreIfUnderCap(h, "dep-1", "", MethodCNAME, 0); !ok {
+			t.Fatalf("maxPerDep=0 (unlimited) should always store, failed on %s", h)
+		}
+	}
+	if s.CountForDeployment("dep-1") != 3 {
+		t.Fatalf("unlimited cap: count = %d, want 3", s.CountForDeployment("dep-1"))
+	}
+}
+
+// TestStoreIfUnderCap_AtomicNoTOCTOU hammers the same deployment from many
+// goroutines with a cap of N and asserts the cap is never exceeded — proving
+// the check+insert is atomic (a separate Count+Store would let multiple
+// concurrent callers slip past).
+func TestStoreIfUnderCap_AtomicNoTOCTOU(t *testing.T) {
+	const cap = 5
+	const goroutines = 64
+	s := NewDomainOwnershipStore(time.Hour)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	stored := 0
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		host := "host" + string(rune('a'+i%26)) + string(rune('0'+i/26)) + ".customer.com"
+		go func(h string) {
+			defer wg.Done()
+			<-start
+			if _, ok := s.StoreIfUnderCap(h, "dep-race", "", MethodCNAME, cap); ok {
+				mu.Lock()
+				stored++
+				mu.Unlock()
+			}
+		}(host)
+	}
+	close(start)
+	wg.Wait()
+
+	if stored > cap {
+		t.Fatalf("cap exceeded under concurrency: stored %d > cap %d", stored, cap)
+	}
+	if got := s.CountForDeployment("dep-race"); got > cap {
+		t.Fatalf("store holds %d > cap %d", got, cap)
+	}
+}

--- a/internal/ingress/proxy.go
+++ b/internal/ingress/proxy.go
@@ -37,6 +37,19 @@ type Proxy struct {
 	// middleware is the optional L7 edge chain (WAF + abuse limits + metrics).
 	// When nil the request path is unchanged (zero overhead). EDGE-01.
 	middleware *IngressMiddleware
+
+	// customDomains, when set, routes verified BYO custom hostnames (e.g.
+	// app.customer.com) to their deployment alongside *.<domain> traffic.
+	// Nil = the original behavior (only *.<domain> Host headers are routed).
+	// EDGE-02.
+	customDomains *DomainOwnershipStore
+
+	// blocklist, when set, is the operator takedown kill-switch consulted on
+	// EVERY request before routing. It is checked at the ingress proxy itself
+	// (not only inside the reverse tunnel) so a takedown reliably severs a live
+	// deployment regardless of whether it is served via the forward or reverse
+	// path. EDGE-02.
+	blocklist tunnel.BlocklistChecker
 }
 
 // NewProxy creates a new ingress proxy.
@@ -84,6 +97,59 @@ func (p *Proxy) SetMiddleware(m *IngressMiddleware) {
 	p.middleware = m
 }
 
+// SetCustomDomains wires the verified-custom-domain store so the proxy will
+// route BYO hostnames (e.g. app.customer.com) to their mapped deployment.
+// When nil the routing path is unchanged (only *.<domain> Host headers are
+// served). EDGE-02.
+func (p *Proxy) SetCustomDomains(store *DomainOwnershipStore) {
+	p.customDomains = store
+}
+
+// SetBlocklist wires the operator takedown kill-switch. When set, every
+// incoming request is checked against the blocklist BEFORE routing — by both
+// the original Host header (the natural custom-domain takedown target) and the
+// resolved subdomain / deployment ID — and a blocked request gets a 403.
+//
+// This enforces the takedown at the ingress proxy itself, so the forward-tunnel
+// serving path (resolver -> tunnelClient.OpenTunnel) and verified custom hosts
+// are covered, not just the reverse-tunnel registration/stream-open path.
+// When nil, no takedown enforcement happens at the proxy layer. EDGE-02.
+func (p *Proxy) SetBlocklist(bl tunnel.BlocklistChecker) {
+	p.blocklist = bl
+}
+
+// isBlocked reports whether any of the given identifiers is on the takedown
+// blocklist, returning the first match's operator reason. Empty identifiers are
+// skipped. When no blocklist is wired it always returns false.
+func (p *Proxy) isBlocked(ids ...string) (bool, string) {
+	if p.blocklist == nil {
+		return false, ""
+	}
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if blocked, reason := p.blocklist.IsBlocked(id); blocked {
+			return true, reason
+		}
+	}
+	return false, ""
+}
+
+// resolveCustomDomain looks up a verified BYO host and returns its deployment
+// ID for routing. Returns "" when no custom-domain store is wired or the host
+// is not a verified custom domain.
+func (p *Proxy) resolveCustomDomain(host string) string {
+	if p.customDomains == nil {
+		return ""
+	}
+	rec, ok := p.customDomains.LookupByHost(host)
+	if !ok {
+		return ""
+	}
+	return rec.DeploymentID
+}
+
 // acquireWebSocket applies the WebSocket-compatible abuse gates (per-tenant
 // rate + concurrency) via the installed middleware and returns a release
 // closure to hold for the connection's lifetime. When no middleware is
@@ -116,10 +182,39 @@ func (p *Proxy) Shutdown(ctx context.Context) error {
 // It extracts the subdomain from the Host header, resolves the service
 // (by deployment ID prefix or vanity name), opens a tunnel, and proxies.
 func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
+	// Strip any client-supplied X-Moltbunker-* control headers before routing.
+	// These are proxy-internal signals; a client must never be able to forge
+	// them (e.g. spoof the "verified custom domain" marker) or leak them to a
+	// tenant backend. The trusted markers are derived below and passed down as
+	// typed arguments, never via the request header. EDGE-02.
+	stripInternalHeaders(r)
+
 	// Extract subdomain from Host header
+	customDomain := false
+	originalHost := r.Host
 	subdomain := p.extractSubdomain(r.Host)
 	if subdomain == "" {
-		http.Error(w, "invalid host", http.StatusBadRequest)
+		// Not a *.<domain> host. It may be a verified BYO custom domain
+		// (EDGE-02) whose Host header is the customer's own hostname; route it
+		// via its mapped deployment ID. The deployment ID resolves through the
+		// same forward-tunnel / reverse-tunnel path as a normal subdomain.
+		if depID := p.resolveCustomDomain(r.Host); depID != "" {
+			customDomain = true
+			subdomain = depID
+		} else {
+			http.Error(w, "invalid host", http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Operator takedown kill-switch, enforced at the ingress proxy on EVERY
+	// request (forward AND reverse paths) before any routing. Check both the
+	// original Host header (the natural custom-domain takedown target,
+	// app.customer.com) and the resolved subdomain / deployment ID, so a
+	// takedown reliably severs the deployment no matter how it was addressed.
+	// EDGE-02.
+	if blocked, _ := p.isBlocked(originalHost, subdomain); blocked {
+		http.Error(w, "service unavailable", http.StatusForbidden)
 		return
 	}
 
@@ -130,19 +225,30 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	// dispatchRequest.
 	if p.middleware != nil && !isWebSocketUpgrade(r) {
 		p.middleware.Wrap(subdomain, http.HandlerFunc(func(mw http.ResponseWriter, mr *http.Request) {
-			p.dispatchRequest(mw, mr, subdomain)
+			p.dispatchRequest(mw, mr, subdomain, customDomain)
 		})).ServeHTTP(w, r)
 		return
 	}
 
-	p.dispatchRequest(w, r, subdomain)
+	p.dispatchRequest(w, r, subdomain, customDomain)
+}
+
+// stripInternalHeaders removes any client-supplied X-Moltbunker-* control
+// headers from the inbound request so they cannot be forged or leaked to tenant
+// backends. The proxy sets its own response markers from trusted state. EDGE-02.
+func stripInternalHeaders(r *http.Request) {
+	for k := range r.Header {
+		if strings.HasPrefix(http.CanonicalHeaderKey(k), "X-Moltbunker-") {
+			r.Header.Del(k)
+		}
+	}
 }
 
 // dispatchRequest resolves the service for subdomain and proxies the request to
 // the provider via a forward tunnel, falling back to the reverse tunnel
 // registry. This is the original handleRequest body, extracted so the edge
 // middleware can wrap it. Behavior is unchanged when middleware is nil.
-func (p *Proxy) dispatchRequest(w http.ResponseWriter, r *http.Request, subdomain string) {
+func (p *Proxy) dispatchRequest(w http.ResponseWriter, r *http.Request, subdomain string, customDomain bool) {
 	// Resolve service location (prefix match or vanity name)
 	service, err := p.resolver.Resolve(subdomain)
 	if err != nil {
@@ -161,7 +267,7 @@ func (p *Proxy) dispatchRequest(w http.ResponseWriter, r *http.Request, subdomai
 					}
 					return
 				}
-				p.proxyHTTPViaStream(w, r, stream, subdomain)
+				p.proxyHTTPViaStream(w, r, stream, subdomain, customDomain)
 				return
 			}
 		}
@@ -201,7 +307,7 @@ func (p *Proxy) dispatchRequest(w http.ResponseWriter, r *http.Request, subdomai
 		return
 	}
 
-	p.proxyHTTP(w, r, tun, service)
+	p.proxyHTTP(w, r, tun, service, customDomain)
 }
 
 // extractSubdomain parses the deployment ID from the Host header.
@@ -227,7 +333,9 @@ func (p *Proxy) extractSubdomain(host string) string {
 }
 
 // proxyHTTP forwards an HTTP request through the tunnel and relays the response.
-func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request, tun tunnel.Tunnel, service *ServiceEntry) {
+// customDomain is the trusted "request arrived on a verified BYO host" signal,
+// derived from resolveCustomDomain (never from a client header). EDGE-02.
+func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request, tun tunnel.Tunnel, service *ServiceEntry, customDomain bool) {
 	// Write the HTTP request through the tunnel connection
 	if err := r.Write(tun); err != nil {
 		http.Error(w, "proxy write failed", http.StatusBadGateway)
@@ -264,6 +372,9 @@ func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request, tun tunnel.Tun
 	// Add proxy identification headers
 	w.Header().Set("X-Moltbunker-Provider", service.ProviderNodeID)
 	w.Header().Set("X-Moltbunker-Deployment", service.DeploymentID)
+	if customDomain {
+		w.Header().Set("X-Moltbunker-CustomDomain", "true")
+	}
 
 	w.WriteHeader(resp.StatusCode)
 
@@ -286,7 +397,9 @@ func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request, tun tunnel.Tun
 }
 
 // proxyHTTPViaStream forwards an HTTP request through a reverse tunnel yamux stream.
-func (p *Proxy) proxyHTTPViaStream(w http.ResponseWriter, r *http.Request, stream net.Conn, subdomain string) {
+// customDomain is the trusted "request arrived on a verified BYO host" signal,
+// derived from resolveCustomDomain (never from a client header). EDGE-02.
+func (p *Proxy) proxyHTTPViaStream(w http.ResponseWriter, r *http.Request, stream net.Conn, subdomain string, customDomain bool) {
 	// Write the HTTP request through the stream
 	if err := r.Write(stream); err != nil {
 		http.Error(w, "proxy write failed", http.StatusBadGateway)
@@ -319,6 +432,9 @@ func (p *Proxy) proxyHTTPViaStream(w http.ResponseWriter, r *http.Request, strea
 	w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
 	w.Header().Set("X-Moltbunker-Tunnel", "reverse")
 	w.Header().Set("X-Moltbunker-Subdomain", subdomain)
+	if customDomain {
+		w.Header().Set("X-Moltbunker-CustomDomain", "true")
+	}
 
 	w.WriteHeader(resp.StatusCode)
 

--- a/internal/ingress/proxy_test.go
+++ b/internal/ingress/proxy_test.go
@@ -1,0 +1,200 @@
+package ingress
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/moltbunker/moltbunker/internal/tunnel"
+)
+
+// newBlockTestProxy builds a Proxy with an empty resolver (no registered
+// services) and a wired blocklist. The forward-path takedown check in
+// handleRequest fires before any tunnel dial, so a nil tunnel client is fine
+// for asserting the 403 short-circuit.
+func newBlockTestProxy(t *testing.T, bl tunnel.BlocklistChecker, cd *DomainOwnershipStore) *Proxy {
+	t.Helper()
+	resolver := NewResolver(nil, nil)
+	p := NewProxy(resolver, nil, "moltbunker.dev")
+	p.SetBlocklist(bl)
+	if cd != nil {
+		p.SetCustomDomains(cd)
+	}
+	return p
+}
+
+// TestProxy_Blocklist_SubdomainForwardPath asserts that a blocked subdomain is
+// rejected with 403 at the ingress proxy itself — i.e. on the primary forward
+// path, before resolver.Resolve / OpenTunnel are ever consulted. EDGE-02.
+func TestProxy_Blocklist_SubdomainForwardPath(t *testing.T) {
+	bl := tunnel.NewBlocklist()
+	bl.Block("a1b2c3d4", "abuse")
+	p := newBlockTestProxy(t, bl, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "http://a1b2c3d4.moltbunker.dev/", nil)
+	rec := httptest.NewRecorder()
+	p.handleRequest(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("blocked subdomain: status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestProxy_Blocklist_CustomHost asserts that blocking the customer's OWN
+// hostname (the natural takedown target) severs the deployment on the forward
+// path, even though routing internally keys on the deployment ID. EDGE-02.
+func TestProxy_Blocklist_CustomHost(t *testing.T) {
+	cd := NewDomainOwnershipStore(time.Hour)
+	cd.Store("app.customer.com", "dep-abc12345", "", MethodCNAME)
+
+	bl := tunnel.NewBlocklist()
+	bl.Block("app.customer.com", "DMCA") // block by custom host, not deployment ID
+	p := newBlockTestProxy(t, bl, cd)
+
+	req := httptest.NewRequest(http.MethodGet, "http://app.customer.com/", nil)
+	req.Host = "app.customer.com"
+	rec := httptest.NewRecorder()
+	p.handleRequest(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("blocked custom host: status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestProxy_Blocklist_NotBlockedPassesThrough confirms a non-blocked request is
+// NOT short-circuited by the takedown check (it proceeds to routing and fails
+// with the normal not-found, proving the 403 is specific to blocked hosts).
+func TestProxy_Blocklist_NotBlockedPassesThrough(t *testing.T) {
+	bl := tunnel.NewBlocklist()
+	bl.Block("someoneelse", "abuse")
+	p := newBlockTestProxy(t, bl, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "http://a1b2c3d4.moltbunker.dev/", nil)
+	rec := httptest.NewRecorder()
+	p.handleRequest(rec, req)
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("non-blocked subdomain must not be 403; got %d", rec.Code)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-blocked, unresolvable subdomain: status = %d, want 404", rec.Code)
+	}
+}
+
+// TestProxy_NilBlocklistIsNoop confirms the seam is optional: with no blocklist
+// wired, requests are never rejected by the takedown check.
+func TestProxy_NilBlocklistIsNoop(t *testing.T) {
+	p := newBlockTestProxy(t, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "http://a1b2c3d4.moltbunker.dev/", nil)
+	rec := httptest.NewRecorder()
+	p.handleRequest(rec, req)
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("nil blocklist must not 403; got %d", rec.Code)
+	}
+}
+
+// TestStripInternalHeaders confirms every client-supplied X-Moltbunker-* header
+// is removed at ingress so it can neither be forged nor leaked to a backend.
+func TestStripInternalHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://a1b2c3d4.moltbunker.dev/", nil)
+	req.Header.Set("X-Moltbunker-CustomDomain", "true")
+	req.Header.Set("X-Moltbunker-Provider", "evil")
+	req.Header.Set("x-moltbunker-deployment", "spoofed") // lowercase variant
+	req.Header.Set("X-Real-Header", "keep")
+
+	stripInternalHeaders(req)
+
+	for k := range req.Header {
+		if strings.HasPrefix(http.CanonicalHeaderKey(k), "X-Moltbunker-") {
+			t.Fatalf("internal header %q was not stripped", k)
+		}
+	}
+	if req.Header.Get("X-Real-Header") != "keep" {
+		t.Fatal("non-internal header was incorrectly stripped")
+	}
+}
+
+// fakeReverseOpener returns one end of a pipe; the test writes a canned HTTP
+// response on the other end so the forward/reverse proxy code can read it.
+type fakeReverseOpener struct {
+	t        *testing.T
+	gotReqCh chan *http.Request
+}
+
+func (f fakeReverseOpener) OpenStream(string) (net.Conn, error) {
+	client, server := net.Pipe()
+	go func() {
+		// Read the proxied request off the stream so we can assert on it.
+		br := bufio.NewReader(server)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			_ = server.Close()
+			return
+		}
+		f.gotReqCh <- req
+		// Write a minimal HTTP/1.1 response back.
+		_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi"))
+		_ = server.Close()
+	}()
+	return client, nil
+}
+
+// TestProxy_ForgedCustomDomainHeader_NotReflected proves that a client sending
+// X-Moltbunker-CustomDomain: true on a normal *.moltbunker.dev request (a) does
+// NOT get the "verified custom domain" marker stamped on the response, and (b)
+// does not leak the forged control header to the backend. EDGE-02.
+func TestProxy_ForgedCustomDomainHeader_NotReflected(t *testing.T) {
+	gotReqCh := make(chan *http.Request, 1)
+	p := newBlockTestProxy(t, nil, nil)
+	p.SetReverseStreamOpener(fakeReverseOpener{t: t, gotReqCh: gotReqCh})
+
+	req := httptest.NewRequest(http.MethodGet, "http://a1b2c3d4.moltbunker.dev/", nil)
+	req.Header.Set("X-Moltbunker-CustomDomain", "true") // forged by client
+	rec := httptest.NewRecorder()
+	p.handleRequest(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if v := rec.Header().Get("X-Moltbunker-CustomDomain"); v != "" {
+		t.Fatalf("forged custom-domain marker reflected to response: %q", v)
+	}
+
+	select {
+	case backendReq := <-gotReqCh:
+		if v := backendReq.Header.Get("X-Moltbunker-CustomDomain"); v != "" {
+			t.Fatalf("forged control header leaked to backend: %q", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("backend did not receive proxied request")
+	}
+}
+
+// TestProxy_VerifiedCustomDomain_MarkerSet proves the marker IS set on the
+// response for a genuine verified BYO host (trusted resolveCustomDomain branch),
+// confirming the signal is driven by trusted state, not a request header.
+func TestProxy_VerifiedCustomDomain_MarkerSet(t *testing.T) {
+	cd := NewDomainOwnershipStore(time.Hour)
+	cd.Store("app.customer.com", "dep-abc12345", "", MethodCNAME)
+
+	gotReqCh := make(chan *http.Request, 1)
+	p := newBlockTestProxy(t, nil, cd)
+	p.SetReverseStreamOpener(fakeReverseOpener{t: t, gotReqCh: gotReqCh})
+
+	req := httptest.NewRequest(http.MethodGet, "http://app.customer.com/", nil)
+	req.Host = "app.customer.com"
+	rec := httptest.NewRecorder()
+	p.handleRequest(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if v := rec.Header().Get("X-Moltbunker-CustomDomain"); v != "true" {
+		t.Fatalf("verified custom-domain marker not set on response: %q", v)
+	}
+	<-gotReqCh // drain
+}

--- a/internal/payment/edge_registry.go
+++ b/internal/payment/edge_registry.go
@@ -1,0 +1,251 @@
+package payment
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// EdgeRegistryABI is the minimal read-only ABI for the BunkerEdgeRegistry
+// contract. It contains only the two view functions EDGE-02 needs
+// (isActiveEdgeProvider, getEdgeProviderInfo). Keeping the surface tiny avoids
+// coupling the daemon to the full contract ABI.
+// #nosec G101 -- not a credential: this is a Solidity contract ABI (JSON interface definition)
+const EdgeRegistryABI = `[
+	{
+		"inputs": [{"name": "provider", "type": "address"}],
+		"name": "isActiveEdgeProvider",
+		"outputs": [{"name": "active", "type": "bool"}],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [{"name": "provider", "type": "address"}],
+		"name": "getEdgeProviderInfo",
+		"outputs": [
+			{
+				"name": "info",
+				"type": "tuple",
+				"components": [
+					{"name": "nodeId", "type": "bytes32"},
+					{"name": "region", "type": "bytes32"},
+					{"name": "registeredAt", "type": "uint48"},
+					{"name": "active", "type": "bool"},
+					{"name": "frozen", "type": "bool"},
+					{"name": "endpointURL", "type": "string"},
+					{"name": "tlsPubkeyHash", "type": "bytes"}
+				]
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]`
+
+// EdgeProviderData is the daemon-side representation of an edge provider's
+// on-chain registration metadata. It mirrors BunkerEdgeRegistry.EdgeProviderInfo
+// but uses Go-native types.
+type EdgeProviderData struct {
+	NodeID        [32]byte
+	Region        [32]byte
+	EndpointURL   string
+	TLSPubkeyHash []byte
+	RegisteredAt  time.Time
+	Active        bool
+	Frozen        bool
+}
+
+// EdgeRegistryReader is the read-only seam EDGE-02 consumes to gate reverse
+// tunnels on edge-provider registration. Both the production contract reader
+// and the in-memory mock implement it, so EDGE-02 can be developed and tested
+// on darwin without a deployed contract.
+type EdgeRegistryReader interface {
+	// IsActiveEdgeProvider reports whether the address is a registered,
+	// active, and unfrozen edge provider.
+	IsActiveEdgeProvider(ctx context.Context, addr common.Address) (bool, error)
+
+	// GetEdgeProviderInfo returns the edge provider's metadata. For an
+	// unregistered address it returns (nil, nil) rather than an error.
+	GetEdgeProviderInfo(ctx context.Context, addr common.Address) (*EdgeProviderData, error)
+}
+
+// edgeProviderInfoTuple matches the on-chain getEdgeProviderInfo tuple return
+// for ABI decoding. The field order and Go types must mirror the tuple
+// components positionally — go-ethereum copies the decoded tuple into this
+// struct field-by-field (see edgeInfoResult), so no `abi` struct tags are
+// required; uint48 registeredAt decodes to *big.Int.
+type edgeProviderInfoTuple struct {
+	NodeId        [32]byte
+	Region        [32]byte
+	RegisteredAt  *big.Int
+	Active        bool
+	Frozen        bool
+	EndpointURL   string
+	TlsPubkeyHash []byte
+}
+
+// EdgeRegistryContract is the production EdgeRegistryReader backed by an on-chain
+// BunkerEdgeRegistry deployment. The contract address is supplied at runtime
+// (from config), never hard-coded.
+type EdgeRegistryContract struct {
+	baseClient   *BaseClient
+	contract     *bind.BoundContract
+	contractABI  abi.ABI
+	contractAddr common.Address
+}
+
+// NewEdgeRegistryContract creates a production edge-registry reader. The address
+// is sourced from config at runtime (address-as-parameter, never a source
+// constant). Returns an error if baseClient is nil or not connected.
+func NewEdgeRegistryContract(baseClient *BaseClient, contractAddr common.Address) (*EdgeRegistryContract, error) {
+	if baseClient == nil {
+		return nil, fmt.Errorf("base client is required (use NewMockEdgeRegistryReader for testing)")
+	}
+	if !baseClient.IsConnected() {
+		return nil, fmt.Errorf("base client not connected to RPC")
+	}
+
+	parsedABI, err := abi.JSON(strings.NewReader(EdgeRegistryABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse edge registry ABI: %w", err)
+	}
+
+	client := baseClient.Client()
+	return &EdgeRegistryContract{
+		baseClient:   baseClient,
+		contract:     bind.NewBoundContract(contractAddr, parsedABI, client, client, client),
+		contractABI:  parsedABI,
+		contractAddr: contractAddr,
+	}, nil
+}
+
+// IsActiveEdgeProvider implements EdgeRegistryReader against the on-chain contract.
+func (ec *EdgeRegistryContract) IsActiveEdgeProvider(ctx context.Context, addr common.Address) (bool, error) {
+	callOpts := &bind.CallOpts{Context: ctx}
+	var result []interface{}
+	if err := ec.contract.Call(callOpts, &result, "isActiveEdgeProvider", addr); err != nil {
+		return false, fmt.Errorf("isActiveEdgeProvider failed: %w", err)
+	}
+	if len(result) < 1 {
+		return false, fmt.Errorf("unexpected result length")
+	}
+	active, ok := result[0].(bool)
+	if !ok {
+		return false, fmt.Errorf("unexpected result type for isActiveEdgeProvider")
+	}
+	return active, nil
+}
+
+// edgeInfoResult wraps the single tuple output of getEdgeProviderInfo. Decoding
+// the tuple into a struct requires a wrapper whose first field is the tuple
+// struct: bind.BoundContract.Call routes a single-element results slice through
+// abi.UnpackIntoInterface, whose copyAtomic step sets dst.Field(0) from the
+// decoded tuple. Pointing Field(0) at edgeProviderInfoTuple makes go-ethereum
+// copy the tuple field-by-field (positionally, no struct tags required).
+// Decoding directly into edgeProviderInfoTuple instead would mis-target only
+// its first field and panic.
+type edgeInfoResult struct {
+	Info edgeProviderInfoTuple
+}
+
+// GetEdgeProviderInfo implements EdgeRegistryReader against the on-chain contract.
+func (ec *EdgeRegistryContract) GetEdgeProviderInfo(ctx context.Context, addr common.Address) (*EdgeProviderData, error) {
+	callOpts := &bind.CallOpts{Context: ctx}
+	out := edgeInfoResult{}
+	results := []interface{}{&out}
+	if err := ec.contract.Call(callOpts, &results, "getEdgeProviderInfo", addr); err != nil {
+		return nil, fmt.Errorf("getEdgeProviderInfo failed: %w", err)
+	}
+	return out.Info.toEdgeProviderData(), nil
+}
+
+// toEdgeProviderData converts the ABI-decoded tuple into the daemon-side
+// representation. Kept separate from the RPC call so the struct-tag decode +
+// type translation can be unit-tested without a live backend.
+func (t edgeProviderInfoTuple) toEdgeProviderData() *EdgeProviderData {
+	var registeredAt time.Time
+	if t.RegisteredAt != nil && t.RegisteredAt.Sign() > 0 {
+		registeredAt = time.Unix(t.RegisteredAt.Int64(), 0)
+	}
+
+	return &EdgeProviderData{
+		NodeID:        t.NodeId,
+		Region:        t.Region,
+		EndpointURL:   t.EndpointURL,
+		TLSPubkeyHash: t.TlsPubkeyHash,
+		RegisteredAt:  registeredAt,
+		Active:        t.Active,
+		Frozen:        t.Frozen,
+	}
+}
+
+// MockEdgeRegistryReader is an in-memory EdgeRegistryReader for tests and darwin
+// builds. It is safe for concurrent use.
+type MockEdgeRegistryReader struct {
+	mu        sync.RWMutex
+	providers map[common.Address]*EdgeProviderData
+}
+
+// NewMockEdgeRegistryReader creates an empty in-memory edge-registry reader.
+func NewMockEdgeRegistryReader() *MockEdgeRegistryReader {
+	return &MockEdgeRegistryReader{
+		providers: make(map[common.Address]*EdgeProviderData),
+	}
+}
+
+// RegisterMock adds or replaces an edge provider in the mock store. A nil data
+// pointer is ignored.
+func (m *MockEdgeRegistryReader) RegisterMock(addr common.Address, data *EdgeProviderData) {
+	if data == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Store a copy so callers cannot mutate the stored record after the fact.
+	cp := *data
+	m.providers[addr] = &cp
+}
+
+// UnregisterMock removes an edge provider from the mock store.
+func (m *MockEdgeRegistryReader) UnregisterMock(addr common.Address) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.providers, addr)
+}
+
+// IsActiveEdgeProvider implements EdgeRegistryReader against the in-memory store.
+func (m *MockEdgeRegistryReader) IsActiveEdgeProvider(_ context.Context, addr common.Address) (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	data, ok := m.providers[addr]
+	if !ok {
+		return false, nil
+	}
+	return data.Active && !data.Frozen, nil
+}
+
+// GetEdgeProviderInfo implements EdgeRegistryReader against the in-memory store.
+// An unregistered address returns (nil, nil), not an error.
+func (m *MockEdgeRegistryReader) GetEdgeProviderInfo(_ context.Context, addr common.Address) (*EdgeProviderData, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	data, ok := m.providers[addr]
+	if !ok {
+		return nil, nil
+	}
+	cp := *data
+	return &cp, nil
+}
+
+// Compile-time assertions that both implementations satisfy the interface.
+var (
+	_ EdgeRegistryReader = (*EdgeRegistryContract)(nil)
+	_ EdgeRegistryReader = (*MockEdgeRegistryReader)(nil)
+)

--- a/internal/payment/edge_registry_test.go
+++ b/internal/payment/edge_registry_test.go
@@ -1,0 +1,298 @@
+package payment
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func sampleEdgeData() *EdgeProviderData {
+	var nodeID, region [32]byte
+	copy(nodeID[:], []byte("edge-node-1"))
+	copy(region[:], []byte("us-east"))
+	return &EdgeProviderData{
+		NodeID:        nodeID,
+		Region:        region,
+		EndpointURL:   "https://edge1.moltbunker.dev",
+		TLSPubkeyHash: []byte{0x00, 0x11, 0x22, 0x33},
+		RegisteredAt:  time.Unix(1_700_000_000, 0),
+		Active:        true,
+		Frozen:        false,
+	}
+}
+
+func TestMockEdgeRegistry_IsActive(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+	addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	// Unknown address returns false, no error.
+	active, err := m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error for unknown address: %v", err)
+	}
+	if active {
+		t.Fatalf("expected unknown address to be inactive")
+	}
+
+	// After registration, returns true.
+	m.RegisterMock(addr, sampleEdgeData())
+	active, err = m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error after register: %v", err)
+	}
+	if !active {
+		t.Fatalf("expected registered active provider to be active")
+	}
+
+	// A frozen provider is reported inactive.
+	frozen := sampleEdgeData()
+	frozen.Frozen = true
+	m.RegisterMock(addr, frozen)
+	active, err = m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error for frozen provider: %v", err)
+	}
+	if active {
+		t.Fatalf("expected frozen provider to be inactive")
+	}
+
+	// An explicitly inactive provider is reported inactive.
+	inactive := sampleEdgeData()
+	inactive.Active = false
+	m.RegisterMock(addr, inactive)
+	active, _ = m.IsActiveEdgeProvider(ctx, addr)
+	if active {
+		t.Fatalf("expected inactive provider to be inactive")
+	}
+
+	// After unregister, returns false.
+	m.RegisterMock(addr, sampleEdgeData())
+	m.UnregisterMock(addr)
+	active, err = m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error after unregister: %v", err)
+	}
+	if active {
+		t.Fatalf("expected unregistered address to be inactive")
+	}
+}
+
+func TestMockEdgeRegistry_GetInfo(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+	addr := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	want := sampleEdgeData()
+	m.RegisterMock(addr, want)
+
+	got, err := m.GetEdgeProviderInfo(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil edge provider data")
+	}
+	if got.NodeID != want.NodeID {
+		t.Errorf("NodeID mismatch: got %x want %x", got.NodeID, want.NodeID)
+	}
+	if got.Region != want.Region {
+		t.Errorf("Region mismatch: got %x want %x", got.Region, want.Region)
+	}
+	if got.EndpointURL != want.EndpointURL {
+		t.Errorf("EndpointURL mismatch: got %q want %q", got.EndpointURL, want.EndpointURL)
+	}
+	if string(got.TLSPubkeyHash) != string(want.TLSPubkeyHash) {
+		t.Errorf("TLSPubkeyHash mismatch: got %x want %x", got.TLSPubkeyHash, want.TLSPubkeyHash)
+	}
+	if !got.RegisteredAt.Equal(want.RegisteredAt) {
+		t.Errorf("RegisteredAt mismatch: got %v want %v", got.RegisteredAt, want.RegisteredAt)
+	}
+
+	// RegisterMock must store a copy: mutating the caller's struct afterward
+	// must not change the stored record.
+	want.EndpointURL = "https://mutated.example"
+	got2, _ := m.GetEdgeProviderInfo(ctx, addr)
+	if got2.EndpointURL == "https://mutated.example" {
+		t.Errorf("stored record was mutated through the caller's pointer")
+	}
+}
+
+func TestMockEdgeRegistry_ZeroAddress(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+
+	got, err := m.GetEdgeProviderInfo(ctx, common.Address{})
+	if err != nil {
+		t.Fatalf("expected nil error for zero address, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil data for zero address, got %+v", got)
+	}
+}
+
+func TestMockEdgeRegistry_Concurrency(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(n int) {
+			defer wg.Done()
+			addr := common.BigToAddress(big.NewInt(int64(n) + 1))
+			data := sampleEdgeData()
+			for j := 0; j < 100; j++ {
+				m.RegisterMock(addr, data)
+				_, _ = m.IsActiveEdgeProvider(ctx, addr)
+				_, _ = m.GetEdgeProviderInfo(ctx, addr)
+				if j%2 == 0 {
+					m.UnregisterMock(addr)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// abiEdgeProviderInfo mirrors the on-chain getEdgeProviderInfo tuple components
+// in declaration order. It is only used by the ABI encoder in the test below to
+// produce wire bytes; the decode under test happens through edgeProviderInfoTuple.
+type abiEdgeProviderInfo struct {
+	NodeId        [32]byte
+	Region        [32]byte
+	RegisteredAt  *big.Int
+	Active        bool
+	Frozen        bool
+	EndpointURL   string
+	TlsPubkeyHash []byte
+}
+
+// TestEdgeProviderInfo_ABIDecode exercises the on-chain decode path of
+// GetEdgeProviderInfo without a live backend: it ABI-encodes a sample
+// EdgeProviderInfo tuple with EdgeRegistryABI's getEdgeProviderInfo output
+// arguments, then runs the exact production decode — abi.Unpack followed by the
+// decodeEdgeProviderInfoResult type-assert + translation that
+// GetEdgeProviderInfo performs on result[0]. This confirms the struct decode is
+// correct, in particular the uint48 registeredAt (decoded as *big.Int) and the
+// two bool fields, which previously had zero coverage. (It also pins the
+// regression where the original results-slice form panicked on this tuple.)
+func TestEdgeProviderInfo_ABIDecode(t *testing.T) {
+	parsedABI, err := abi.JSON(strings.NewReader(EdgeRegistryABI))
+	if err != nil {
+		t.Fatalf("failed to parse edge registry ABI: %v", err)
+	}
+	method, ok := parsedABI.Methods["getEdgeProviderInfo"]
+	if !ok {
+		t.Fatalf("getEdgeProviderInfo not present in ABI")
+	}
+
+	var nodeID, region [32]byte
+	copy(nodeID[:], []byte("edge-node-abc"))
+	copy(region[:], []byte("eu-west"))
+
+	const registeredAtUnix int64 = 1_700_000_123
+	sample := abiEdgeProviderInfo{
+		NodeId:        nodeID,
+		Region:        region,
+		RegisteredAt:  big.NewInt(registeredAtUnix),
+		Active:        true,
+		Frozen:        true,
+		EndpointURL:   "https://edge-abc.moltbunker.dev",
+		TlsPubkeyHash: []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x99},
+	}
+
+	// Encode exactly as the contract would return it (the tuple is the single
+	// output argument of getEdgeProviderInfo).
+	encoded, err := method.Outputs.Pack(sample)
+	if err != nil {
+		t.Fatalf("failed to ABI-encode sample tuple: %v", err)
+	}
+
+	// Decode through the exact production path bind.BoundContract.Call drives:
+	// UnpackIntoInterface into &edgeInfoResult{} (its Info field is the tuple),
+	// then the tuple->EdgeProviderData translation.
+	out := edgeInfoResult{}
+	if err := parsedABI.UnpackIntoInterface(&out, "getEdgeProviderInfo", encoded); err != nil {
+		t.Fatalf("UnpackIntoInterface failed: %v", err)
+	}
+	data := out.Info.toEdgeProviderData()
+
+	// Production translation into the daemon-side struct.
+	if data.NodeID != nodeID {
+		t.Errorf("data.NodeID mismatch: got %x want %x", data.NodeID, nodeID)
+	}
+	if data.Region != region {
+		t.Errorf("data.Region mismatch: got %x want %x", data.Region, region)
+	}
+	if !data.RegisteredAt.Equal(time.Unix(registeredAtUnix, 0)) {
+		t.Errorf("data.RegisteredAt mismatch: got %v want %v", data.RegisteredAt, time.Unix(registeredAtUnix, 0))
+	}
+	if !data.Active {
+		t.Errorf("data.Active mismatch: got false want true")
+	}
+	if !data.Frozen {
+		t.Errorf("data.Frozen mismatch: got false want true")
+	}
+	if data.EndpointURL != sample.EndpointURL {
+		t.Errorf("data.EndpointURL mismatch: got %q want %q", data.EndpointURL, sample.EndpointURL)
+	}
+	if string(data.TLSPubkeyHash) != string(sample.TlsPubkeyHash) {
+		t.Errorf("data.TLSPubkeyHash mismatch: got %x want %x", data.TLSPubkeyHash, sample.TlsPubkeyHash)
+	}
+}
+
+// TestEdgeProviderInfo_ABIDecode_ZeroRegisteredAt confirms a zero uint48
+// registeredAt maps to the Go zero time (not a 1970 epoch timestamp).
+func TestEdgeProviderInfo_ABIDecode_ZeroRegisteredAt(t *testing.T) {
+	parsedABI, err := abi.JSON(strings.NewReader(EdgeRegistryABI))
+	if err != nil {
+		t.Fatalf("failed to parse edge registry ABI: %v", err)
+	}
+	method := parsedABI.Methods["getEdgeProviderInfo"]
+
+	sample := abiEdgeProviderInfo{
+		RegisteredAt:  big.NewInt(0),
+		TlsPubkeyHash: []byte{},
+	}
+	encoded, err := method.Outputs.Pack(sample)
+	if err != nil {
+		t.Fatalf("failed to ABI-encode sample tuple: %v", err)
+	}
+
+	out := edgeInfoResult{}
+	if err := parsedABI.UnpackIntoInterface(&out, "getEdgeProviderInfo", encoded); err != nil {
+		t.Fatalf("UnpackIntoInterface failed: %v", err)
+	}
+	data := out.Info.toEdgeProviderData()
+	if !data.RegisteredAt.IsZero() {
+		t.Errorf("expected zero RegisteredAt for unset uint48, got %v", data.RegisteredAt)
+	}
+	if data.Active || data.Frozen {
+		t.Errorf("expected false bools for empty tuple, got active=%v frozen=%v", data.Active, data.Frozen)
+	}
+}
+
+func TestMockEdgeRegistry_NilDataIgnored(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockEdgeRegistryReader()
+	addr := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	// Registering nil data is a no-op (no panic, address stays unknown).
+	m.RegisterMock(addr, nil)
+	active, err := m.IsActiveEdgeProvider(ctx, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active {
+		t.Fatalf("expected address to stay inactive after nil register")
+	}
+}

--- a/internal/payment/service.go
+++ b/internal/payment/service.go
@@ -15,11 +15,11 @@ import (
 
 // PaymentService provides a unified interface for all payment operations
 type PaymentService struct {
-	config          *PaymentServiceConfig
-	baseClient      *BaseClient
-	tokenContract   *TokenContract
-	stakingContract *StakingContract
-	escrowContract  *EscrowContract
+	config           *PaymentServiceConfig
+	baseClient       *BaseClient
+	tokenContract    *TokenContract
+	stakingContract  *StakingContract
+	escrowContract   *EscrowContract
 	slashingContract *SlashingContract
 
 	// Governance contracts
@@ -56,16 +56,16 @@ type PaymentServiceConfig struct {
 	BlockConfirmations int
 
 	// Contract addresses
-	TokenAddress              common.Address
-	RegistryAddress           common.Address
-	EscrowAddress             common.Address
-	StakingAddress            common.Address
-	SlashingAddress           common.Address
-	DelegationAddress         common.Address
-	ReputationAddress         common.Address
-	VerificationAddress       common.Address
-	PricingAddress            common.Address
-	SubdomainRegistryAddress  common.Address
+	TokenAddress             common.Address
+	RegistryAddress          common.Address
+	EscrowAddress            common.Address
+	StakingAddress           common.Address
+	SlashingAddress          common.Address
+	DelegationAddress        common.Address
+	ReputationAddress        common.Address
+	VerificationAddress      common.Address
+	PricingAddress           common.Address
+	SubdomainRegistryAddress common.Address
 
 	// Wallet (nil for read-only mode)
 	PrivateKey *ecdsa.PrivateKey
@@ -252,6 +252,13 @@ func (ps *PaymentService) IsConnected() bool {
 // IsMockMode returns true if running in mock mode
 func (ps *PaymentService) IsMockMode() bool {
 	return ps.config.MockMode
+}
+
+// BaseClient returns the underlying Base RPC client, or nil in mock mode / when
+// not connected. Used by EDGE-02 to construct the on-chain edge-registry reader
+// (NewEdgeRegistryContract) from the daemon's existing RPC connection.
+func (ps *PaymentService) BaseClient() *BaseClient {
+	return ps.baseClient
 }
 
 // GetWalletAddress returns the wallet address

--- a/internal/tunnel/blocklist.go
+++ b/internal/tunnel/blocklist.go
@@ -1,0 +1,187 @@
+package tunnel
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// blocklist.go implements the operator takedown kill-switch (EDGE-02): the
+// daemon side of the abuse-takedown flow. An operator can block a subdomain (or
+// custom host) at ingress so the reverse tunnel server refuses to register it
+// and refuses to open streams for it. This is the enforcement primitive that a
+// higher-level abuse/legal workflow (LEGAL-01) drives.
+
+// BlocklistChecker reports whether a host/subdomain is blocked at ingress.
+// ReverseServer consults it on both registration and stream-open so a takedown
+// takes effect immediately for new sessions and is enforced on every request
+// for live sessions.
+type BlocklistChecker interface {
+	// IsBlocked reports whether the given subdomain/host is on the blocklist,
+	// and the operator-supplied reason when it is.
+	IsBlocked(subdomain string) (blocked bool, reason string)
+}
+
+// BlockEntry is a single blocklist record.
+type BlockEntry struct {
+	Subdomain string    `json:"subdomain"`
+	Reason    string    `json:"reason,omitempty"`
+	BlockedAt time.Time `json:"blocked_at"`
+}
+
+// Blocklist is a thread-safe in-memory set of blocked subdomains/hosts. It is
+// the default BlocklistChecker. Persistence across restart is a documented
+// follow-up; the abuse workflow re-applies blocks on startup.
+type Blocklist struct {
+	mu      sync.RWMutex
+	entries map[string]BlockEntry // normalized subdomain -> entry
+}
+
+// NewBlocklist creates an empty blocklist.
+func NewBlocklist() *Blocklist {
+	return &Blocklist{entries: make(map[string]BlockEntry)}
+}
+
+// normalizeSub lowercases and trims a subdomain/host for stable matching.
+func normalizeSub(s string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(s)), ".")
+}
+
+// Block adds a subdomain/host to the blocklist with an optional reason.
+func (b *Blocklist) Block(subdomain, reason string) {
+	sub := normalizeSub(subdomain)
+	if sub == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.entries[sub] = BlockEntry{Subdomain: sub, Reason: reason, BlockedAt: time.Now()}
+}
+
+// Unblock removes a subdomain/host from the blocklist. Reports whether an entry
+// was present.
+func (b *Blocklist) Unblock(subdomain string) bool {
+	sub := normalizeSub(subdomain)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, ok := b.entries[sub]
+	delete(b.entries, sub)
+	return ok
+}
+
+// IsBlocked implements BlocklistChecker.
+func (b *Blocklist) IsBlocked(subdomain string) (bool, string) {
+	sub := normalizeSub(subdomain)
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	e, ok := b.entries[sub]
+	if !ok {
+		return false, ""
+	}
+	return true, e.Reason
+}
+
+// List returns all blocklist entries sorted by subdomain (stable output).
+func (b *Blocklist) List() []BlockEntry {
+	b.mu.RLock()
+	out := make([]BlockEntry, 0, len(b.entries))
+	for _, e := range b.entries {
+		out = append(out, e)
+	}
+	b.mu.RUnlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].Subdomain < out[j].Subdomain })
+	return out
+}
+
+// Len returns the number of blocked entries.
+func (b *Blocklist) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.entries)
+}
+
+// Compile-time assertion.
+var _ BlocklistChecker = (*Blocklist)(nil)
+
+// --- Admin HTTP surface ---------------------------------------------------
+
+const maxBlocklistBody = 4 << 10 // 4 KiB
+
+// blockRequest is the body for POST (block) requests.
+type blockRequest struct {
+	Subdomain string `json:"subdomain"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// BlocklistAdminHandler is a small admin API to manage the takedown blocklist.
+// It carries no auth of its own; the daemon mounts it behind the existing
+// API-key/admin middleware. Routes (under a mount prefix):
+//
+//	GET    .../blocklist            -> [{subdomain, reason, blocked_at}, ...]
+//	POST   .../blocklist  {subdomain, reason}  -> 201
+//	DELETE .../blocklist?subdomain=<host>      -> 204 / 404
+type BlocklistAdminHandler struct {
+	bl *Blocklist
+}
+
+// NewBlocklistAdminHandler builds the admin handler around a blocklist.
+func NewBlocklistAdminHandler(bl *Blocklist) *BlocklistAdminHandler {
+	return &BlocklistAdminHandler{bl: bl}
+}
+
+// ServeHTTP dispatches by method.
+func (h *BlocklistAdminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.writeJSON(w, http.StatusOK, h.bl.List())
+	case http.MethodPost:
+		var req blockRequest
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxBlocklistBody))
+		if err != nil {
+			h.writeErr(w, http.StatusBadRequest, "failed to read body")
+			return
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			h.writeErr(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		if strings.TrimSpace(req.Subdomain) == "" {
+			h.writeErr(w, http.StatusBadRequest, "subdomain is required")
+			return
+		}
+		h.bl.Block(req.Subdomain, req.Reason)
+		h.writeJSON(w, http.StatusCreated, BlockEntry{
+			Subdomain: normalizeSub(req.Subdomain),
+			Reason:    req.Reason,
+			BlockedAt: time.Now(),
+		})
+	case http.MethodDelete:
+		sub := r.URL.Query().Get("subdomain")
+		if strings.TrimSpace(sub) == "" {
+			h.writeErr(w, http.StatusBadRequest, "subdomain query param is required")
+			return
+		}
+		if !h.bl.Unblock(sub) {
+			h.writeErr(w, http.StatusNotFound, "subdomain not blocked")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.Header().Set("Allow", "GET, POST, DELETE")
+		h.writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *BlocklistAdminHandler) writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (h *BlocklistAdminHandler) writeErr(w http.ResponseWriter, status int, msg string) {
+	h.writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/tunnel/blocklist_test.go
+++ b/internal/tunnel/blocklist_test.go
@@ -1,0 +1,126 @@
+package tunnel
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBlocklist_BlockUnblock(t *testing.T) {
+	bl := NewBlocklist()
+	if blocked, _ := bl.IsBlocked("evil"); blocked {
+		t.Fatal("nothing should be blocked initially")
+	}
+	bl.Block("Evil", "abuse") // case-insensitive
+	blocked, reason := bl.IsBlocked("evil")
+	if !blocked || reason != "abuse" {
+		t.Fatalf("blocked=%v reason=%q", blocked, reason)
+	}
+	if !bl.Unblock("evil") {
+		t.Fatal("Unblock should report a removed entry")
+	}
+	if blocked, _ := bl.IsBlocked("evil"); blocked {
+		t.Fatal("should be unblocked")
+	}
+	if bl.Unblock("evil") {
+		t.Fatal("Unblock of absent entry should report false")
+	}
+}
+
+func TestBlocklist_List(t *testing.T) {
+	bl := NewBlocklist()
+	bl.Block("b", "")
+	bl.Block("a", "reason-a")
+	list := bl.List()
+	if len(list) != 2 {
+		t.Fatalf("len = %d, want 2", len(list))
+	}
+	if list[0].Subdomain != "a" || list[1].Subdomain != "b" {
+		t.Fatalf("expected sorted list, got %+v", list)
+	}
+}
+
+func TestBlocklist_EmptySubdomainIgnored(t *testing.T) {
+	bl := NewBlocklist()
+	bl.Block("   ", "x")
+	if bl.Len() != 0 {
+		t.Fatal("empty subdomain must not be blocked")
+	}
+}
+
+func TestBlocklistAdmin_PostGetDelete(t *testing.T) {
+	bl := NewBlocklist()
+	h := NewBlocklistAdminHandler(bl)
+
+	// POST a block.
+	post := httptest.NewRequest(http.MethodPost, "/v1/ingress/blocklist",
+		strings.NewReader(`{"subdomain":"evil","reason":"takedown"}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, post)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if blocked, _ := bl.IsBlocked("evil"); !blocked {
+		t.Fatal("subdomain not blocked after POST")
+	}
+
+	// GET the list.
+	get := httptest.NewRequest(http.MethodGet, "/v1/ingress/blocklist", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, get)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", rec.Code)
+	}
+	var list []BlockEntry
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list) != 1 || list[0].Subdomain != "evil" {
+		t.Fatalf("unexpected list: %+v", list)
+	}
+
+	// DELETE (unblock).
+	del := httptest.NewRequest(http.MethodDelete, "/v1/ingress/blocklist?subdomain=evil", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, del)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want 204", rec.Code)
+	}
+	if blocked, _ := bl.IsBlocked("evil"); blocked {
+		t.Fatal("subdomain still blocked after DELETE")
+	}
+}
+
+func TestBlocklistAdmin_Errors(t *testing.T) {
+	h := NewBlocklistAdminHandler(NewBlocklist())
+
+	// POST without subdomain.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST empty status = %d, want 400", rec.Code)
+	}
+
+	// DELETE without subdomain query.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/x", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("DELETE no-param status = %d, want 400", rec.Code)
+	}
+
+	// DELETE absent subdomain.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/x?subdomain=missing", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("DELETE missing status = %d, want 404", rec.Code)
+	}
+
+	// Unsupported method.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/x", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("PUT status = %d, want 405", rec.Code)
+	}
+}

--- a/internal/tunnel/reverse_server.go
+++ b/internal/tunnel/reverse_server.go
@@ -74,6 +74,43 @@ func WithWalletVerifier(fn WalletVerifyFunc) ReverseServerOption {
 	return func(s *ReverseServer) { s.verifyWallet = fn }
 }
 
+// EdgeAuthorizeFunc reports whether the node (identified by its NodeID hex and
+// recovered wallet address) is authorized to register as an edge provider. It
+// is the tunnel-package seam that internal/edge.EdgeTierChecker is adapted to
+// in main.go, keeping internal/tunnel free of an internal/edge import. A nil
+// func disables edge gating (the default). Returning (false, nil) rejects; a
+// non-nil error is treated as "not authorized" (fail-closed).
+type EdgeAuthorizeFunc func(nodeID string, walletAddr string) (bool, error)
+
+// WithEdgeTierChecker installs the edge-role gate. When set, handleProviderConn
+// rejects registrations from nodes that are not authorized edge providers. The
+// gate runs only when the provider declares EdgeCapabilities in its register
+// request, so non-edge container providers are unaffected. EDGE-02.
+func WithEdgeTierChecker(fn EdgeAuthorizeFunc) ReverseServerOption {
+	return func(s *ReverseServer) { s.edgeAuthorize = fn }
+}
+
+// WithBlocklist installs the operator takedown blocklist. When set, blocked
+// subdomains/hosts are refused at registration and on every stream open.
+// EDGE-02.
+func WithBlocklist(checker BlocklistChecker) ReverseServerOption {
+	return func(s *ReverseServer) { s.blocklist = checker }
+}
+
+// WithEdgeRegistry installs the in-memory edge registry the server populates
+// when an edge provider registers with EdgeCapabilities. The registry feeds the
+// edge selector/probe on the ingress side. EDGE-02.
+func WithEdgeRegistry(reg EdgeRegistrar) ReverseServerOption {
+	return func(s *ReverseServer) { s.edgeRegistry = reg }
+}
+
+// EdgeRegistrar is the minimal seam ReverseServer uses to announce a freshly
+// registered edge node, satisfied by edge.EdgeRegistry (adapted in main.go).
+// Declaring it here avoids an internal/edge import in internal/tunnel.
+type EdgeRegistrar interface {
+	RegisterEdge(nodeID types.NodeID, walletAddr, ingressAddr string, tunnelPort, maxStreams int)
+}
+
 // ReverseServer accepts outbound connections from providers,
 // establishes yamux sessions, and registers subdomains.
 type ReverseServer struct {
@@ -85,6 +122,11 @@ type ReverseServer struct {
 	maxConns     int
 	maxPerIP     int
 	verifyWallet WalletVerifyFunc
+
+	// EDGE-02 gates (all optional; nil = feature off).
+	edgeAuthorize EdgeAuthorizeFunc // edge-role gate (only when provider declares EdgeCapabilities)
+	edgeRegistry  EdgeRegistrar     // populated with edge node info on edge registration
+	blocklist     BlocklistChecker  // operator takedown kill-switch
 
 	// Connection tracking
 	connSemaphore chan struct{}
@@ -220,6 +262,14 @@ func (s *ReverseServer) Shutdown(ctx context.Context) error {
 // OpenStream opens a yamux stream to the provider for a given subdomain.
 // Called by the ingress proxy when routing an HTTP request.
 func (s *ReverseServer) OpenStream(subdomain string) (net.Conn, error) {
+	// EDGE-02: enforce operator takedown on every request, not just at
+	// registration, so a live session is severed the instant it is blocked.
+	if s.blocklist != nil {
+		if blocked, _ := s.blocklist.IsBlocked(subdomain); blocked {
+			return nil, fmt.Errorf("subdomain %q blocked by operator", subdomain)
+		}
+	}
+
 	sess, ok := s.registry.Lookup(subdomain)
 	if !ok {
 		return nil, fmt.Errorf("no reverse tunnel for subdomain %q", subdomain)
@@ -362,6 +412,7 @@ func (s *ReverseServer) handleProviderConn(ctx context.Context, conn net.Conn) {
 
 	// Determine tier: verify wallet proof if provided, otherwise free tier
 	tier := "free"
+	walletVerified := false
 	if req.WalletProof != nil && s.verifyWallet != nil {
 		verified, verifyErr := s.verifyWallet(req.WalletProof, nodeID.String())
 		if verifyErr != nil {
@@ -372,10 +423,37 @@ func (s *ReverseServer) handleProviderConn(ctx context.Context, conn net.Conn) {
 			// Fall through to free tier — don't reject, just don't upgrade
 		} else {
 			tier = verified
+			walletVerified = true
 			logging.Debug("reverse tunnel: wallet verified",
 				"node_id", nodeID.String()[:16],
 				"tier", tier,
 				logging.Component("reverse-tunnel"))
+		}
+	}
+
+	// EDGE-02: edge-role gate. Only runs when the provider declares
+	// EdgeCapabilities (an edge node), so container providers are unaffected.
+	// The wallet address is forwarded to the checker ONLY when the wallet proof
+	// actually verified — otherwise a node could claim any wallet's edge stake.
+	// With the config (NodeID-allowlist) checker the wallet is irrelevant; with
+	// the on-chain checker an unverified wallet yields an empty address, which
+	// the registry treats as not-authorized (fail-closed).
+	if req.EdgeCapabilities != nil && s.edgeAuthorize != nil {
+		walletAddr := ""
+		if walletVerified && req.WalletProof != nil {
+			walletAddr = req.WalletProof.Address
+		}
+		authorized, edgeErr := s.edgeAuthorize(nodeID.String(), walletAddr)
+		if edgeErr != nil || !authorized {
+			logging.Warn("reverse tunnel: edge role not authorized",
+				"node_id", nodeID.String()[:16],
+				logging.Component("reverse-tunnel"))
+			if writeErr := writeControlMsg(ctrlStream, MsgEdgeRoleRejected, []byte("edge role not authorized")); writeErr != nil {
+				logging.Debug("reverse tunnel: write edge-reject failed",
+					logging.Err(writeErr),
+					logging.Component("reverse-tunnel"))
+			}
+			return
 		}
 	}
 
@@ -445,6 +523,37 @@ func (s *ReverseServer) handleProviderConn(ctx context.Context, conn net.Conn) {
 				logging.Component("reverse-tunnel"))
 		}
 		return
+	}
+
+	// EDGE-02: operator takedown kill-switch. A blocked subdomain/host is
+	// refused registration so a taken-down deployment cannot re-establish a
+	// tunnel. (OpenStream also enforces this for any already-live session.)
+	if s.blocklist != nil {
+		if blocked, reason := s.blocklist.IsBlocked(subdomain); blocked {
+			logging.Warn("reverse tunnel: subdomain blocked by operator takedown",
+				"subdomain", subdomain,
+				"reason", reason,
+				logging.Component("reverse-tunnel"))
+			if writeErr := writeControlMsg(ctrlStream, MsgTunnelError, []byte("subdomain blocked by operator")); writeErr != nil {
+				logging.Debug("reverse tunnel: write block error failed",
+					logging.Err(writeErr),
+					logging.Component("reverse-tunnel"))
+			}
+			return
+		}
+	}
+
+	// EDGE-02: record the edge node so the ingress-side selector/probe can use
+	// it. Only edge providers (those declaring EdgeCapabilities) are recorded.
+	if req.EdgeCapabilities != nil && s.edgeRegistry != nil {
+		wallet := ""
+		if walletVerified && req.WalletProof != nil {
+			wallet = req.WalletProof.Address
+		}
+		s.edgeRegistry.RegisterEdge(nodeID, wallet,
+			req.EdgeCapabilities.IngressAddr,
+			req.EdgeCapabilities.TunnelPort,
+			req.EdgeCapabilities.MaxStreams)
 	}
 
 	// Create and register session

--- a/internal/tunnel/reverse_server_test.go
+++ b/internal/tunnel/reverse_server_test.go
@@ -1,0 +1,184 @@
+package tunnel
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/yamux"
+	"github.com/moltbunker/moltbunker/pkg/types"
+)
+
+// edgeProbeProvider dials the reverse server, establishes the provider-side
+// yamux session, sends a register request, and returns the first control
+// message type the server writes back. It is a minimal hand-rolled provider so
+// the test can inject EdgeCapabilities (which the production ReverseClient does
+// not yet send).
+func edgeProbeProvider(t *testing.T, serverAddr string, clientCfg *tls.Config, req TunnelRegisterRequest) (byte, []byte) {
+	t.Helper()
+	conn, err := tls.Dial("tcp", serverAddr, clientCfg)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	yc := yamux.DefaultConfig()
+	yc.LogOutput = io.Discard
+	session, err := yamux.Server(conn, yc)
+	if err != nil {
+		t.Fatalf("yamux server: %v", err)
+	}
+	defer session.Close()
+
+	// The ingress opens the control stream; accept it.
+	ctrl, err := session.Accept()
+	if err != nil {
+		t.Fatalf("accept control stream: %v", err)
+	}
+	defer ctrl.Close()
+	_ = ctrl.SetDeadline(time.Now().Add(5 * time.Second))
+
+	payload, _ := json.Marshal(req)
+	if err := writeControlMsg(ctrl, MsgTunnelRegister, payload); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	msgType, respPayload, err := readControlMsg(ctrl)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return msgType, respPayload
+}
+
+// startEdgeTestServer spins up a ReverseServer with the given options and
+// returns its address and a client TLS config trusting it.
+func startEdgeTestServer(t *testing.T, opts ...ReverseServerOption) string {
+	t.Helper()
+	ingressCert := generateTestCert(t)
+	providerCert := generateTestCert(t)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(ingressCert.Leaf)
+	pool.AddCert(providerCert.Leaf)
+
+	ingressTLSCfg := &tls.Config{
+		Certificates: []tls.Certificate{ingressCert},
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAnyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}
+	lis, err := tls.Listen("tcp", "127.0.0.1:0", ingressTLSCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	srv := NewReverseServer(lis, opts...)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = srv.Serve(ctx) }()
+
+	// Stash the provider cert on the test via a closure-captured client config.
+	t.Cleanup(func() {})
+	clientCfgHolder[t.Name()] = &tls.Config{
+		Certificates:       []tls.Certificate{providerCert},
+		RootCAs:            pool,
+		InsecureSkipVerify: true, // test only: self-signed
+		MinVersion:         tls.VersionTLS13,
+	}
+	return lis.Addr().String()
+}
+
+// clientCfgHolder passes the per-test provider TLS config from the server
+// helper to the test body without changing the helper's return signature.
+var clientCfgHolder = map[string]*tls.Config{}
+
+func baseEdgeRegisterReq() TunnelRegisterRequest {
+	nonce := make([]byte, 32)
+	for i := range nonce {
+		nonce[i] = byte(i)
+	}
+	return TunnelRegisterRequest{
+		NodeID:        "edge-node",
+		DeploymentID:  "dep-edge",
+		ContainerPort: 8080,
+		Nonce:         hex.EncodeToString(nonce),
+		Timestamp:     time.Now().Unix(),
+		EdgeCapabilities: &EdgeCapabilities{
+			IngressAddr: "edge.example.com",
+			TunnelPort:  9443,
+			MaxStreams:  1000,
+		},
+		WalletProof: &WalletProof{Address: "0x1111111111111111111111111111111111111111"},
+	}
+}
+
+func TestReverseServer_EdgeGate_Rejected(t *testing.T) {
+	checker := func(_, _ string) (bool, error) { return false, nil }
+	addr := startEdgeTestServer(t, WithEdgeTierChecker(checker))
+	clientCfg := clientCfgHolder[t.Name()]
+
+	msgType, payload := edgeProbeProvider(t, addr, clientCfg, baseEdgeRegisterReq())
+	if msgType != MsgEdgeRoleRejected {
+		t.Fatalf("msgType = 0x%02x, want MsgEdgeRoleRejected (0x%02x); payload=%q", msgType, MsgEdgeRoleRejected, payload)
+	}
+}
+
+func TestReverseServer_EdgeGate_Authorized(t *testing.T) {
+	// Authorized edge passes the gate, then proceeds to registration validation.
+	// The hand-rolled request does not carry a valid TLS-bound nonce, so it is
+	// rejected at validation with MsgTunnelError — NOT MsgEdgeRoleRejected. That
+	// distinction proves the gate let it through.
+	checker := func(_, _ string) (bool, error) { return true, nil }
+	reg := newEdgeRegistrarSpy()
+	addr := startEdgeTestServer(t, WithEdgeTierChecker(checker), WithEdgeRegistry(reg))
+	clientCfg := clientCfgHolder[t.Name()]
+
+	msgType, _ := edgeProbeProvider(t, addr, clientCfg, baseEdgeRegisterReq())
+	if msgType == MsgEdgeRoleRejected {
+		t.Fatal("authorized edge must not be rejected by the edge gate")
+	}
+	if msgType != MsgTunnelError && msgType != MsgTunnelRegistered {
+		t.Fatalf("unexpected msgType 0x%02x", msgType)
+	}
+	// When registration completes, the edge node is recorded in the registry.
+	if msgType == MsgTunnelRegistered && reg.calls == 0 {
+		t.Fatal("edge node was not recorded in the registry on successful registration")
+	}
+}
+
+func TestReverseServer_Blocklist_OpenStreamRejected(t *testing.T) {
+	bl := NewBlocklist()
+	bl.Block("evil", "takedown")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+	srv := NewReverseServer(lis, WithBlocklist(bl))
+
+	if _, err := srv.OpenStream("evil"); err == nil {
+		t.Fatal("expected blocked subdomain to be refused at OpenStream")
+	}
+	// A non-blocked subdomain falls through to the normal not-registered error.
+	if _, err := srv.OpenStream("clean"); err == nil {
+		t.Fatal("expected not-found error for unregistered subdomain")
+	}
+}
+
+// edgeRegistrarSpy records RegisterEdge calls.
+type edgeRegistrarSpy struct {
+	calls int
+}
+
+func newEdgeRegistrarSpy() *edgeRegistrarSpy { return &edgeRegistrarSpy{} }
+
+func (s *edgeRegistrarSpy) RegisterEdge(_ types.NodeID, _, _ string, _, _ int) {
+	s.calls++
+}

--- a/internal/tunnel/reverse_types.go
+++ b/internal/tunnel/reverse_types.go
@@ -8,12 +8,13 @@ const (
 	MsgTunnelPing       byte = 0x12 // Ingress → Provider: liveness check
 	MsgTunnelPong       byte = 0x13 // Provider → Ingress: alive
 	MsgTunnelDeregister byte = 0x14 // Provider → Ingress: graceful disconnect
+	MsgEdgeRoleRejected byte = 0x15 // Ingress → Provider: edge-role registration rejected (EDGE-02)
 )
 
 // TunnelRegisterRequest is sent by the provider to the ingress to register a reverse tunnel.
 type TunnelRegisterRequest struct {
 	NodeID        string       `json:"node_id"`
-	Subdomain     string       `json:"subdomain,omitempty"`    // empty = auto-assign
+	Subdomain     string       `json:"subdomain,omitempty"` // empty = auto-assign
 	DeploymentID  string       `json:"deployment_id"`
 	ContainerPort int          `json:"container_port"`
 	Nonce         string       `json:"nonce"`                  // 32-byte hex
@@ -21,6 +22,22 @@ type TunnelRegisterRequest struct {
 	TLSBinding    string       `json:"tls_binding"`            // hex(tls.ConnectionState().TLSUnique)
 	WalletProof   *WalletProof `json:"wallet_proof,omitempty"` // for staked tiers
 	ReconnToken   string       `json:"reconn_token,omitempty"` // reconnection
+
+	// EdgeCapabilities, when present, declares that the connecting node is an
+	// edge provider and announces where it accepts tunnels. The ingress side
+	// gates registration on edge-tier authorization and records the node in the
+	// edge registry. Additive (omitempty pointer) — existing register requests
+	// serialize unchanged. EDGE-02.
+	EdgeCapabilities *EdgeCapabilities `json:"edge_capabilities,omitempty"`
+}
+
+// EdgeCapabilities is announced by an edge provider during reverse-tunnel
+// registration. It carries the public ingress address + tunnel port other
+// container hosts dial, and the node's advertised stream capacity.
+type EdgeCapabilities struct {
+	IngressAddr string `json:"ingress_addr"` // public host the edge node terminates TLS on
+	TunnelPort  int    `json:"tunnel_port"`  // port container hosts dial for a reverse tunnel
+	MaxStreams  int    `json:"max_streams"`  // advertised concurrent-stream capacity
 }
 
 // TunnelRegisterResponse is sent by the ingress to confirm registration.

--- a/pkg/types/edge_types.go
+++ b/pkg/types/edge_types.go
@@ -11,6 +11,19 @@ package types
 // tier enum.
 const StakingTierEdge StakingTier = "edge"
 
+// NodeRoleEdge is the edge-provider node role: a stake-gated node that
+// terminates TLS, runs the L7 WAF, and accepts reverse tunnels from container
+// hosts (Approach A). It is additive — NodeRole.IsValid() has a default false
+// branch, so adding this constant does not change validation of the existing
+// provider/requester/hybrid roles.
+const NodeRoleEdge NodeRole = "edge"
+
+// EdgeMinStakeTier documents the minimum staking tier an edge provider is
+// expected to hold. The on-chain BunkerEdgeRegistry enforces the actual stake;
+// this constant is the daemon-side default the config gate references when no
+// explicit minimum is configured.
+const EdgeMinStakeTier StakingTier = StakingTierBronze
+
 // IsEdgeTier reports whether the given staking tier is the edge-provider role.
 func IsEdgeTier(t StakingTier) bool {
 	return t == StakingTierEdge

--- a/pkg/types/edge_types.go
+++ b/pkg/types/edge_types.go
@@ -1,0 +1,42 @@
+package types
+
+// This file holds edge-provider (L7 edge layer, Approach A) types. Per the
+// types zone rule, a new topic gets its own file — these constants are NOT
+// appended to economics.go or types.go.
+
+// StakingTierEdge is the edge-provider role tier. It is distinct from the
+// compute-provider staking tiers (starter/bronze/silver/gold/platinum) because
+// edge providers stake against a separate on-chain registry (BunkerEdgeRegistry)
+// with its own minimum and slashing semantics, rather than the BunkerStaking
+// tier enum.
+const StakingTierEdge StakingTier = "edge"
+
+// IsEdgeTier reports whether the given staking tier is the edge-provider role.
+func IsEdgeTier(t StakingTier) bool {
+	return t == StakingTierEdge
+}
+
+// EdgeProviderCapability is a bitmask describing the L7 edge features a provider
+// advertises. EDGE-02's tunnel gate logic references these bits without locking
+// the on-chain registry to a specific bitmask encoding (the contract stores
+// opaque metadata; the daemon interprets capabilities off-chain).
+type EdgeProviderCapability uint64
+
+const (
+	// EdgeCapWAF indicates the edge node runs an application-layer WAF.
+	EdgeCapWAF EdgeProviderCapability = 1 << 0
+
+	// EdgeCapDDoSMitigation indicates the edge node performs L3/L4/L7 DDoS mitigation.
+	EdgeCapDDoSMitigation EdgeProviderCapability = 1 << 1
+
+	// EdgeCapTLSTermination indicates the edge node terminates TLS for tenants.
+	EdgeCapTLSTermination EdgeProviderCapability = 1 << 2
+
+	// EdgeCapACME indicates the edge node issues/renews certificates via ACME.
+	EdgeCapACME EdgeProviderCapability = 1 << 3
+)
+
+// Has reports whether the capability set includes the given capability bit.
+func (c EdgeProviderCapability) Has(cap EdgeProviderCapability) bool {
+	return c&cap == cap
+}


### PR DESCRIPTION
## EDGE-02 — BYO custom-hostname ACME + edge-provider role + operator takedown

- **Custom-hostname ACME:** CNAME/TXT domain-ownership verification before issuing a cert for a customer host; `autotls` hostPolicy extended to accept verified custom hosts (was hard-rejecting non-`*.moltbunker.dev`). Per-deployment domain cap is atomic (no TOCTOU).
- **Edge-provider role gating:** `EdgeTierChecker` interface with `OnChainEdgeTierChecker` (consumes SC-EDGE-01's `EdgeRegistryReader`) **and** a `ConfigEdgeTierChecker` allowlist so it works **without** the contract deployed; new `internal/edge` package for edge selection/discovery + multi-edge tunnel-selection/failover foundation.
- **Operator takedown kill-switch:** a shared `Blocklist` enforced at the **ingress proxy on every request** (against both the original `Host`/custom-domain and the resolved subdomain/deployment ID → 403), plus the reverse tunnel and an admin API — one instance shared across all three. Client-supplied `X-Moltbunker-*` headers are stripped at ingress (verified-custom-domain signal can't be forged).

Verification: build + vet + linux cross-build + gosec(0) + ingress/edge/tunnel/api tests (incl. forward-path 403 + 64-goroutine cap race test) green. Secret-scan clean.

Strong foundation: decentralized edge discovery (vs manual registration) is a documented multi-month follow-up.

> **Stacked PR — base `HARDEN-01`.** This branch includes the **SC-EDGE-01 (#37)** commit for compilation; merge after #37 + the daemon stack (git drops the duplicate on rebase).
